### PR TITLE
v0.1 #6 — WAT std-lib equivalents (allocator, string table, dynamic arrays, hash map) (closes #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ bash tools/build.sh
 ls dist/index.html dist/bootstrap.bundle.js dist/wasm/app.wasm
 
 # run watwat tests
-node tools/watwat.js dist/wasm/*.test.wasm
+node tools/watwat.js dist/wasm/*.test.wasm dist/wasm/std/*.test.wasm
 
 # serve dist/ locally
 python3 -m http.server -d dist 8000
@@ -76,6 +76,11 @@ python3 -m http.server -d dist 8000
 The hosted scaffold is <https://rhencke.github.io/tracy/>.  At this
 stage it is intentionally only a blank full-screen canvas loaded from
 the placeholder wasm module.
+
+`watwat` provides behavioral coverage for hand-written WAT modules in
+CI.  Tracy does not currently report WAT/WASM line or branch coverage;
+that needs a separate tooling evaluation once there is a practical path
+for this stack.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "bash tools/build.sh",
     "test": "npm run test:wat && npm run test:watwat-probe",
-    "test:wat": "node tools/watwat.js dist/wasm/*.test.wasm",
+    "test:wat": "node tools/watwat.js dist/wasm/*.test.wasm dist/wasm/std/*.test.wasm",
     "test:watwat-probe": "node tools/watwat.js --expect-failure probe_assert_eq_i32_failure \"deliberate i32 failure\" dist/wasm/watwat.test.wasm"
   },
   "devDependencies": {

--- a/tools/watwat.js
+++ b/tools/watwat.js
@@ -129,9 +129,28 @@ async function instantiateStdModule(file, imports) {
     throw error;
   }
 
-  const bytes = await fs.readFile(stdPath);
-  const { instance } = await WebAssembly.instantiate(bytes, imports);
+  const allocPath = path.join(path.dirname(stdPath), "alloc.wasm");
+  const stdImports = { ...imports };
   const aliases = {};
+
+  if (path.basename(stdPath) !== "alloc.wasm") {
+    try {
+      await fs.access(allocPath);
+      const allocBytes = await fs.readFile(allocPath);
+      const { instance } = await WebAssembly.instantiate(allocBytes, stdImports);
+      stdImports.alloc = instance.exports;
+      aliases.alloc = instance.exports;
+      aliases["std/alloc"] = instance.exports;
+      aliases["wat/std/alloc"] = instance.exports;
+    } catch (error) {
+      if (error.code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+
+  const bytes = await fs.readFile(stdPath);
+  const { instance } = await WebAssembly.instantiate(bytes, stdImports);
 
   for (const name of stdImportAliases(stdPath)) {
     aliases[name] = instance.exports;

--- a/tools/watwat.js
+++ b/tools/watwat.js
@@ -91,6 +91,55 @@ async function instantiateAssert(assertPath, memory, watwat) {
   return instance.exports;
 }
 
+function stdModulePathForTest(file) {
+  if (!file.endsWith(".test.wasm")) {
+    return null;
+  }
+
+  const parsed = path.parse(file);
+  if (path.basename(parsed.dir) !== "std") {
+    return null;
+  }
+
+  return path.join(parsed.dir, `${parsed.name.replace(/\.test$/, "")}.wasm`);
+}
+
+function stdImportAliases(file) {
+  const parsed = path.parse(file);
+  const name = parsed.name;
+  const parent = path.basename(parsed.dir);
+
+  return [name, `${parent}/${name}`, `wat/${parent}/${name}`];
+}
+
+async function instantiateStdModule(file, imports) {
+  const stdPath = stdModulePathForTest(file);
+
+  if (stdPath === null) {
+    return {};
+  }
+
+  try {
+    await fs.access(stdPath);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return {};
+    }
+
+    throw error;
+  }
+
+  const bytes = await fs.readFile(stdPath);
+  const { instance } = await WebAssembly.instantiate(bytes, imports);
+  const aliases = {};
+
+  for (const name of stdImportAliases(stdPath)) {
+    aliases[name] = instance.exports;
+  }
+
+  return aliases;
+}
+
 async function instantiateTestModule(file, assertPath) {
   const memory = new WebAssembly.Memory({ initial: 1, maximum: 32768 });
   const watwat = {
@@ -100,12 +149,15 @@ async function instantiateTestModule(file, assertPath) {
   };
   const assert = await instantiateAssert(assertPath, memory, watwat);
   Object.assign(watwat, assert);
-  const bytes = await fs.readFile(file);
-  const { instance } = await WebAssembly.instantiate(bytes, {
+  const imports = {
     env: { memory },
     watwat,
     assert,
-  });
+  };
+  Object.assign(imports, await instantiateStdModule(file, imports));
+
+  const bytes = await fs.readFile(file);
+  const { instance } = await WebAssembly.instantiate(bytes, imports);
 
   return {
     instance,

--- a/tools/watwat.js
+++ b/tools/watwat.js
@@ -149,6 +149,24 @@ async function instantiateStdModule(file, imports) {
     }
   }
 
+  const hashPath = path.join(path.dirname(stdPath), "hash.wasm");
+
+  if (path.basename(stdPath) === "strtab.wasm") {
+    try {
+      await fs.access(hashPath);
+      const hashBytes = await fs.readFile(hashPath);
+      const { instance } = await WebAssembly.instantiate(hashBytes, stdImports);
+      stdImports.hash = instance.exports;
+      aliases.hash = instance.exports;
+      aliases["std/hash"] = instance.exports;
+      aliases["wat/std/hash"] = instance.exports;
+    } catch (error) {
+      if (error.code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+
   const bytes = await fs.readFile(stdPath);
   const { instance } = await WebAssembly.instantiate(bytes, stdImports);
 

--- a/wat/std/alloc.test.wat
+++ b/wat/std/alloc.test.wat
@@ -1,0 +1,147 @@
+(module
+  (import "env" "memory" (memory $memory 1 32768))
+  (import "watwat" "assert_eq_i32"
+    (func $assert_eq_i32 (param i32) (param i32) (param i32)))
+  (import "watwat" "assert_true"
+    (func $assert_true (param i32) (param i32)))
+  (import "alloc" "bump_init"
+    (func $bump_init (param i32) (param i32)))
+  (import "alloc" "alloc"
+    (func $alloc (param i32) (result i32)))
+  (import "alloc" "checkpoint"
+    (func $checkpoint (result i32)))
+  (import "alloc" "reset_to"
+    (func $reset_to (param i32)))
+
+  (data (i32.const 1024) "alloc test failed")
+
+  (func (export "message_for") (param $code i32) (result i32 i32)
+    i32.const 1024
+    i32.const 17
+  )
+
+  (func (export "test_alloc_aligns_to_8_bytes")
+    (local $ptr i32)
+
+    i32.const 1001
+    i32.const 2048
+    call $bump_init
+
+    i32.const 1
+    call $alloc
+    local.tee $ptr
+    i32.const 1008
+    i32.const 1
+    call $assert_eq_i32
+
+    local.get $ptr
+    i32.const 7
+    i32.and
+    i32.const 0
+    i32.const 2
+    call $assert_eq_i32
+  )
+
+  (func (export "test_alloc_rounds_next_pointer")
+    i32.const 2048
+    i32.const 4096
+    call $bump_init
+
+    i32.const 3
+    call $alloc
+    i32.const 2048
+    i32.const 3
+    call $assert_eq_i32
+
+    i32.const 1
+    call $alloc
+    i32.const 2056
+    i32.const 4
+    call $assert_eq_i32
+  )
+
+  (func (export "test_alloc_zero_does_not_advance")
+    i32.const 3001
+    i32.const 4096
+    call $bump_init
+
+    i32.const 0
+    call $alloc
+    i32.const 3008
+    i32.const 5
+    call $assert_eq_i32
+
+    i32.const 1
+    call $alloc
+    i32.const 3008
+    i32.const 6
+    call $assert_eq_i32
+  )
+
+  (func (export "test_checkpoint_and_reset_reuse_space")
+    (local $label i32)
+
+    i32.const 4096
+    i32.const 8192
+    call $bump_init
+
+    i32.const 8
+    call $alloc
+    i32.const 4096
+    i32.const 7
+    call $assert_eq_i32
+
+    call $checkpoint
+    local.set $label
+
+    i32.const 16
+    call $alloc
+    drop
+
+    local.get $label
+    call $reset_to
+
+    i32.const 8
+    call $alloc
+    local.get $label
+    i32.const 8
+    call $assert_eq_i32
+  )
+
+  (func (export "test_alloc_grows_linear_memory")
+    (local $before_pages i32)
+    (local $current_bytes i32)
+    (local $ptr i32)
+
+    memory.size
+    local.set $before_pages
+
+    local.get $before_pages
+    i32.const 65536
+    i32.mul
+    local.set $current_bytes
+
+    local.get $current_bytes
+    i32.const 16
+    i32.sub
+    local.get $current_bytes
+    call $bump_init
+
+    i32.const 64
+    call $alloc
+    local.set $ptr
+
+    local.get $ptr
+    local.get $current_bytes
+    i32.const 16
+    i32.sub
+    i32.const 9
+    call $assert_eq_i32
+
+    memory.size
+    local.get $before_pages
+    i32.gt_u
+    i32.const 10
+    call $assert_true
+  )
+)

--- a/wat/std/alloc.wat
+++ b/wat/std/alloc.wat
@@ -1,0 +1,145 @@
+(module
+  (import "env" "memory" (memory $memory 1 32768))
+
+  (global $WASM_PAGE_SIZE i32 (i32.const 0x00010000))
+  (global $heap_base (mut i32) (i32.const 0))
+  (global $heap_ptr (mut i32) (i32.const 0))
+  (global $heap_end (mut i32) (i32.const 0))
+
+  (func $align8 (param $value i32) (result i32)
+    local.get $value
+    i32.const 7
+    i32.add
+    i32.const -8
+    i32.and
+  )
+
+  (func $memory_bytes (result i32)
+    memory.size
+    global.get $WASM_PAGE_SIZE
+    i32.mul
+  )
+
+  (func $ensure_capacity (param $needed_end i32) (result i32)
+    (local $current_bytes i32)
+    (local $grow_bytes i32)
+    (local $grow_pages i32)
+
+    call $memory_bytes
+    local.tee $current_bytes
+    local.get $needed_end
+    i32.ge_u
+    if
+      local.get $needed_end
+      global.get $heap_end
+      i32.gt_u
+      if
+        local.get $current_bytes
+        global.set $heap_end
+      end
+
+      i32.const 1
+      return
+    end
+
+    local.get $needed_end
+    local.get $current_bytes
+    i32.sub
+    local.set $grow_bytes
+
+    local.get $grow_bytes
+    global.get $WASM_PAGE_SIZE
+    i32.const 1
+    i32.sub
+    i32.add
+    global.get $WASM_PAGE_SIZE
+    i32.div_u
+    local.set $grow_pages
+
+    local.get $grow_pages
+    memory.grow
+    i32.const -1
+    i32.eq
+    if
+      i32.const 0
+      return
+    end
+
+    call $memory_bytes
+    global.set $heap_end
+    i32.const 1
+  )
+
+  (func (export "bump_init") (param $base i32) (param $end i32)
+    local.get $base
+    global.set $heap_base
+
+    local.get $base
+    global.set $heap_ptr
+
+    local.get $end
+    global.set $heap_end
+  )
+
+  (func (export "alloc") (param $bytes i32) (result i32)
+    (local $ptr i32)
+    (local $next i32)
+
+    global.get $heap_ptr
+    call $align8
+    local.set $ptr
+
+    local.get $ptr
+    local.get $bytes
+    i32.add
+    call $align8
+    local.set $next
+
+    local.get $next
+    local.get $ptr
+    i32.lt_u
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $next
+    global.get $heap_end
+    i32.gt_u
+    local.get $next
+    call $memory_bytes
+    i32.gt_u
+    i32.or
+    if
+      local.get $next
+      call $ensure_capacity
+      i32.eqz
+      if
+        i32.const 0
+        return
+      end
+    end
+
+    local.get $next
+    global.set $heap_ptr
+    local.get $ptr
+  )
+
+  (func (export "checkpoint") (result i32)
+    global.get $heap_ptr
+  )
+
+  (func (export "reset_to") (param $label i32)
+    local.get $label
+    global.get $heap_base
+    i32.ge_u
+    local.get $label
+    global.get $heap_end
+    i32.le_u
+    i32.and
+    if
+      local.get $label
+      global.set $heap_ptr
+    end
+  )
+)

--- a/wat/std/array.test.wat
+++ b/wat/std/array.test.wat
@@ -1,0 +1,217 @@
+(module
+  (import "env" "memory" (memory $memory 1 32768))
+  (import "watwat" "assert_eq_i32"
+    (func $assert_eq_i32 (param i32) (param i32) (param i32)))
+  (import "watwat" "assert_eq_f64"
+    (func $assert_eq_f64 (param f64) (param f64) (param f64) (param i32)))
+  (import "watwat" "assert_true"
+    (func $assert_true (param i32) (param i32)))
+  (import "alloc" "bump_init"
+    (func $bump_init (param i32) (param i32)))
+  (import "array" "arr_i32_new"
+    (func $arr_i32_new (param i32) (result i32)))
+  (import "array" "arr_i32_push"
+    (func $arr_i32_push (param i32) (param i32)))
+  (import "array" "arr_i32_at"
+    (func $arr_i32_at (param i32) (param i32) (result i32)))
+  (import "array" "arr_i32_len"
+    (func $arr_i32_len (param i32) (result i32)))
+  (import "array" "arr_f64_new"
+    (func $arr_f64_new (param i32) (result i32)))
+  (import "array" "arr_f64_push"
+    (func $arr_f64_push (param i32) (param f64)))
+  (import "array" "arr_f64_at"
+    (func $arr_f64_at (param i32) (param i32) (result f64)))
+  (import "array" "arr_f64_len"
+    (func $arr_f64_len (param i32) (result i32)))
+  (import "array" "arr_u8_new"
+    (func $arr_u8_new (param i32) (result i32)))
+  (import "array" "arr_u8_push"
+    (func $arr_u8_push (param i32) (param i32)))
+  (import "array" "arr_u8_at"
+    (func $arr_u8_at (param i32) (param i32) (result i32)))
+  (import "array" "arr_u8_len"
+    (func $arr_u8_len (param i32) (result i32)))
+
+  (data (i32.const 1024) "array test failed")
+
+  (func (export "message_for") (param $code i32) (result i32 i32)
+    i32.const 1024
+    i32.const 17
+  )
+
+  (func $init_heap
+    i32.const 4096
+    i32.const 65536
+    call $bump_init
+  )
+
+  (func (export "test_i32_array_empty_and_bounds")
+    (local $arr i32)
+
+    call $init_heap
+
+    i32.const 0
+    call $arr_i32_new
+    local.tee $arr
+    i32.const 0
+    i32.ne
+    i32.const 1
+    call $assert_true
+
+    local.get $arr
+    call $arr_i32_len
+    i32.const 0
+    i32.const 2
+    call $assert_eq_i32
+
+    local.get $arr
+    i32.const 0
+    call $arr_i32_at
+    i32.const 0
+    i32.const 3
+    call $assert_eq_i32
+  )
+
+  (func (export "test_i32_array_push_order_and_growth")
+    (local $arr i32)
+
+    call $init_heap
+
+    i32.const 1
+    call $arr_i32_new
+    local.set $arr
+
+    local.get $arr
+    i32.const 11
+    call $arr_i32_push
+
+    local.get $arr
+    i32.const 22
+    call $arr_i32_push
+
+    local.get $arr
+    i32.const -7
+    call $arr_i32_push
+
+    local.get $arr
+    call $arr_i32_len
+    i32.const 3
+    i32.const 4
+    call $assert_eq_i32
+
+    local.get $arr
+    i32.const 0
+    call $arr_i32_at
+    i32.const 11
+    i32.const 5
+    call $assert_eq_i32
+
+    local.get $arr
+    i32.const 1
+    call $arr_i32_at
+    i32.const 22
+    i32.const 6
+    call $assert_eq_i32
+
+    local.get $arr
+    i32.const 2
+    call $arr_i32_at
+    i32.const -7
+    i32.const 7
+    call $assert_eq_i32
+  )
+
+  (func (export "test_f64_array_push_order_and_bounds")
+    (local $arr i32)
+
+    call $init_heap
+
+    i32.const 0
+    call $arr_f64_new
+    local.set $arr
+
+    local.get $arr
+    f64.const 1.25
+    call $arr_f64_push
+
+    local.get $arr
+    f64.const -2.5
+    call $arr_f64_push
+
+    local.get $arr
+    call $arr_f64_len
+    i32.const 2
+    i32.const 8
+    call $assert_eq_i32
+
+    local.get $arr
+    i32.const 0
+    call $arr_f64_at
+    f64.const 1.25
+    f64.const 0.000001
+    i32.const 9
+    call $assert_eq_f64
+
+    local.get $arr
+    i32.const 1
+    call $arr_f64_at
+    f64.const -2.5
+    f64.const 0.000001
+    i32.const 10
+    call $assert_eq_f64
+
+    local.get $arr
+    i32.const 2
+    call $arr_f64_at
+    f64.const 0
+    f64.const 0.000001
+    i32.const 11
+    call $assert_eq_f64
+  )
+
+  (func (export "test_u8_array_push_masks_to_byte")
+    (local $arr i32)
+
+    call $init_heap
+
+    i32.const 1
+    call $arr_u8_new
+    local.set $arr
+
+    local.get $arr
+    i32.const 255
+    call $arr_u8_push
+
+    local.get $arr
+    i32.const 256
+    call $arr_u8_push
+
+    local.get $arr
+    call $arr_u8_len
+    i32.const 2
+    i32.const 12
+    call $assert_eq_i32
+
+    local.get $arr
+    i32.const 0
+    call $arr_u8_at
+    i32.const 255
+    i32.const 13
+    call $assert_eq_i32
+
+    local.get $arr
+    i32.const 1
+    call $arr_u8_at
+    i32.const 0
+    i32.const 14
+    call $assert_eq_i32
+
+    local.get $arr
+    i32.const 4
+    call $arr_u8_at
+    i32.const 0
+    i32.const 15
+    call $assert_eq_i32
+  )
+)

--- a/wat/std/array.wat
+++ b/wat/std/array.wat
@@ -1,0 +1,425 @@
+(module
+  (import "env" "memory" (memory $memory 1 32768))
+  (import "alloc" "alloc" (func $alloc (param i32) (result i32)))
+
+  (global $ARR_DATA_PTR i32 (i32.const 0))
+  (global $ARR_LEN i32 (i32.const 4))
+  (global $ARR_CAP i32 (i32.const 8))
+  (global $ARR_ELEM_SIZE i32 (i32.const 12))
+  (global $ARR_HEADER_BYTES i32 (i32.const 16))
+
+  (func $field (param $arr i32) (param $offset i32) (result i32)
+    local.get $arr
+    local.get $offset
+    i32.add
+  )
+
+  (func $copy_bytes (param $dst i32) (param $src i32) (param $len i32)
+    (local $i i32)
+
+    block $done
+      loop $loop
+        local.get $i
+        local.get $len
+        i32.ge_u
+        br_if $done
+
+        local.get $dst
+        local.get $i
+        i32.add
+        local.get $src
+        local.get $i
+        i32.add
+        i32.load8_u
+        i32.store8
+
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+        br $loop
+      end
+    end
+  )
+
+  (func $array_new (param $initial_cap i32) (param $elem_size i32) (result i32)
+    (local $arr i32)
+    (local $data_ptr i32)
+
+    global.get $ARR_HEADER_BYTES
+    call $alloc
+    local.tee $arr
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $initial_cap
+    if
+      local.get $initial_cap
+      local.get $elem_size
+      i32.mul
+      call $alloc
+      local.tee $data_ptr
+      i32.eqz
+      if
+        i32.const 0
+        return
+      end
+    end
+
+    local.get $arr
+    global.get $ARR_DATA_PTR
+    call $field
+    local.get $data_ptr
+    i32.store
+
+    local.get $arr
+    global.get $ARR_LEN
+    call $field
+    i32.const 0
+    i32.store
+
+    local.get $arr
+    global.get $ARR_CAP
+    call $field
+    local.get $initial_cap
+    i32.store
+
+    local.get $arr
+    global.get $ARR_ELEM_SIZE
+    call $field
+    local.get $elem_size
+    i32.store
+
+    local.get $arr
+  )
+
+  (func $ensure_push_capacity (param $arr i32) (result i32)
+    (local $len i32)
+    (local $cap i32)
+    (local $elem_size i32)
+    (local $old_data i32)
+    (local $new_data i32)
+    (local $new_cap i32)
+
+    local.get $arr
+    global.get $ARR_LEN
+    call $field
+    i32.load
+    local.set $len
+
+    local.get $arr
+    global.get $ARR_CAP
+    call $field
+    i32.load
+    local.set $cap
+
+    local.get $len
+    local.get $cap
+    i32.lt_u
+    if
+      i32.const 1
+      return
+    end
+
+    local.get $cap
+    if (result i32)
+      local.get $cap
+      i32.const 2
+      i32.mul
+    else
+      i32.const 1
+    end
+    local.set $new_cap
+
+    local.get $arr
+    global.get $ARR_ELEM_SIZE
+    call $field
+    i32.load
+    local.set $elem_size
+
+    local.get $arr
+    global.get $ARR_DATA_PTR
+    call $field
+    i32.load
+    local.set $old_data
+
+    local.get $new_cap
+    local.get $elem_size
+    i32.mul
+    call $alloc
+    local.tee $new_data
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $new_data
+    local.get $old_data
+    local.get $len
+    local.get $elem_size
+    i32.mul
+    call $copy_bytes
+
+    local.get $arr
+    global.get $ARR_DATA_PTR
+    call $field
+    local.get $new_data
+    i32.store
+
+    local.get $arr
+    global.get $ARR_CAP
+    call $field
+    local.get $new_cap
+    i32.store
+
+    i32.const 1
+  )
+
+  (func $push_i32 (param $arr i32) (param $value i32)
+    (local $data_ptr i32)
+    (local $len i32)
+
+    local.get $arr
+    call $ensure_push_capacity
+    i32.eqz
+    if
+      return
+    end
+
+    local.get $arr
+    global.get $ARR_DATA_PTR
+    call $field
+    i32.load
+    local.set $data_ptr
+
+    local.get $arr
+    global.get $ARR_LEN
+    call $field
+    i32.load
+    local.set $len
+
+    local.get $data_ptr
+    local.get $len
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $value
+    i32.store
+
+    local.get $arr
+    global.get $ARR_LEN
+    call $field
+    local.get $len
+    i32.const 1
+    i32.add
+    i32.store
+  )
+
+  (func $push_f64 (param $arr i32) (param $value f64)
+    (local $data_ptr i32)
+    (local $len i32)
+
+    local.get $arr
+    call $ensure_push_capacity
+    i32.eqz
+    if
+      return
+    end
+
+    local.get $arr
+    global.get $ARR_DATA_PTR
+    call $field
+    i32.load
+    local.set $data_ptr
+
+    local.get $arr
+    global.get $ARR_LEN
+    call $field
+    i32.load
+    local.set $len
+
+    local.get $data_ptr
+    local.get $len
+    i32.const 3
+    i32.shl
+    i32.add
+    local.get $value
+    f64.store
+
+    local.get $arr
+    global.get $ARR_LEN
+    call $field
+    local.get $len
+    i32.const 1
+    i32.add
+    i32.store
+  )
+
+  (func $push_u8 (param $arr i32) (param $value i32)
+    (local $data_ptr i32)
+    (local $len i32)
+
+    local.get $arr
+    call $ensure_push_capacity
+    i32.eqz
+    if
+      return
+    end
+
+    local.get $arr
+    global.get $ARR_DATA_PTR
+    call $field
+    i32.load
+    local.set $data_ptr
+
+    local.get $arr
+    global.get $ARR_LEN
+    call $field
+    i32.load
+    local.set $len
+
+    local.get $data_ptr
+    local.get $len
+    i32.add
+    local.get $value
+    i32.store8
+
+    local.get $arr
+    global.get $ARR_LEN
+    call $field
+    local.get $len
+    i32.const 1
+    i32.add
+    i32.store
+  )
+
+  (func $array_len (param $arr i32) (result i32)
+    local.get $arr
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $arr
+    global.get $ARR_LEN
+    call $field
+    i32.load
+  )
+
+  (func (export "arr_i32_new") (param $initial_cap i32) (result i32)
+    local.get $initial_cap
+    i32.const 4
+    call $array_new
+  )
+
+  (func (export "arr_i32_push") (param $arr i32) (param $value i32)
+    local.get $arr
+    local.get $value
+    call $push_i32
+  )
+
+  (func (export "arr_i32_at") (param $arr i32) (param $index i32) (result i32)
+    local.get $index
+    local.get $arr
+    call $array_len
+    i32.ge_u
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $arr
+    global.get $ARR_DATA_PTR
+    call $field
+    i32.load
+    local.get $index
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load
+  )
+
+  (func (export "arr_i32_len") (param $arr i32) (result i32)
+    local.get $arr
+    call $array_len
+  )
+
+  (func (export "arr_f64_new") (param $initial_cap i32) (result i32)
+    local.get $initial_cap
+    i32.const 8
+    call $array_new
+  )
+
+  (func (export "arr_f64_push") (param $arr i32) (param $value f64)
+    local.get $arr
+    local.get $value
+    call $push_f64
+  )
+
+  (func (export "arr_f64_at") (param $arr i32) (param $index i32) (result f64)
+    local.get $index
+    local.get $arr
+    call $array_len
+    i32.ge_u
+    if
+      f64.const 0
+      return
+    end
+
+    local.get $arr
+    global.get $ARR_DATA_PTR
+    call $field
+    i32.load
+    local.get $index
+    i32.const 3
+    i32.shl
+    i32.add
+    f64.load
+  )
+
+  (func (export "arr_f64_len") (param $arr i32) (result i32)
+    local.get $arr
+    call $array_len
+  )
+
+  (func (export "arr_u8_new") (param $initial_cap i32) (result i32)
+    local.get $initial_cap
+    i32.const 1
+    call $array_new
+  )
+
+  (func (export "arr_u8_push") (param $arr i32) (param $value i32)
+    local.get $arr
+    local.get $value
+    call $push_u8
+  )
+
+  (func (export "arr_u8_at") (param $arr i32) (param $index i32) (result i32)
+    local.get $index
+    local.get $arr
+    call $array_len
+    i32.ge_u
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $arr
+    global.get $ARR_DATA_PTR
+    call $field
+    i32.load
+    local.get $index
+    i32.add
+    i32.load8_u
+  )
+
+  (func (export "arr_u8_len") (param $arr i32) (result i32)
+    local.get $arr
+    call $array_len
+  )
+)

--- a/wat/std/hash.test.wat
+++ b/wat/std/hash.test.wat
@@ -1,0 +1,182 @@
+(module
+  (import "env" "memory" (memory $memory 1 32768))
+  (import "watwat" "assert_eq_i32"
+    (func $assert_eq_i32 (param i32) (param i32) (param i32)))
+  (import "watwat" "assert_true"
+    (func $assert_true (param i32) (param i32)))
+  (import "watwat" "assert_false"
+    (func $assert_false (param i32) (param i32)))
+  (import "alloc" "bump_init"
+    (func $bump_init (param i32) (param i32)))
+  (import "hash" "hash_new"
+    (func $hash_new (param i32) (result i32)))
+  (import "hash" "hash_put"
+    (func $hash_put (param i32) (param i32) (param i32)))
+  (import "hash" "hash_get"
+    (func $hash_get (param i32) (param i32) (result i32)))
+  (import "hash" "hash_has"
+    (func $hash_has (param i32) (param i32) (result i32)))
+
+  (data (i32.const 1024) "hash test failed")
+
+  (func (export "message_for") (param $code i32) (result i32 i32)
+    i32.const 1024
+    i32.const 16
+  )
+
+  (func $init_heap
+    i32.const 4096
+    i32.const 65536
+    call $bump_init
+  )
+
+  (func (export "test_hash_missing_key")
+    (local $map i32)
+
+    call $init_heap
+
+    i32.const 0
+    call $hash_new
+    local.set $map
+
+    local.get $map
+    i32.const 123
+    call $hash_has
+    i32.const 1
+    call $assert_false
+
+    local.get $map
+    i32.const 123
+    call $hash_get
+    i32.const 0
+    i32.const 2
+    call $assert_eq_i32
+  )
+
+  (func (export "test_hash_put_get_and_update")
+    (local $map i32)
+
+    call $init_heap
+
+    i32.const 4
+    call $hash_new
+    local.set $map
+
+    local.get $map
+    i32.const 10
+    i32.const 100
+    call $hash_put
+
+    local.get $map
+    i32.const 10
+    call $hash_has
+    i32.const 3
+    call $assert_true
+
+    local.get $map
+    i32.const 10
+    call $hash_get
+    i32.const 100
+    i32.const 4
+    call $assert_eq_i32
+
+    local.get $map
+    i32.const 10
+    i32.const 200
+    call $hash_put
+
+    local.get $map
+    i32.const 10
+    call $hash_get
+    i32.const 200
+    i32.const 5
+    call $assert_eq_i32
+  )
+
+  (func (export "test_hash_linear_probe_collision")
+    (local $map i32)
+
+    call $init_heap
+
+    i32.const 2
+    call $hash_new
+    local.set $map
+
+    local.get $map
+    i32.const 0
+    i32.const 11
+    call $hash_put
+
+    local.get $map
+    i32.const 8
+    i32.const 22
+    call $hash_put
+
+    local.get $map
+    i32.const 0
+    call $hash_get
+    i32.const 11
+    i32.const 6
+    call $assert_eq_i32
+
+    local.get $map
+    i32.const 8
+    call $hash_get
+    i32.const 22
+    i32.const 7
+    call $assert_eq_i32
+  )
+
+  (func (export "test_hash_grows_and_rehashes_entries")
+    (local $map i32)
+    (local $i i32)
+
+    call $init_heap
+
+    i32.const 1
+    call $hash_new
+    local.set $map
+
+    block $done
+      loop $insert
+        local.get $i
+        i32.const 20
+        i32.ge_u
+        br_if $done
+
+        local.get $map
+        local.get $i
+        local.get $i
+        i32.const 1000
+        i32.add
+        call $hash_put
+
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+        br $insert
+      end
+    end
+
+    local.get $map
+    i32.const 0
+    call $hash_get
+    i32.const 1000
+    i32.const 8
+    call $assert_eq_i32
+
+    local.get $map
+    i32.const 19
+    call $hash_get
+    i32.const 1019
+    i32.const 9
+    call $assert_eq_i32
+
+    local.get $map
+    i32.const 99
+    call $hash_has
+    i32.const 10
+    call $assert_false
+  )
+)

--- a/wat/std/hash.wat
+++ b/wat/std/hash.wat
@@ -1,0 +1,574 @@
+(module
+  (import "env" "memory" (memory $memory 1 32768))
+  (import "alloc" "alloc" (func $alloc (param i32) (result i32)))
+
+  (global $HASH_KEYS_PTR i32 (i32.const 0))
+  (global $HASH_VALUES_PTR i32 (i32.const 4))
+  (global $HASH_STATES_PTR i32 (i32.const 8))
+  (global $HASH_CAP i32 (i32.const 12))
+  (global $HASH_LEN i32 (i32.const 16))
+  (global $HASH_HEADER_BYTES i32 (i32.const 20))
+  (global $FNV_OFFSET i32 (i32.const -2128831035))
+  (global $FNV_PRIME i32 (i32.const 16777619))
+
+  (func $field (param $map i32) (param $offset i32) (result i32)
+    local.get $map
+    local.get $offset
+    i32.add
+  )
+
+  (func $zero_bytes (param $ptr i32) (param $len i32)
+    (local $i i32)
+
+    block $done
+      loop $loop
+        local.get $i
+        local.get $len
+        i32.ge_u
+        br_if $done
+
+        local.get $ptr
+        local.get $i
+        i32.add
+        i32.const 0
+        i32.store8
+
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+        br $loop
+      end
+    end
+  )
+
+  (func $normalize_cap (param $initial_cap i32) (result i32)
+    (local $cap i32)
+
+    i32.const 8
+    local.set $cap
+
+    block $done
+      loop $loop
+        local.get $cap
+        local.get $initial_cap
+        i32.ge_u
+        br_if $done
+
+        local.get $cap
+        i32.const 2
+        i32.mul
+        local.set $cap
+        br $loop
+      end
+    end
+
+    local.get $cap
+  )
+
+  (func $hash_byte (param $hash i32) (param $byte i32) (result i32)
+    local.get $hash
+    local.get $byte
+    i32.const 255
+    i32.and
+    i32.xor
+    global.get $FNV_PRIME
+    i32.mul
+  )
+
+  (func $hash_i32 (export "hash_i32") (param $key i32) (result i32)
+    (local $hash i32)
+
+    global.get $FNV_OFFSET
+    local.set $hash
+
+    local.get $hash
+    local.get $key
+    call $hash_byte
+    local.set $hash
+
+    local.get $hash
+    local.get $key
+    i32.const 8
+    i32.shr_u
+    call $hash_byte
+    local.set $hash
+
+    local.get $hash
+    local.get $key
+    i32.const 16
+    i32.shr_u
+    call $hash_byte
+    local.set $hash
+
+    local.get $hash
+    local.get $key
+    i32.const 24
+    i32.shr_u
+    call $hash_byte
+  )
+
+  (func $key_ptr (param $map i32) (param $index i32) (result i32)
+    local.get $map
+    global.get $HASH_KEYS_PTR
+    call $field
+    i32.load
+    local.get $index
+    i32.const 2
+    i32.shl
+    i32.add
+  )
+
+  (func $value_ptr (param $map i32) (param $index i32) (result i32)
+    local.get $map
+    global.get $HASH_VALUES_PTR
+    call $field
+    i32.load
+    local.get $index
+    i32.const 2
+    i32.shl
+    i32.add
+  )
+
+  (func $state_ptr (param $map i32) (param $index i32) (result i32)
+    local.get $map
+    global.get $HASH_STATES_PTR
+    call $field
+    i32.load
+    local.get $index
+    i32.add
+  )
+
+  (func $set_len (param $map i32) (param $len i32)
+    local.get $map
+    global.get $HASH_LEN
+    call $field
+    local.get $len
+    i32.store
+  )
+
+  (func $insert_no_grow (param $map i32) (param $key i32) (param $value i32) (result i32)
+    (local $cap i32)
+    (local $index i32)
+    (local $probes i32)
+
+    local.get $map
+    global.get $HASH_CAP
+    call $field
+    i32.load
+    local.set $cap
+
+    local.get $key
+    call $hash_i32
+    local.get $cap
+    i32.rem_u
+    local.set $index
+
+    block $full
+      loop $probe
+        local.get $probes
+        local.get $cap
+        i32.ge_u
+        br_if $full
+
+        local.get $map
+        local.get $index
+        call $state_ptr
+        i32.load8_u
+        i32.eqz
+        if
+          local.get $map
+          local.get $index
+          call $state_ptr
+          i32.const 1
+          i32.store8
+
+          local.get $map
+          local.get $index
+          call $key_ptr
+          local.get $key
+          i32.store
+
+          local.get $map
+          local.get $index
+          call $value_ptr
+          local.get $value
+          i32.store
+
+          local.get $map
+          local.get $map
+          global.get $HASH_LEN
+          call $field
+          i32.load
+          i32.const 1
+          i32.add
+          call $set_len
+
+          i32.const 1
+          return
+        end
+
+        local.get $map
+        local.get $index
+        call $key_ptr
+        i32.load
+        local.get $key
+        i32.eq
+        if
+          local.get $map
+          local.get $index
+          call $value_ptr
+          local.get $value
+          i32.store
+
+          i32.const 1
+          return
+        end
+
+        local.get $index
+        i32.const 1
+        i32.add
+        local.get $cap
+        i32.rem_u
+        local.set $index
+
+        local.get $probes
+        i32.const 1
+        i32.add
+        local.set $probes
+        br $probe
+      end
+    end
+
+    i32.const 0
+  )
+
+  (func $allocate_tables (param $map i32) (param $cap i32) (result i32)
+    (local $keys_ptr i32)
+    (local $values_ptr i32)
+    (local $states_ptr i32)
+
+    local.get $cap
+    i32.const 2
+    i32.shl
+    call $alloc
+    local.tee $keys_ptr
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $cap
+    i32.const 2
+    i32.shl
+    call $alloc
+    local.tee $values_ptr
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $cap
+    call $alloc
+    local.tee $states_ptr
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $states_ptr
+    local.get $cap
+    call $zero_bytes
+
+    local.get $map
+    global.get $HASH_KEYS_PTR
+    call $field
+    local.get $keys_ptr
+    i32.store
+
+    local.get $map
+    global.get $HASH_VALUES_PTR
+    call $field
+    local.get $values_ptr
+    i32.store
+
+    local.get $map
+    global.get $HASH_STATES_PTR
+    call $field
+    local.get $states_ptr
+    i32.store
+
+    local.get $map
+    global.get $HASH_CAP
+    call $field
+    local.get $cap
+    i32.store
+
+    i32.const 1
+  )
+
+  (func $grow (param $map i32) (result i32)
+    (local $old_keys i32)
+    (local $old_values i32)
+    (local $old_states i32)
+    (local $old_cap i32)
+    (local $old_len i32)
+    (local $i i32)
+
+    local.get $map
+    global.get $HASH_KEYS_PTR
+    call $field
+    i32.load
+    local.set $old_keys
+
+    local.get $map
+    global.get $HASH_VALUES_PTR
+    call $field
+    i32.load
+    local.set $old_values
+
+    local.get $map
+    global.get $HASH_STATES_PTR
+    call $field
+    i32.load
+    local.set $old_states
+
+    local.get $map
+    global.get $HASH_CAP
+    call $field
+    i32.load
+    local.set $old_cap
+
+    local.get $map
+    global.get $HASH_LEN
+    call $field
+    i32.load
+    local.set $old_len
+
+    local.get $map
+    local.get $old_cap
+    i32.const 2
+    i32.mul
+    call $allocate_tables
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $map
+    i32.const 0
+    call $set_len
+
+    block $done
+      loop $loop
+        local.get $i
+        local.get $old_cap
+        i32.ge_u
+        br_if $done
+
+        local.get $old_states
+        local.get $i
+        i32.add
+        i32.load8_u
+        if
+          local.get $map
+          local.get $old_keys
+          local.get $i
+          i32.const 2
+          i32.shl
+          i32.add
+          i32.load
+          local.get $old_values
+          local.get $i
+          i32.const 2
+          i32.shl
+          i32.add
+          i32.load
+          call $insert_no_grow
+          drop
+        end
+
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+        br $loop
+      end
+    end
+
+    local.get $map
+    global.get $HASH_LEN
+    call $field
+    i32.load
+    local.get $old_len
+    i32.eq
+  )
+
+  (func (export "hash_new") (param $initial_cap i32) (result i32)
+    (local $map i32)
+    (local $cap i32)
+
+    global.get $HASH_HEADER_BYTES
+    call $alloc
+    local.tee $map
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $initial_cap
+    call $normalize_cap
+    local.set $cap
+
+    local.get $map
+    local.get $cap
+    call $allocate_tables
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $map
+    i32.const 0
+    call $set_len
+
+    local.get $map
+  )
+
+  (func (export "hash_put") (param $map i32) (param $key i32) (param $value i32)
+    local.get $map
+    i32.eqz
+    if
+      return
+    end
+
+    local.get $map
+    global.get $HASH_LEN
+    call $field
+    i32.load
+    i32.const 4
+    i32.mul
+    local.get $map
+    global.get $HASH_CAP
+    call $field
+    i32.load
+    i32.const 3
+    i32.mul
+    i32.ge_u
+    if
+      local.get $map
+      call $grow
+      i32.eqz
+      if
+        return
+      end
+    end
+
+    local.get $map
+    local.get $key
+    local.get $value
+    call $insert_no_grow
+    drop
+  )
+
+  (func $find_index (param $map i32) (param $key i32) (result i32)
+    (local $cap i32)
+    (local $index i32)
+    (local $probes i32)
+
+    local.get $map
+    i32.eqz
+    if
+      i32.const -1
+      return
+    end
+
+    local.get $map
+    global.get $HASH_CAP
+    call $field
+    i32.load
+    local.set $cap
+
+    local.get $key
+    call $hash_i32
+    local.get $cap
+    i32.rem_u
+    local.set $index
+
+    block $missing
+      loop $probe
+        local.get $probes
+        local.get $cap
+        i32.ge_u
+        br_if $missing
+
+        local.get $map
+        local.get $index
+        call $state_ptr
+        i32.load8_u
+        i32.eqz
+        br_if $missing
+
+        local.get $map
+        local.get $index
+        call $key_ptr
+        i32.load
+        local.get $key
+        i32.eq
+        if
+          local.get $index
+          return
+        end
+
+        local.get $index
+        i32.const 1
+        i32.add
+        local.get $cap
+        i32.rem_u
+        local.set $index
+
+        local.get $probes
+        i32.const 1
+        i32.add
+        local.set $probes
+        br $probe
+      end
+    end
+
+    i32.const -1
+  )
+
+  (func (export "hash_get") (param $map i32) (param $key i32) (result i32)
+    (local $index i32)
+
+    local.get $map
+    local.get $key
+    call $find_index
+    local.tee $index
+    i32.const -1
+    i32.eq
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $map
+    local.get $index
+    call $value_ptr
+    i32.load
+  )
+
+  (func (export "hash_has") (param $map i32) (param $key i32) (result i32)
+    local.get $map
+    local.get $key
+    call $find_index
+    i32.const -1
+    i32.ne
+  )
+)

--- a/wat/std/pool.test.wat
+++ b/wat/std/pool.test.wat
@@ -1,0 +1,173 @@
+(module
+  (import "env" "memory" (memory $memory 1 32768))
+  (import "watwat" "assert_eq_i32"
+    (func $assert_eq_i32 (param i32) (param i32) (param i32)))
+  (import "watwat" "assert_true"
+    (func $assert_true (param i32) (param i32)))
+  (import "alloc" "bump_init"
+    (func $bump_init (param i32) (param i32)))
+  (import "pool" "pool_new"
+    (func $pool_new (param i32) (param i32) (result i32)))
+  (import "pool" "pool_alloc"
+    (func $pool_alloc (param i32) (result i32)))
+  (import "pool" "pool_free"
+    (func $pool_free (param i32) (param i32)))
+  (import "pool" "pool_count"
+    (func $pool_count (param i32) (result i32)))
+
+  (data (i32.const 1024) "pool test failed")
+
+  (func (export "message_for") (param $code i32) (result i32 i32)
+    i32.const 1024
+    i32.const 16
+  )
+
+  (func $init_heap
+    i32.const 4096
+    i32.const 65536
+    call $bump_init
+  )
+
+  (func (export "test_pool_new_rejects_empty_pool")
+    call $init_heap
+
+    i32.const 8
+    i32.const 0
+    call $pool_new
+    i32.const 0
+    i32.const 1
+    call $assert_eq_i32
+
+    i32.const 0
+    i32.const 4
+    call $pool_new
+    i32.const 0
+    i32.const 2
+    call $assert_eq_i32
+  )
+
+  (func (export "test_pool_alloc_until_full")
+    (local $pool i32)
+    (local $first i32)
+    (local $second i32)
+
+    call $init_heap
+
+    i32.const 16
+    i32.const 2
+    call $pool_new
+    local.set $pool
+
+    local.get $pool
+    call $pool_alloc
+    local.tee $first
+    i32.const 0
+    i32.ne
+    i32.const 3
+    call $assert_true
+
+    local.get $pool
+    call $pool_alloc
+    local.set $second
+
+    local.get $second
+    local.get $first
+    i32.const 16
+    i32.add
+    i32.const 4
+    call $assert_eq_i32
+
+    local.get $pool
+    call $pool_alloc
+    i32.const 0
+    i32.const 5
+    call $assert_eq_i32
+
+    local.get $pool
+    call $pool_count
+    i32.const 2
+    i32.const 6
+    call $assert_eq_i32
+  )
+
+  (func (export "test_pool_free_recycles_slot")
+    (local $pool i32)
+    (local $first i32)
+    (local $second i32)
+
+    call $init_heap
+
+    i32.const 8
+    i32.const 2
+    call $pool_new
+    local.set $pool
+
+    local.get $pool
+    call $pool_alloc
+    local.set $first
+
+    local.get $pool
+    call $pool_alloc
+    local.set $second
+
+    local.get $pool
+    local.get $first
+    call $pool_free
+
+    local.get $pool
+    call $pool_count
+    i32.const 1
+    i32.const 7
+    call $assert_eq_i32
+
+    local.get $pool
+    call $pool_alloc
+    local.get $first
+    i32.const 8
+    call $assert_eq_i32
+
+    local.get $second
+    i32.const 0
+    i32.ne
+    i32.const 9
+    call $assert_true
+  )
+
+  (func (export "test_pool_free_ignores_invalid_pointer")
+    (local $pool i32)
+    (local $first i32)
+
+    call $init_heap
+
+    i32.const 8
+    i32.const 1
+    call $pool_new
+    local.set $pool
+
+    local.get $pool
+    call $pool_alloc
+    local.set $first
+
+    local.get $pool
+    local.get $first
+    i32.const 1
+    i32.add
+    call $pool_free
+
+    local.get $pool
+    call $pool_count
+    i32.const 1
+    i32.const 10
+    call $assert_eq_i32
+
+    local.get $pool
+    local.get $first
+    call $pool_free
+
+    local.get $pool
+    call $pool_count
+    i32.const 0
+    i32.const 11
+    call $assert_eq_i32
+  )
+)

--- a/wat/std/pool.wat
+++ b/wat/std/pool.wat
@@ -1,0 +1,379 @@
+(module
+  (import "env" "memory" (memory $memory 1 32768))
+  (import "alloc" "alloc" (func $alloc (param i32) (result i32)))
+
+  (global $POOL_ELEM_SIZE i32 (i32.const 0))
+  (global $POOL_CAPACITY i32 (i32.const 4))
+  (global $POOL_SLAB_PTR i32 (i32.const 8))
+  (global $POOL_BITMAP_PTR i32 (i32.const 12))
+  (global $POOL_IN_USE i32 (i32.const 16))
+  (global $POOL_BITMAP_BYTES i32 (i32.const 20))
+  (global $POOL_HEADER_BYTES i32 (i32.const 24))
+
+  (func $align8 (param $value i32) (result i32)
+    local.get $value
+    i32.const 7
+    i32.add
+    i32.const -8
+    i32.and
+  )
+
+  (func $pool_field (param $pool i32) (param $offset i32) (result i32)
+    local.get $pool
+    local.get $offset
+    i32.add
+  )
+
+  (func $bitmap_byte_ptr (param $pool i32) (param $index i32) (result i32)
+    local.get $pool
+    global.get $POOL_BITMAP_PTR
+    call $pool_field
+    i32.load
+    local.get $index
+    i32.const 3
+    i32.shr_u
+    i32.add
+  )
+
+  (func $bitmap_mask (param $index i32) (result i32)
+    i32.const 1
+    local.get $index
+    i32.const 7
+    i32.and
+    i32.shl
+  )
+
+  (func $zero_bytes (param $ptr i32) (param $len i32)
+    (local $i i32)
+
+    block $done
+      loop $loop
+        local.get $i
+        local.get $len
+        i32.ge_u
+        br_if $done
+
+        local.get $ptr
+        local.get $i
+        i32.add
+        i32.const 0
+        i32.store8
+
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+        br $loop
+      end
+    end
+  )
+
+  (func (export "pool_new") (param $elem_size i32) (param $capacity i32) (result i32)
+    (local $pool i32)
+    (local $slot_size i32)
+    (local $bitmap_bytes i32)
+    (local $bitmap_ptr i32)
+    (local $slab_ptr i32)
+
+    local.get $elem_size
+    i32.eqz
+    local.get $capacity
+    i32.eqz
+    i32.or
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $elem_size
+    call $align8
+    local.set $slot_size
+
+    local.get $capacity
+    i32.const 7
+    i32.add
+    i32.const 3
+    i32.shr_u
+    local.set $bitmap_bytes
+
+    global.get $POOL_HEADER_BYTES
+    call $alloc
+    local.tee $pool
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $bitmap_bytes
+    call $alloc
+    local.tee $bitmap_ptr
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $slot_size
+    local.get $capacity
+    i32.mul
+    call $alloc
+    local.tee $slab_ptr
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $bitmap_ptr
+    local.get $bitmap_bytes
+    call $zero_bytes
+
+    local.get $pool
+    global.get $POOL_ELEM_SIZE
+    call $pool_field
+    local.get $slot_size
+    i32.store
+
+    local.get $pool
+    global.get $POOL_CAPACITY
+    call $pool_field
+    local.get $capacity
+    i32.store
+
+    local.get $pool
+    global.get $POOL_SLAB_PTR
+    call $pool_field
+    local.get $slab_ptr
+    i32.store
+
+    local.get $pool
+    global.get $POOL_BITMAP_PTR
+    call $pool_field
+    local.get $bitmap_ptr
+    i32.store
+
+    local.get $pool
+    global.get $POOL_IN_USE
+    call $pool_field
+    i32.const 0
+    i32.store
+
+    local.get $pool
+    global.get $POOL_BITMAP_BYTES
+    call $pool_field
+    local.get $bitmap_bytes
+    i32.store
+
+    local.get $pool
+  )
+
+  (func (export "pool_alloc") (param $pool i32) (result i32)
+    (local $capacity i32)
+    (local $slot_size i32)
+    (local $slab_ptr i32)
+    (local $index i32)
+    (local $byte_ptr i32)
+    (local $mask i32)
+    (local $byte i32)
+
+    local.get $pool
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $pool
+    global.get $POOL_CAPACITY
+    call $pool_field
+    i32.load
+    local.set $capacity
+
+    local.get $pool
+    global.get $POOL_ELEM_SIZE
+    call $pool_field
+    i32.load
+    local.set $slot_size
+
+    local.get $pool
+    global.get $POOL_SLAB_PTR
+    call $pool_field
+    i32.load
+    local.set $slab_ptr
+
+    block $full
+      loop $scan
+        local.get $index
+        local.get $capacity
+        i32.ge_u
+        br_if $full
+
+        local.get $pool
+        local.get $index
+        call $bitmap_byte_ptr
+        local.set $byte_ptr
+
+        local.get $index
+        call $bitmap_mask
+        local.set $mask
+
+        local.get $byte_ptr
+        i32.load8_u
+        local.tee $byte
+        local.get $mask
+        i32.and
+        i32.eqz
+        if
+          local.get $byte_ptr
+          local.get $byte
+          local.get $mask
+          i32.or
+          i32.store8
+
+          local.get $pool
+          global.get $POOL_IN_USE
+          call $pool_field
+          local.get $pool
+          global.get $POOL_IN_USE
+          call $pool_field
+          i32.load
+          i32.const 1
+          i32.add
+          i32.store
+
+          local.get $slab_ptr
+          local.get $index
+          local.get $slot_size
+          i32.mul
+          i32.add
+          return
+        end
+
+        local.get $index
+        i32.const 1
+        i32.add
+        local.set $index
+        br $scan
+      end
+    end
+
+    i32.const 0
+  )
+
+  (func (export "pool_free") (param $pool i32) (param $ptr i32)
+    (local $capacity i32)
+    (local $slot_size i32)
+    (local $slab_ptr i32)
+    (local $offset i32)
+    (local $index i32)
+    (local $byte_ptr i32)
+    (local $mask i32)
+    (local $byte i32)
+
+    local.get $pool
+    i32.eqz
+    if
+      return
+    end
+
+    local.get $pool
+    global.get $POOL_CAPACITY
+    call $pool_field
+    i32.load
+    local.set $capacity
+
+    local.get $pool
+    global.get $POOL_ELEM_SIZE
+    call $pool_field
+    i32.load
+    local.set $slot_size
+
+    local.get $pool
+    global.get $POOL_SLAB_PTR
+    call $pool_field
+    i32.load
+    local.set $slab_ptr
+
+    local.get $ptr
+    local.get $slab_ptr
+    i32.lt_u
+    if
+      return
+    end
+
+    local.get $ptr
+    local.get $slab_ptr
+    i32.sub
+    local.set $offset
+
+    local.get $offset
+    local.get $slot_size
+    i32.rem_u
+    if
+      return
+    end
+
+    local.get $offset
+    local.get $slot_size
+    i32.div_u
+    local.tee $index
+    local.get $capacity
+    i32.ge_u
+    if
+      return
+    end
+
+    local.get $pool
+    local.get $index
+    call $bitmap_byte_ptr
+    local.set $byte_ptr
+
+    local.get $index
+    call $bitmap_mask
+    local.set $mask
+
+    local.get $byte_ptr
+    i32.load8_u
+    local.tee $byte
+    local.get $mask
+    i32.and
+    i32.eqz
+    if
+      return
+    end
+
+    local.get $byte_ptr
+    local.get $byte
+    local.get $mask
+    i32.const -1
+    i32.xor
+    i32.and
+    i32.store8
+
+    local.get $pool
+    global.get $POOL_IN_USE
+    call $pool_field
+    local.get $pool
+    global.get $POOL_IN_USE
+    call $pool_field
+    i32.load
+    i32.const 1
+    i32.sub
+    i32.store
+  )
+
+  (func (export "pool_count") (param $pool i32) (result i32)
+    local.get $pool
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $pool
+    global.get $POOL_IN_USE
+    call $pool_field
+    i32.load
+  )
+)

--- a/wat/std/ring.test.wat
+++ b/wat/std/ring.test.wat
@@ -1,0 +1,170 @@
+(module
+  (import "env" "memory" (memory $memory 1 32768))
+  (import "watwat" "assert_eq_i32"
+    (func $assert_eq_i32 (param i32) (param i32) (param i32)))
+  (import "watwat" "assert_eq_str"
+    (func $assert_eq_str (param i32) (param i32) (param i32) (param i32) (param i32)))
+  (import "watwat" "assert_true"
+    (func $assert_true (param i32) (param i32)))
+  (import "alloc" "bump_init"
+    (func $bump_init (param i32) (param i32)))
+  (import "ring" "ring_new"
+    (func $ring_new (param i32) (result i32)))
+  (import "ring" "ring_write"
+    (func $ring_write (param i32) (param i32) (param i32)))
+  (import "ring" "ring_read"
+    (func $ring_read (param i32) (param i32) (param i32) (result i32)))
+  (import "ring" "ring_available"
+    (func $ring_available (param i32) (result i32)))
+
+  (data (i32.const 1024) "ring test failed")
+  (data (i32.const 2048) "abcdef")
+  (data (i32.const 2064) "WXYZ")
+
+  (func (export "message_for") (param $code i32) (result i32 i32)
+    i32.const 1024
+    i32.const 16
+  )
+
+  (func $init_heap
+    i32.const 4096
+    i32.const 65536
+    call $bump_init
+  )
+
+  (func (export "test_ring_empty_and_zero_capacity")
+    (local $ring i32)
+
+    call $init_heap
+
+    i32.const 0
+    call $ring_new
+    i32.const 0
+    i32.const 1
+    call $assert_eq_i32
+
+    i32.const 4
+    call $ring_new
+    local.tee $ring
+    i32.const 0
+    i32.ne
+    i32.const 2
+    call $assert_true
+
+    local.get $ring
+    call $ring_available
+    i32.const 0
+    i32.const 3
+    call $assert_eq_i32
+
+    local.get $ring
+    i32.const 3000
+    i32.const 2
+    call $ring_read
+    i32.const 0
+    i32.const 4
+    call $assert_eq_i32
+  )
+
+  (func (export "test_ring_write_read_fifo_and_partial")
+    (local $ring i32)
+
+    call $init_heap
+
+    i32.const 4
+    call $ring_new
+    local.set $ring
+
+    local.get $ring
+    i32.const 2048
+    i32.const 6
+    call $ring_write
+
+    local.get $ring
+    call $ring_available
+    i32.const 4
+    i32.const 5
+    call $assert_eq_i32
+
+    local.get $ring
+    i32.const 3000
+    i32.const 2
+    call $ring_read
+    i32.const 2
+    i32.const 6
+    call $assert_eq_i32
+
+    i32.const 3000
+    i32.const 2
+    i32.const 2048
+    i32.const 2
+    i32.const 7
+    call $assert_eq_str
+
+    local.get $ring
+    call $ring_available
+    i32.const 2
+    i32.const 8
+    call $assert_eq_i32
+  )
+
+  (func (export "test_ring_wraparound_preserves_order")
+    (local $ring i32)
+
+    call $init_heap
+
+    i32.const 4
+    call $ring_new
+    local.set $ring
+
+    local.get $ring
+    i32.const 2048
+    i32.const 4
+    call $ring_write
+
+    local.get $ring
+    i32.const 3000
+    i32.const 3
+    call $ring_read
+    drop
+
+    local.get $ring
+    i32.const 2064
+    i32.const 3
+    call $ring_write
+
+    local.get $ring
+    call $ring_available
+    i32.const 4
+    i32.const 9
+    call $assert_eq_i32
+
+    local.get $ring
+    i32.const 3010
+    i32.const 4
+    call $ring_read
+    i32.const 4
+    i32.const 10
+    call $assert_eq_i32
+
+    i32.const 3010
+    i32.const 1
+    i32.const 2051
+    i32.const 1
+    i32.const 11
+    call $assert_eq_str
+
+    i32.const 3011
+    i32.const 3
+    i32.const 2064
+    i32.const 3
+    i32.const 12
+    call $assert_eq_str
+
+    local.get $ring
+    call $ring_available
+    i32.const 0
+    i32.const 13
+    call $assert_eq_i32
+  )
+)

--- a/wat/std/ring.wat
+++ b/wat/std/ring.wat
@@ -1,0 +1,284 @@
+(module
+  (import "env" "memory" (memory $memory 1 32768))
+  (import "alloc" "alloc" (func $alloc (param i32) (result i32)))
+
+  (global $RING_BUF_PTR i32 (i32.const 0))
+  (global $RING_CAP i32 (i32.const 4))
+  (global $RING_READ_POS i32 (i32.const 8))
+  (global $RING_WRITE_POS i32 (i32.const 12))
+  (global $RING_COUNT i32 (i32.const 16))
+  (global $RING_HEADER_BYTES i32 (i32.const 20))
+
+  (func $field (param $ring i32) (param $offset i32) (result i32)
+    local.get $ring
+    local.get $offset
+    i32.add
+  )
+
+  (func $get (param $ring i32) (param $offset i32) (result i32)
+    local.get $ring
+    local.get $offset
+    call $field
+    i32.load
+  )
+
+  (func $set (param $ring i32) (param $offset i32) (param $value i32)
+    local.get $ring
+    local.get $offset
+    call $field
+    local.get $value
+    i32.store
+  )
+
+  (func $min_u (param $a i32) (param $b i32) (result i32)
+    local.get $a
+    local.get $b
+    i32.lt_u
+    if (result i32)
+      local.get $a
+    else
+      local.get $b
+    end
+  )
+
+  (func (export "ring_new") (param $byte_cap i32) (result i32)
+    (local $ring i32)
+    (local $buf i32)
+
+    local.get $byte_cap
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    global.get $RING_HEADER_BYTES
+    call $alloc
+    local.tee $ring
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $byte_cap
+    call $alloc
+    local.tee $buf
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $ring
+    global.get $RING_BUF_PTR
+    local.get $buf
+    call $set
+
+    local.get $ring
+    global.get $RING_CAP
+    local.get $byte_cap
+    call $set
+
+    local.get $ring
+    global.get $RING_READ_POS
+    i32.const 0
+    call $set
+
+    local.get $ring
+    global.get $RING_WRITE_POS
+    i32.const 0
+    call $set
+
+    local.get $ring
+    global.get $RING_COUNT
+    i32.const 0
+    call $set
+
+    local.get $ring
+  )
+
+  (func (export "ring_write") (param $ring i32) (param $src_ptr i32) (param $len i32)
+    (local $buf i32)
+    (local $cap i32)
+    (local $write_pos i32)
+    (local $count i32)
+    (local $to_write i32)
+    (local $i i32)
+
+    local.get $ring
+    i32.eqz
+    if
+      return
+    end
+
+    local.get $ring
+    global.get $RING_BUF_PTR
+    call $get
+    local.set $buf
+
+    local.get $ring
+    global.get $RING_CAP
+    call $get
+    local.set $cap
+
+    local.get $ring
+    global.get $RING_WRITE_POS
+    call $get
+    local.set $write_pos
+
+    local.get $ring
+    global.get $RING_COUNT
+    call $get
+    local.set $count
+
+    local.get $len
+    local.get $cap
+    local.get $count
+    i32.sub
+    call $min_u
+    local.set $to_write
+
+    block $done
+      loop $loop
+        local.get $i
+        local.get $to_write
+        i32.ge_u
+        br_if $done
+
+        local.get $buf
+        local.get $write_pos
+        i32.add
+        local.get $src_ptr
+        local.get $i
+        i32.add
+        i32.load8_u
+        i32.store8
+
+        local.get $write_pos
+        i32.const 1
+        i32.add
+        local.get $cap
+        i32.rem_u
+        local.set $write_pos
+
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+        br $loop
+      end
+    end
+
+    local.get $ring
+    global.get $RING_WRITE_POS
+    local.get $write_pos
+    call $set
+
+    local.get $ring
+    global.get $RING_COUNT
+    local.get $count
+    local.get $to_write
+    i32.add
+    call $set
+  )
+
+  (func (export "ring_read") (param $ring i32) (param $dst_ptr i32) (param $len i32) (result i32)
+    (local $buf i32)
+    (local $cap i32)
+    (local $read_pos i32)
+    (local $count i32)
+    (local $to_read i32)
+    (local $i i32)
+
+    local.get $ring
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $ring
+    global.get $RING_BUF_PTR
+    call $get
+    local.set $buf
+
+    local.get $ring
+    global.get $RING_CAP
+    call $get
+    local.set $cap
+
+    local.get $ring
+    global.get $RING_READ_POS
+    call $get
+    local.set $read_pos
+
+    local.get $ring
+    global.get $RING_COUNT
+    call $get
+    local.set $count
+
+    local.get $len
+    local.get $count
+    call $min_u
+    local.set $to_read
+
+    block $done
+      loop $loop
+        local.get $i
+        local.get $to_read
+        i32.ge_u
+        br_if $done
+
+        local.get $dst_ptr
+        local.get $i
+        i32.add
+        local.get $buf
+        local.get $read_pos
+        i32.add
+        i32.load8_u
+        i32.store8
+
+        local.get $read_pos
+        i32.const 1
+        i32.add
+        local.get $cap
+        i32.rem_u
+        local.set $read_pos
+
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+        br $loop
+      end
+    end
+
+    local.get $ring
+    global.get $RING_READ_POS
+    local.get $read_pos
+    call $set
+
+    local.get $ring
+    global.get $RING_COUNT
+    local.get $count
+    local.get $to_read
+    i32.sub
+    call $set
+
+    local.get $to_read
+  )
+
+  (func (export "ring_available") (param $ring i32) (result i32)
+    local.get $ring
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $ring
+    global.get $RING_COUNT
+    call $get
+  )
+)

--- a/wat/std/strtab.test.wat
+++ b/wat/std/strtab.test.wat
@@ -1,0 +1,140 @@
+(module
+  (import "env" "memory" (memory $memory 1 32768))
+  (import "watwat" "assert_eq_i32"
+    (func $assert_eq_i32 (param i32) (param i32) (param i32)))
+  (import "watwat" "assert_eq_str"
+    (func $assert_eq_str (param i32) (param i32) (param i32) (param i32) (param i32)))
+  (import "watwat" "assert_true"
+    (func $assert_true (param i32) (param i32)))
+  (import "watwat" "assert_false"
+    (func $assert_false (param i32) (param i32)))
+  (import "alloc" "bump_init"
+    (func $bump_init (param i32) (param i32)))
+  (import "strtab" "strtab_intern"
+    (func $strtab_intern (param i32) (param i32) (result i32)))
+  (import "strtab" "strtab_get"
+    (func $strtab_get (param i32) (result i32 i32)))
+  (import "strtab" "strtab_eq"
+    (func $strtab_eq (param i32) (param i32) (result i32)))
+
+  (data (i32.const 1024) "strtab test failed")
+  (data (i32.const 2048) "alpha")
+  (data (i32.const 2064) "alpha")
+  (data (i32.const 2080) "beta")
+
+  (func (export "message_for") (param $code i32) (result i32 i32)
+    i32.const 1024
+    i32.const 18
+  )
+
+  (func (export "test_strtab_intern_get_and_eq")
+    (local $alpha_a i32)
+    (local $alpha_b i32)
+    (local $beta i32)
+    (local $empty i32)
+    (local $got_ptr i32)
+    (local $got_len i32)
+
+    i32.const 4096
+    i32.const 65536
+    call $bump_init
+
+    i32.const 2048
+    i32.const 5
+    call $strtab_intern
+    local.set $alpha_a
+
+    i32.const 2064
+    i32.const 5
+    call $strtab_intern
+    local.set $alpha_b
+
+    i32.const 2080
+    i32.const 4
+    call $strtab_intern
+    local.set $beta
+
+    i32.const 2048
+    i32.const 0
+    call $strtab_intern
+    local.set $empty
+
+    local.get $alpha_a
+    i32.const 0
+    i32.ne
+    i32.const 1
+    call $assert_true
+
+    local.get $alpha_a
+    local.get $alpha_b
+    i32.const 2
+    call $assert_eq_i32
+
+    local.get $alpha_a
+    local.get $beta
+    call $strtab_eq
+    i32.const 3
+    call $assert_false
+
+    local.get $alpha_a
+    local.get $alpha_b
+    call $strtab_eq
+    i32.const 4
+    call $assert_true
+
+    local.get $alpha_a
+    call $strtab_get
+    local.set $got_len
+    local.set $got_ptr
+
+    local.get $got_ptr
+    local.get $got_len
+    i32.const 2048
+    i32.const 5
+    i32.const 5
+    call $assert_eq_str
+
+    local.get $got_ptr
+    i32.const 2048
+    i32.ne
+    i32.const 10
+    call $assert_true
+
+    local.get $beta
+    call $strtab_get
+    local.set $got_len
+    local.set $got_ptr
+
+    local.get $got_ptr
+    local.get $got_len
+    i32.const 2080
+    i32.const 4
+    i32.const 6
+    call $assert_eq_str
+
+    local.get $empty
+    call $strtab_get
+    local.set $got_len
+    local.set $got_ptr
+
+    local.get $got_len
+    i32.const 0
+    i32.const 7
+    call $assert_eq_i32
+
+    i32.const 999
+    call $strtab_get
+    local.set $got_len
+    local.set $got_ptr
+
+    local.get $got_ptr
+    i32.const 0
+    i32.const 8
+    call $assert_eq_i32
+
+    local.get $got_len
+    i32.const 0
+    i32.const 9
+    call $assert_eq_i32
+  )
+)

--- a/wat/std/strtab.wat
+++ b/wat/std/strtab.wat
@@ -1,0 +1,449 @@
+(module
+  (import "env" "memory" (memory $memory 1 32768))
+  (import "alloc" "alloc" (func $alloc (param i32) (result i32)))
+  (import "hash" "hash_new" (func $hash_new (param i32) (result i32)))
+  (import "hash" "hash_put" (func $hash_put (param i32) (param i32) (param i32)))
+  (import "hash" "hash_get" (func $hash_get (param i32) (param i32) (result i32)))
+
+  (global $FNV_OFFSET i32 (i32.const -2128831035))
+  (global $FNV_PRIME i32 (i32.const 16777619))
+  (global $ENTRY_START_CAP i32 (i32.const 16))
+
+  (global $index (mut i32) (i32.const 0))
+  (global $ptrs (mut i32) (i32.const 0))
+  (global $lens (mut i32) (i32.const 0))
+  (global $hashes (mut i32) (i32.const 0))
+  (global $nexts (mut i32) (i32.const 0))
+  (global $count (mut i32) (i32.const 0))
+  (global $capacity (mut i32) (i32.const 0))
+
+  (func $hash_byte (param $hash i32) (param $byte i32) (result i32)
+    local.get $hash
+    local.get $byte
+    i32.const 255
+    i32.and
+    i32.xor
+    global.get $FNV_PRIME
+    i32.mul
+  )
+
+  (func $hash_bytes (param $ptr i32) (param $len i32) (result i32)
+    (local $hash i32)
+    (local $i i32)
+
+    global.get $FNV_OFFSET
+    local.set $hash
+
+    block $done
+      loop $loop
+        local.get $i
+        local.get $len
+        i32.ge_u
+        br_if $done
+
+        local.get $hash
+        local.get $ptr
+        local.get $i
+        i32.add
+        i32.load8_u
+        call $hash_byte
+        local.set $hash
+
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+        br $loop
+      end
+    end
+
+    local.get $hash
+  )
+
+  (func $copy_bytes (param $dst i32) (param $src i32) (param $len i32)
+    (local $i i32)
+
+    block $done
+      loop $loop
+        local.get $i
+        local.get $len
+        i32.ge_u
+        br_if $done
+
+        local.get $dst
+        local.get $i
+        i32.add
+        local.get $src
+        local.get $i
+        i32.add
+        i32.load8_u
+        i32.store8
+
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+        br $loop
+      end
+    end
+  )
+
+  (func $bytes_eq (param $a_ptr i32) (param $b_ptr i32) (param $len i32) (result i32)
+    (local $i i32)
+
+    block $same
+      loop $loop
+        local.get $i
+        local.get $len
+        i32.ge_u
+        br_if $same
+
+        local.get $a_ptr
+        local.get $i
+        i32.add
+        i32.load8_u
+        local.get $b_ptr
+        local.get $i
+        i32.add
+        i32.load8_u
+        i32.ne
+        if
+          i32.const 0
+          return
+        end
+
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+        br $loop
+      end
+    end
+
+    i32.const 1
+  )
+
+  (func $entry_ptr (param $base i32) (param $id i32) (result i32)
+    local.get $base
+    local.get $id
+    i32.const 2
+    i32.shl
+    i32.add
+  )
+
+  (func $alloc_entry_array (param $cap i32) (result i32)
+    local.get $cap
+    i32.const 1
+    i32.add
+    i32.const 2
+    i32.shl
+    call $alloc
+  )
+
+  (func $ensure_init (result i32)
+    global.get $index
+    if
+      i32.const 1
+      return
+    end
+
+    i32.const 16
+    call $hash_new
+    global.set $index
+
+    global.get $ENTRY_START_CAP
+    global.set $capacity
+
+    global.get $capacity
+    call $alloc_entry_array
+    global.set $ptrs
+
+    global.get $capacity
+    call $alloc_entry_array
+    global.set $lens
+
+    global.get $capacity
+    call $alloc_entry_array
+    global.set $hashes
+
+    global.get $capacity
+    call $alloc_entry_array
+    global.set $nexts
+
+    global.get $index
+    global.get $ptrs
+    i32.and
+    global.get $lens
+    i32.and
+    global.get $hashes
+    i32.and
+    global.get $nexts
+    i32.and
+    i32.const 0
+    i32.ne
+  )
+
+  (func $grow_entries (result i32)
+    (local $old_cap i32)
+    (local $old_ptrs i32)
+    (local $old_lens i32)
+    (local $old_hashes i32)
+    (local $old_nexts i32)
+    (local $new_cap i32)
+
+    global.get $capacity
+    local.set $old_cap
+    global.get $ptrs
+    local.set $old_ptrs
+    global.get $lens
+    local.set $old_lens
+    global.get $hashes
+    local.set $old_hashes
+    global.get $nexts
+    local.set $old_nexts
+
+    local.get $old_cap
+    i32.const 2
+    i32.mul
+    local.set $new_cap
+
+    local.get $new_cap
+    call $alloc_entry_array
+    global.set $ptrs
+
+    local.get $new_cap
+    call $alloc_entry_array
+    global.set $lens
+
+    local.get $new_cap
+    call $alloc_entry_array
+    global.set $hashes
+
+    local.get $new_cap
+    call $alloc_entry_array
+    global.set $nexts
+
+    global.get $ptrs
+    global.get $lens
+    i32.and
+    global.get $hashes
+    i32.and
+    global.get $nexts
+    i32.and
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    global.get $ptrs
+    local.get $old_ptrs
+    global.get $count
+    i32.const 1
+    i32.add
+    i32.const 2
+    i32.shl
+    call $copy_bytes
+
+    global.get $lens
+    local.get $old_lens
+    global.get $count
+    i32.const 1
+    i32.add
+    i32.const 2
+    i32.shl
+    call $copy_bytes
+
+    global.get $hashes
+    local.get $old_hashes
+    global.get $count
+    i32.const 1
+    i32.add
+    i32.const 2
+    i32.shl
+    call $copy_bytes
+
+    global.get $nexts
+    local.get $old_nexts
+    global.get $count
+    i32.const 1
+    i32.add
+    i32.const 2
+    i32.shl
+    call $copy_bytes
+
+    local.get $new_cap
+    global.set $capacity
+
+    i32.const 1
+  )
+
+  (func $ensure_entry_capacity (result i32)
+    global.get $count
+    global.get $capacity
+    i32.lt_u
+    if
+      i32.const 1
+      return
+    end
+
+    call $grow_entries
+  )
+
+  (func (export "strtab_intern") (param $ptr i32) (param $len i32) (result i32)
+    (local $hash i32)
+    (local $id i32)
+    (local $copy_ptr i32)
+    (local $head i32)
+
+    call $ensure_init
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $ptr
+    local.get $len
+    call $hash_bytes
+    local.set $hash
+
+    global.get $index
+    local.get $hash
+    call $hash_get
+    local.tee $id
+    local.set $head
+
+    block $not_found
+      loop $scan
+        local.get $id
+        i32.eqz
+        br_if $not_found
+
+        global.get $hashes
+        local.get $id
+        call $entry_ptr
+        i32.load
+        local.get $hash
+        i32.eq
+        global.get $lens
+        local.get $id
+        call $entry_ptr
+        i32.load
+        local.get $len
+        i32.eq
+        i32.and
+        if
+          global.get $ptrs
+          local.get $id
+          call $entry_ptr
+          i32.load
+          local.get $ptr
+          local.get $len
+          call $bytes_eq
+          if
+            local.get $id
+            return
+          end
+        end
+
+        global.get $nexts
+        local.get $id
+        call $entry_ptr
+        i32.load
+        local.set $id
+        br $scan
+      end
+    end
+
+    call $ensure_entry_capacity
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $len
+    if
+      local.get $len
+      call $alloc
+      local.tee $copy_ptr
+      i32.eqz
+      if
+        i32.const 0
+        return
+      end
+
+      local.get $copy_ptr
+      local.get $ptr
+      local.get $len
+      call $copy_bytes
+    end
+
+    global.get $count
+    i32.const 1
+    i32.add
+    global.set $count
+
+    global.get $ptrs
+    global.get $count
+    call $entry_ptr
+    local.get $copy_ptr
+    i32.store
+
+    global.get $lens
+    global.get $count
+    call $entry_ptr
+    local.get $len
+    i32.store
+
+    global.get $hashes
+    global.get $count
+    call $entry_ptr
+    local.get $hash
+    i32.store
+
+    global.get $nexts
+    global.get $count
+    call $entry_ptr
+    local.get $head
+    i32.store
+
+    global.get $index
+    local.get $hash
+    global.get $count
+    call $hash_put
+
+    global.get $count
+  )
+
+  (func (export "strtab_get") (param $id i32) (result i32 i32)
+    local.get $id
+    i32.eqz
+    local.get $id
+    global.get $count
+    i32.gt_u
+    i32.or
+    if
+      i32.const 0
+      i32.const 0
+      return
+    end
+
+    global.get $ptrs
+    local.get $id
+    call $entry_ptr
+    i32.load
+
+    global.get $lens
+    local.get $id
+    call $entry_ptr
+    i32.load
+  )
+
+  (func (export "strtab_eq") (param $a i32) (param $b i32) (result i32)
+    local.get $a
+    local.get $b
+    i32.eq
+  )
+)


### PR DESCRIPTION
Adds Tracy's WAT std-library foundation for explicit v0.1 memory management, including the bump arena, slab pool, typed append-only arrays, open-addressed hash map, interned string table, and byte ring buffer. Remaining work wires `dist/wasm/std/*.test.wasm` into the package/CI test path and documents the practical coverage path for hand-written WAT.

Fixes #7.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (9)</summary>

- [x] [Update the package/CI test command so the new std WAT test modules run in CI and provide behavioral coverage for the added std-lib code.](https://github.com/rhencke/tracy/pull/79#issuecomment-4384362275) <!-- type:thread -->
- [x] Add byte ring buffer and tests <!-- type:spec -->
- [x] Refresh compiled WAT artifacts <!-- type:spec -->
- [x] Add interned string table and tests <!-- type:spec -->
- [x] Add open-addressed hash map and tests <!-- type:spec -->
- [x] Add typed append-only arrays and tests <!-- type:spec -->
- [x] Add slab object pool and tests <!-- type:spec -->
- [x] Add bump arena allocator and tests <!-- type:spec -->
- [x] Load std modules for watwat tests <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->