### PR TITLE
v0.1 #3 — JS bootstrap (≤50 LOC) (closes #4)

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1,36 +1,27 @@
-const canvas = document.getElementById("tracy");
-const context = canvas.getContext("2d", { alpha: false });
+import { makeShim } from "./shim.js";
 
-function resizeCanvas() {
-  const scale = window.devicePixelRatio || 1;
-  const width = Math.max(1, Math.floor(canvas.clientWidth * scale));
-  const height = Math.max(1, Math.floor(canvas.clientHeight * scale));
-
-  if (canvas.width !== width || canvas.height !== height) {
-    canvas.width = width;
-    canvas.height = height;
-  }
-
-  context.setTransform(scale, 0, 0, scale, 0, 0);
-  context.fillStyle = "#fbf8f4";
-  context.fillRect(0, 0, canvas.clientWidth, canvas.clientHeight);
-}
+const memory = new WebAssembly.Memory({
+  initial: 256,
+  maximum: 32768,
+  shared: false,
+});
 
 async function loadApp() {
-  resizeCanvas();
-  const imports = { env: {} };
-  const { instance } = await WebAssembly.instantiateStreaming(fetch("wasm/app.wasm"), imports);
+  const imports = { env: { memory }, host: makeShim(memory) };
+  const { instance } = await WebAssembly.instantiateStreaming(
+    fetch("wasm/app.wasm"),
+    imports,
+  );
+  const { tracy_main, tracy_tick } = instance.exports;
 
-  instance.exports.tracy_main?.();
+  tracy_main();
 
-  function tick() {
-    resizeCanvas();
-    instance.exports.tracy_tick?.();
-    requestAnimationFrame(tick);
-  }
+  const loop = (ts) => {
+    tracy_tick(ts);
+    requestAnimationFrame(loop);
+  };
 
-  requestAnimationFrame(tick);
+  requestAnimationFrame(loop);
 }
 
-window.addEventListener("resize", resizeCanvas);
 loadApp();

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1,4 +1,4 @@
-const canvas = document.getElementById("tracy-canvas");
+const canvas = document.getElementById("tracy");
 const context = canvas.getContext("2d", { alpha: false });
 
 function resizeCanvas() {

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         background: #fbf8f4;
       }
 
-      #tracy-canvas {
+      #tracy {
         display: block;
         width: 100vw;
         height: 100vh;
@@ -46,7 +46,7 @@
     </style>
   </head>
   <body>
-    <canvas id="tracy-canvas" aria-label="tracy trace canvas"></canvas>
+    <canvas id="tracy" aria-label="tracy trace canvas"></canvas>
     <noscript>tracy needs JavaScript enabled to load the WebAssembly viewer.</noscript>
     <script src="bootstrap.bundle.js" defer></script>
   </body>

--- a/shim.js
+++ b/shim.js
@@ -1,0 +1,24 @@
+export function makeShim(memory) {
+  const canvas = document.getElementById("tracy");
+  const context = canvas.getContext("2d", { alpha: false });
+
+  function resize() {
+    const scale = window.devicePixelRatio || 1;
+    const width = Math.max(1, Math.floor(canvas.clientWidth * scale));
+    const height = Math.max(1, Math.floor(canvas.clientHeight * scale));
+
+    if (canvas.width !== width || canvas.height !== height) {
+      canvas.width = width;
+      canvas.height = height;
+    }
+
+    context.setTransform(scale, 0, 0, scale, 0, 0);
+    context.fillStyle = "#fbf8f4";
+    context.fillRect(0, 0, canvas.clientWidth, canvas.clientHeight);
+  }
+
+  resize();
+  window.addEventListener("resize", resize);
+
+  return {};
+}


### PR DESCRIPTION
## Summary

- Add the production JS bootstrap path that loads `wasm/app.wasm`, supplies host imports, and drives the frame loop through `tracy_tick(ts)`.
- Split browser-facing canvas setup into a thin `shim.js` stub so later host operations can land without growing the bootstrap.
- Preserve the repo constraint that `bootstrap.js` stays at or below 50 lines.

## Test plan

- `npm run build`
- `npm test`
- `wc -l bootstrap.js`

Fixes #4.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Add host shim for canvas setup <!-- type:spec -->
- [x] Wire bootstrap to wasm memory and rAF <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->