### PR TITLE
v0.1 #7 — Host shim API: minimal (canvas, pointer, file, OPFS) (closes #8)

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -45,6 +45,80 @@ so design docs and module code use the same names.
 also be exported for convenience, but the base constants above are the
 cross-module ABI surface required by v0.1.
 
+## Host scratch ABI
+
+The browser host shim owns the first page of `MEM_SCRATCH_BASE` for v0.1
+browser input state.  Wasm may read these bytes during `tracy_tick`; no wasm
+module may allocate from or overwrite this range.  The app may clear the rest
+of scratch every tick, but it must preserve the host range below.
+
+Multi-byte fields are little-endian.  Canvas sizes are physical pixels:
+`floor(canvas.clientWidth * devicePixelRatio)` and
+`floor(canvas.clientHeight * devicePixelRatio)`, clamped to at least `1`.
+The packed canvas size returned by `canvas_get_size()` is a 64-bit value with
+width in bits `0..31` and height in bits `32..63`.
+
+### Host scratch layout
+
+| Offset | Constant | Size | Field |
+|---:|---|---:|---|
+| `0x0000` | `HOST_CANVAS_SIZE_OFFSET` | 4 | Canvas width, `u32`. |
+| `0x0004` | `HOST_CANVAS_SIZE_OFFSET + 4` | 4 | Canvas height, `u32`. |
+| `0x0008` | `HOST_CANVAS_RESIZE_SEQ_OFFSET` | 4 | Incremented after each resize write. |
+| `0x000C..0x003F` | | 52 | Reserved, zero for v0.1. |
+| `0x0040` | `HOST_POINTER_RING_OFFSET` | 32 | Pointer ring header. |
+| `0x0060` | `HOST_POINTER_RECORDS_OFFSET` | 8192 | Pointer event records. |
+| `0x2060..0xFFFF` | | 57248 | Reserved for future host scratch fields. |
+
+The resize observer writes width and height first, then increments
+`HOST_CANVAS_RESIZE_SEQ_OFFSET`.  Readers that need a stable pair should read
+the sequence before and after the size fields and retry when it changes.
+
+### Pointer ring
+
+`pointer_listen()` appends fixed-width records to a circular ring in host
+scratch memory.  The ring capacity is 256 records, and each record is 32
+bytes.  When the ring is full, the host drops the newest event and increments
+the dropped counter; wasm advances the read index as it consumes records.
+
+The ring header at `HOST_POINTER_RING_OFFSET` is:
+
+| Header offset | Size | Field |
+|---:|---:|---|
+| 0 | 4 | `read_index`, `u32`, written by wasm. |
+| 4 | 4 | `write_index`, `u32`, written by the host. |
+| 8 | 4 | `count`, `u32`, number of unread records. |
+| 12 | 4 | `dropped`, `u32`, count of events dropped because the ring was full. |
+| 16 | 4 | `capacity`, `u32`, always `256` for v0.1. |
+| 20 | 4 | `record_size`, `u32`, always `32` for v0.1. |
+| 24 | 8 | Reserved, zero for v0.1. |
+
+Each pointer record is:
+
+| Record offset | Size | Type | Field |
+|---:|---:|---|---|
+| 0 | 1 | `u8` | Kind: `1` down, `2` move, `3` up, `4` cancel. |
+| 1 | 3 | | Padding, zero. |
+| 4 | 4 | `u32` | `pointerId`. |
+| 8 | 4 | `f32` | Canvas-local x in CSS pixels. |
+| 12 | 4 | `f32` | Canvas-local y in CSS pixels. |
+| 16 | 8 | `f64` | DOM event timestamp. |
+| 24 | 4 | `f32` | Pressure, or `0` when unavailable. |
+| 28 | 4 | `u32` | Modifier bitset. |
+
+Modifier bits are:
+
+| Bit | Constant | Meaning |
+|---:|---|---|
+| `0x00000001` | `HOST_POINTER_MOD_SHIFT` | Shift key active. |
+| `0x00000002` | `HOST_POINTER_MOD_CTRL` | Control key active. |
+| `0x00000004` | `HOST_POINTER_MOD_ALT` | Alt key active. |
+| `0x00000008` | `HOST_POINTER_MOD_META` | Meta key active. |
+| `0x00000010` | `HOST_POINTER_MOD_PRIMARY` | Event is the primary pointer. |
+| `0x00000020` | `HOST_POINTER_MOD_BUTTON_PRIMARY` | Primary pointer button is down. |
+| `0x00000040` | `HOST_POINTER_MOD_BUTTON_SECONDARY` | Secondary pointer button is down. |
+| `0x00000080` | `HOST_POINTER_MOD_BUTTON_AUXILIARY` | Auxiliary pointer button is down. |
+
 ## Ownership rules
 
 Each region has exactly one writer.  Reads are unrestricted, but a reader

--- a/README.md
+++ b/README.md
@@ -73,6 +73,40 @@ node tools/watwat.js dist/wasm/*.test.wasm dist/wasm/std/*.test.wasm
 python3 -m http.server -d dist 8000
 ```
 
+## Browser smoke checks
+
+The host shim smoke fixture is built to `dist/wasm/host_smoke.wasm` by
+`bash tools/build.sh`.  It uses the same host imports as the app and is meant
+for a manual run in a JSPI-capable browser.
+
+1. Serve the repository root after building:
+
+   ```sh
+   python3 -m http.server 8000
+   ```
+
+2. Open `http://localhost:8000/smoke/host-shim.html`.  The page imports
+   `shim.js`, loads `dist/wasm/host_smoke.wasm`, and calls `tracy_main()` to
+   install resize and pointer listeners.  Press **Canvas size** to call
+   `canvas_get_size()` through wasm; the result packs width in the low 32 bits
+   and height in the high 32 bits.
+
+3. Tap or drag on the canvas, then press **Canvas size** again.  The displayed
+   pointer record count should increase.  The same value is visible in
+   DevTools from the documented scratch ring:
+
+   ```js
+   const memory = await import("./host-shim.js").then((module) => module.memory);
+   const view = new DataView(memory.buffer);
+   view.getUint32(0x48, true); // unread pointer record count
+   view.getUint8(0x60);        // first record kind: 1 down, 2 move, 3 up, 4 cancel
+   ```
+
+4. Press **File round trip** and choose a small trace or JSON file.  A
+   non-negative byte count means the file picker resolved, the file was copied
+   into OPFS, and the first chunk was copied back into linear memory at
+   `0x800`.
+
 The hosted scaffold is <https://rhencke.github.io/tracy/>.  At this
 stage it is intentionally only a blank full-screen canvas loaded from
 the placeholder wasm module.

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1,13 +1,65 @@
 import { makeShim } from "./shim.js";
 
+const asyncHostImports = new Set([
+  "file_picker_open",
+  "opfs_create_from_file",
+  "opfs_read_chunk",
+]);
+
 const memory = new WebAssembly.Memory({
   initial: 256,
   maximum: 32768,
   shared: false,
 });
 
+function supportsJSPI() {
+  return typeof WebAssembly.Suspending === "function";
+}
+
+function showError(message) {
+  const canvas = document.getElementById("tracy");
+  const error = document.createElement("div");
+
+  error.setAttribute("role", "alert");
+  error.style.position = "fixed";
+  error.style.inset = "0";
+  error.style.display = "grid";
+  error.style.placeItems = "center";
+  error.style.padding = "2rem";
+  error.style.color = "#1f1b16";
+  error.style.font = "1rem/1.4 system-ui, sans-serif";
+  error.style.textAlign = "center";
+  error.style.background = "#fbf8f4";
+  error.textContent = message;
+
+  if (canvas !== null) {
+    canvas.hidden = true;
+  }
+
+  document.body.appendChild(error);
+}
+
+function wrapAsyncHostImports(host) {
+  return Object.fromEntries(
+    Object.entries(host).map(([name, value]) => [
+      name,
+      asyncHostImports.has(name) ? new WebAssembly.Suspending(value) : value,
+    ]),
+  );
+}
+
 async function loadApp() {
-  const imports = { env: { memory }, host: makeShim(memory) };
+  if (!supportsJSPI()) {
+    showError(
+      "tracy needs a browser with WebAssembly JavaScript Promise Integration (JSPI) enabled.",
+    );
+    return;
+  }
+
+  const imports = {
+    env: { memory },
+    host: wrapAsyncHostImports(makeShim(memory)),
+  };
   const { instance } = await WebAssembly.instantiateStreaming(
     fetch("wasm/app.wasm"),
     imports,
@@ -24,4 +76,7 @@ async function loadApp() {
   requestAnimationFrame(loop);
 }
 
-loadApp();
+loadApp().catch((error) => {
+  console.error(error);
+  showError("tracy failed to load the WebAssembly viewer.");
+});

--- a/shim.js
+++ b/shim.js
@@ -23,14 +23,45 @@ export const HOST_POINTER_MOD_BUTTON_PRIMARY = 0x00000020;
 export const HOST_POINTER_MOD_BUTTON_SECONDARY = 0x00000040;
 export const HOST_POINTER_MOD_BUTTON_AUXILIARY = 0x00000080;
 
+const POINTER_RING_READ_INDEX_OFFSET = HOST_POINTER_RING_OFFSET;
+const POINTER_RING_WRITE_INDEX_OFFSET = HOST_POINTER_RING_OFFSET + 4;
+const POINTER_RING_COUNT_OFFSET = HOST_POINTER_RING_OFFSET + 8;
+const POINTER_RING_DROPPED_OFFSET = HOST_POINTER_RING_OFFSET + 12;
+const POINTER_RING_CAPACITY_OFFSET = HOST_POINTER_RING_OFFSET + 16;
+const POINTER_RING_RECORD_SIZE_OFFSET = HOST_POINTER_RING_OFFSET + 20;
+
 export function makeShim(memory) {
   const canvas = document.getElementById("tracy");
   const context = canvas.getContext("2d", { alpha: false });
+  let resizeObserver = null;
+  let resizeListenerInstalled = false;
+  let pointerListenerInstalled = false;
+
+  function view() {
+    return new DataView(memory.buffer);
+  }
+
+  function canvasSize() {
+    const scale = window.devicePixelRatio || 1;
+
+    return {
+      scale,
+      width: Math.max(1, Math.floor(canvas.clientWidth * scale)),
+      height: Math.max(1, Math.floor(canvas.clientHeight * scale)),
+    };
+  }
+
+  function writeCanvasSize(width, height) {
+    const scratch = view();
+    const seq = scratch.getUint32(HOST_CANVAS_RESIZE_SEQ_OFFSET, true);
+
+    scratch.setUint32(HOST_CANVAS_SIZE_OFFSET, width, true);
+    scratch.setUint32(HOST_CANVAS_SIZE_OFFSET + 4, height, true);
+    scratch.setUint32(HOST_CANVAS_RESIZE_SEQ_OFFSET, seq + 1, true);
+  }
 
   function resize() {
-    const scale = window.devicePixelRatio || 1;
-    const width = Math.max(1, Math.floor(canvas.clientWidth * scale));
-    const height = Math.max(1, Math.floor(canvas.clientHeight * scale));
+    const { scale, width, height } = canvasSize();
 
     if (canvas.width !== width || canvas.height !== height) {
       canvas.width = width;
@@ -40,10 +71,173 @@ export function makeShim(memory) {
     context.setTransform(scale, 0, 0, scale, 0, 0);
     context.fillStyle = "#fbf8f4";
     context.fillRect(0, 0, canvas.clientWidth, canvas.clientHeight);
+    writeCanvasSize(width, height);
+  }
+
+  function canvasGetSize() {
+    const { width, height } = canvasSize();
+
+    return (BigInt(height) << 32n) | BigInt(width);
+  }
+
+  function canvasListenResize() {
+    if (resizeListenerInstalled) {
+      resize();
+      return;
+    }
+
+    resizeListenerInstalled = true;
+
+    if (typeof ResizeObserver === "function") {
+      resizeObserver = new ResizeObserver(resize);
+      resizeObserver.observe(canvas);
+    } else {
+      window.addEventListener("resize", resize);
+    }
+
+    window.addEventListener("orientationchange", resize);
+    resize();
+  }
+
+  function resetPointerRing() {
+    const scratch = view();
+
+    scratch.setUint32(POINTER_RING_READ_INDEX_OFFSET, 0, true);
+    scratch.setUint32(POINTER_RING_WRITE_INDEX_OFFSET, 0, true);
+    scratch.setUint32(POINTER_RING_COUNT_OFFSET, 0, true);
+    scratch.setUint32(POINTER_RING_DROPPED_OFFSET, 0, true);
+    scratch.setUint32(
+      POINTER_RING_CAPACITY_OFFSET,
+      HOST_POINTER_RECORD_CAPACITY,
+      true,
+    );
+    scratch.setUint32(
+      POINTER_RING_RECORD_SIZE_OFFSET,
+      HOST_POINTER_RECORD_SIZE,
+      true,
+    );
+    scratch.setUint32(HOST_POINTER_RING_OFFSET + 24, 0, true);
+    scratch.setUint32(HOST_POINTER_RING_OFFSET + 28, 0, true);
+  }
+
+  function pointerKind(type) {
+    switch (type) {
+      case "pointerdown":
+        return HOST_POINTER_KIND_DOWN;
+      case "pointermove":
+        return HOST_POINTER_KIND_MOVE;
+      case "pointerup":
+        return HOST_POINTER_KIND_UP;
+      case "pointercancel":
+        return HOST_POINTER_KIND_CANCEL;
+      default:
+        return 0;
+    }
+  }
+
+  function pointerModifiers(event) {
+    let modifiers = 0;
+
+    if (event.shiftKey) {
+      modifiers |= HOST_POINTER_MOD_SHIFT;
+    }
+    if (event.ctrlKey) {
+      modifiers |= HOST_POINTER_MOD_CTRL;
+    }
+    if (event.altKey) {
+      modifiers |= HOST_POINTER_MOD_ALT;
+    }
+    if (event.metaKey) {
+      modifiers |= HOST_POINTER_MOD_META;
+    }
+    if (event.isPrimary) {
+      modifiers |= HOST_POINTER_MOD_PRIMARY;
+    }
+    if ((event.buttons & 1) !== 0) {
+      modifiers |= HOST_POINTER_MOD_BUTTON_PRIMARY;
+    }
+    if ((event.buttons & 2) !== 0) {
+      modifiers |= HOST_POINTER_MOD_BUTTON_SECONDARY;
+    }
+    if ((event.buttons & 4) !== 0) {
+      modifiers |= HOST_POINTER_MOD_BUTTON_AUXILIARY;
+    }
+
+    return modifiers;
+  }
+
+  function pointerPosition(event) {
+    const rect = canvas.getBoundingClientRect();
+
+    return {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+    };
+  }
+
+  function appendPointerEvent(event) {
+    const kind = pointerKind(event.type);
+
+    if (kind === 0) {
+      return;
+    }
+
+    const scratch = view();
+    const count = scratch.getUint32(POINTER_RING_COUNT_OFFSET, true);
+
+    if (count >= HOST_POINTER_RECORD_CAPACITY) {
+      const dropped = scratch.getUint32(POINTER_RING_DROPPED_OFFSET, true);
+      scratch.setUint32(POINTER_RING_DROPPED_OFFSET, dropped + 1, true);
+      return;
+    }
+
+    const writeIndex = scratch.getUint32(POINTER_RING_WRITE_INDEX_OFFSET, true);
+    const recordOffset =
+      HOST_POINTER_RECORDS_OFFSET + writeIndex * HOST_POINTER_RECORD_SIZE;
+    const { x, y } = pointerPosition(event);
+
+    scratch.setUint8(recordOffset, kind);
+    scratch.setUint8(recordOffset + 1, 0);
+    scratch.setUint8(recordOffset + 2, 0);
+    scratch.setUint8(recordOffset + 3, 0);
+    scratch.setUint32(recordOffset + 4, event.pointerId >>> 0, true);
+    scratch.setFloat32(recordOffset + 8, x, true);
+    scratch.setFloat32(recordOffset + 12, y, true);
+    scratch.setFloat64(recordOffset + 16, event.timeStamp, true);
+    scratch.setFloat32(recordOffset + 24, event.pressure || 0, true);
+    scratch.setUint32(recordOffset + 28, pointerModifiers(event), true);
+
+    scratch.setUint32(
+      POINTER_RING_WRITE_INDEX_OFFSET,
+      (writeIndex + 1) % HOST_POINTER_RECORD_CAPACITY,
+      true,
+    );
+    scratch.setUint32(POINTER_RING_COUNT_OFFSET, count + 1, true);
+  }
+
+  function pointerListen() {
+    if (pointerListenerInstalled) {
+      return;
+    }
+
+    pointerListenerInstalled = true;
+    resetPointerRing();
+
+    for (const type of [
+      "pointerdown",
+      "pointermove",
+      "pointerup",
+      "pointercancel",
+    ]) {
+      canvas.addEventListener(type, appendPointerEvent);
+    }
   }
 
   resize();
-  window.addEventListener("resize", resize);
 
-  return {};
+  return {
+    canvas_get_size: canvasGetSize,
+    canvas_listen_resize: canvasListenResize,
+    pointer_listen: pointerListen,
+  };
 }

--- a/shim.js
+++ b/shim.js
@@ -30,15 +30,45 @@ const POINTER_RING_DROPPED_OFFSET = HOST_POINTER_RING_OFFSET + 12;
 const POINTER_RING_CAPACITY_OFFSET = HOST_POINTER_RING_OFFSET + 16;
 const POINTER_RING_RECORD_SIZE_OFFSET = HOST_POINTER_RING_OFFSET + 20;
 
+function u64ToNumber(value) {
+  const number = typeof value === "bigint" ? Number(value) : value;
+
+  return Number.isSafeInteger(number) && number >= 0 ? number : -1;
+}
+
 export function makeShim(memory) {
   const canvas = document.getElementById("tracy");
   const context = canvas.getContext("2d", { alpha: false });
+  const files = new Map();
+  const opfsFiles = new Map();
+  const decoder = new TextDecoder();
   let resizeObserver = null;
   let resizeListenerInstalled = false;
   let pointerListenerInstalled = false;
+  let fileInput = null;
+  let nextFileHandle = 1;
+  let nextOpfsId = 1;
 
   function view() {
     return new DataView(memory.buffer);
+  }
+
+  function bytes() {
+    return new Uint8Array(memory.buffer);
+  }
+
+  function decodeString(ptr, len) {
+    if (!Number.isInteger(ptr) || !Number.isInteger(len) || ptr < 0 || len < 0) {
+      return "";
+    }
+
+    const end = ptr + len;
+
+    if (end < ptr || end > memory.buffer.byteLength) {
+      return "";
+    }
+
+    return decoder.decode(bytes().subarray(ptr, end));
   }
 
   function canvasSize() {
@@ -233,11 +263,144 @@ export function makeShim(memory) {
     }
   }
 
+  function ensureFileInput() {
+    if (fileInput !== null) {
+      return fileInput;
+    }
+
+    fileInput = document.createElement("input");
+    fileInput.type = "file";
+    fileInput.hidden = true;
+    fileInput.tabIndex = -1;
+    document.body.appendChild(fileInput);
+
+    return fileInput;
+  }
+
+  function filePickerOpen(acceptPtr, acceptLen) {
+    const input = ensureFileInput();
+    const accept = decodeString(acceptPtr, acceptLen).trim();
+
+    if (accept.length > 0) {
+      input.accept = accept;
+    } else {
+      input.removeAttribute("accept");
+    }
+
+    input.value = "";
+
+    return new Promise((resolve) => {
+      let settled = false;
+
+      function settle(value) {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        input.removeEventListener("change", onChange);
+        window.removeEventListener("focus", onFocus);
+        resolve(value);
+      }
+
+      function onChange() {
+        const file = input.files?.[0] ?? null;
+
+        if (file === null) {
+          settle(-1);
+          return;
+        }
+
+        const handle = nextFileHandle;
+        nextFileHandle += 1;
+        files.set(handle, file);
+        settle(handle);
+      }
+
+      function onFocus() {
+        setTimeout(() => {
+          if ((input.files?.length ?? 0) === 0) {
+            settle(-1);
+          }
+        }, 0);
+      }
+
+      input.addEventListener("change", onChange, { once: true });
+      window.addEventListener("focus", onFocus, { once: true });
+      input.click();
+    });
+  }
+
+  async function opfsCreateFromFile(fileHandle) {
+    const file = files.get(fileHandle);
+
+    if (file === undefined || navigator.storage?.getDirectory === undefined) {
+      return -1;
+    }
+
+    try {
+      const root = await navigator.storage.getDirectory();
+      const opfsId = nextOpfsId;
+      nextOpfsId += 1;
+      const opfsName = `trace-${opfsId}.bin`;
+      const handle = await root.getFileHandle(opfsName, { create: true });
+      const writable = await handle.createWritable();
+
+      await writable.write(file);
+      await writable.close();
+
+      opfsFiles.set(opfsId, {
+        handle,
+        name: opfsName,
+        size: file.size,
+      });
+
+      return opfsId;
+    } catch (error) {
+      return -1;
+    }
+  }
+
+  async function opfsReadChunk(opfsId, offset, len, destPtr) {
+    const entry = opfsFiles.get(opfsId);
+    const start = u64ToNumber(offset);
+
+    if (
+      entry === undefined ||
+      start < 0 ||
+      !Number.isInteger(len) ||
+      len < 0 ||
+      !Number.isInteger(destPtr) ||
+      destPtr < 0
+    ) {
+      return -1;
+    }
+
+    if (destPtr + len < destPtr || destPtr + len > memory.buffer.byteLength) {
+      return -1;
+    }
+
+    try {
+      const file = await entry.handle.getFile();
+      const chunk = await file.slice(start, start + len).arrayBuffer();
+      const src = new Uint8Array(chunk);
+
+      bytes().set(src, destPtr);
+
+      return src.byteLength;
+    } catch (error) {
+      return -1;
+    }
+  }
+
   resize();
 
   return {
     canvas_get_size: canvasGetSize,
     canvas_listen_resize: canvasListenResize,
+    file_picker_open: filePickerOpen,
+    opfs_create_from_file: opfsCreateFromFile,
+    opfs_read_chunk: opfsReadChunk,
     pointer_listen: pointerListen,
   };
 }

--- a/shim.js
+++ b/shim.js
@@ -1,3 +1,28 @@
+export const HOST_SCRATCH_BASE = 0x00000000;
+export const HOST_CANVAS_SIZE_OFFSET = HOST_SCRATCH_BASE + 0x0000;
+export const HOST_CANVAS_RESIZE_SEQ_OFFSET = HOST_SCRATCH_BASE + 0x0008;
+
+export const HOST_POINTER_RING_OFFSET = HOST_SCRATCH_BASE + 0x0040;
+export const HOST_POINTER_RING_HEADER_BYTES = 32;
+export const HOST_POINTER_RECORD_SIZE = 32;
+export const HOST_POINTER_RECORD_CAPACITY = 256;
+export const HOST_POINTER_RECORDS_OFFSET =
+  HOST_POINTER_RING_OFFSET + HOST_POINTER_RING_HEADER_BYTES;
+
+export const HOST_POINTER_KIND_DOWN = 1;
+export const HOST_POINTER_KIND_MOVE = 2;
+export const HOST_POINTER_KIND_UP = 3;
+export const HOST_POINTER_KIND_CANCEL = 4;
+
+export const HOST_POINTER_MOD_SHIFT = 0x00000001;
+export const HOST_POINTER_MOD_CTRL = 0x00000002;
+export const HOST_POINTER_MOD_ALT = 0x00000004;
+export const HOST_POINTER_MOD_META = 0x00000008;
+export const HOST_POINTER_MOD_PRIMARY = 0x00000010;
+export const HOST_POINTER_MOD_BUTTON_PRIMARY = 0x00000020;
+export const HOST_POINTER_MOD_BUTTON_SECONDARY = 0x00000040;
+export const HOST_POINTER_MOD_BUTTON_AUXILIARY = 0x00000080;
+
 export function makeShim(memory) {
   const canvas = document.getElementById("tracy");
   const context = canvas.getContext("2d", { alpha: false });

--- a/tools/watwat.js
+++ b/tools/watwat.js
@@ -172,6 +172,25 @@ function memoryMaximumPagesFor(file) {
   return constrainedSuites.has(path.basename(file)) ? 1 : 32768;
 }
 
+function createHostImports() {
+  return {
+    canvas_get_size() {
+      return (BigInt(600) << 32n) | BigInt(800);
+    },
+    canvas_listen_resize() {},
+    pointer_listen() {},
+    file_picker_open() {
+      return -1;
+    },
+    opfs_create_from_file() {
+      return -1;
+    },
+    opfs_read_chunk() {
+      return 0;
+    },
+  };
+}
+
 function dependencyImportsFor(imports) {
   if (imports.cov === undefined) {
     return imports;
@@ -283,6 +302,7 @@ async function instantiateTestModule(file, assertPath, coverage = null) {
   Object.assign(watwat, assert);
   const imports = {
     env: { memory },
+    host: createHostImports(),
     watwat,
     assert,
   };

--- a/tools/watwat.js
+++ b/tools/watwat.js
@@ -180,13 +180,13 @@ function createHostImports() {
     canvas_listen_resize() {},
     pointer_listen() {},
     file_picker_open() {
-      return -1;
+      return 7;
     },
     opfs_create_from_file() {
-      return -1;
+      return 11;
     },
     opfs_read_chunk() {
-      return 0;
+      return 16;
     },
   };
 }

--- a/wat/app.test.wat
+++ b/wat/app.test.wat
@@ -2,6 +2,19 @@
   (import "env" "memory" (memory $memory 1))
   (import "watwat" "assert_true"
     (func $assert_true (param i32) (param i32)))
+  (import "watwat" "assert_eq_i32"
+    (func $assert_eq_i32 (param i32) (param i32) (param i32)))
+  (import "watwat" "assert_eq_i64"
+    (func $assert_eq_i64 (param i64) (param i64) (param i32)))
+  (import "host" "canvas_get_size" (func $canvas_get_size (result i64)))
+  (import "host" "canvas_listen_resize" (func $canvas_listen_resize))
+  (import "host" "pointer_listen" (func $pointer_listen))
+  (import "host" "file_picker_open"
+    (func $file_picker_open (param i32) (param i32) (result i32)))
+  (import "host" "opfs_create_from_file"
+    (func $opfs_create_from_file (param i32) (result i32)))
+  (import "host" "opfs_read_chunk"
+    (func $opfs_read_chunk (param i32) (param i64) (param i32) (param i32) (result i32)))
   (import "app" "tracy_main" (func $tracy_main))
   (import "app" "tracy_tick" (func $tracy_tick))
 
@@ -19,5 +32,37 @@
     i32.const 1
     i32.const 1
     call $assert_true
+  )
+
+  (func (export "test_host_stubs_are_deterministic")
+    call $canvas_get_size
+    i64.const 0x0000025800000320
+    i32.const 2
+    call $assert_eq_i64
+
+    call $canvas_listen_resize
+    call $pointer_listen
+
+    i32.const 0
+    i32.const 0
+    call $file_picker_open
+    i32.const -1
+    i32.const 3
+    call $assert_eq_i32
+
+    i32.const 1
+    call $opfs_create_from_file
+    i32.const -1
+    i32.const 4
+    call $assert_eq_i32
+
+    i32.const 1
+    i64.const 0
+    i32.const 16
+    i32.const 2048
+    call $opfs_read_chunk
+    i32.const 0
+    i32.const 5
+    call $assert_eq_i32
   )
 )

--- a/wat/app.test.wat
+++ b/wat/app.test.wat
@@ -46,13 +46,13 @@
     i32.const 0
     i32.const 0
     call $file_picker_open
-    i32.const -1
+    i32.const 7
     i32.const 3
     call $assert_eq_i32
 
     i32.const 1
     call $opfs_create_from_file
-    i32.const -1
+    i32.const 11
     i32.const 4
     call $assert_eq_i32
 
@@ -61,7 +61,7 @@
     i32.const 16
     i32.const 2048
     call $opfs_read_chunk
-    i32.const 0
+    i32.const 16
     i32.const 5
     call $assert_eq_i32
   )

--- a/wat/app.wat
+++ b/wat/app.wat
@@ -1,4 +1,14 @@
 (module
+  (import "host" "canvas_get_size" (func $canvas_get_size (result i64)))
+  (import "host" "canvas_listen_resize" (func $canvas_listen_resize))
+  (import "host" "pointer_listen" (func $pointer_listen))
+  (import "host" "file_picker_open"
+    (func $file_picker_open (param i32) (param i32) (result i32)))
+  (import "host" "opfs_create_from_file"
+    (func $opfs_create_from_file (param i32) (result i32)))
+  (import "host" "opfs_read_chunk"
+    (func $opfs_read_chunk (param i32) (param i64) (param i32) (param i32) (result i32)))
+
   (func (export "tracy_main"))
   (func (export "tracy_tick"))
 )


### PR DESCRIPTION
Adds the minimal browser host shim for v0.1, with canvas, pointer, file picker, OPFS imports, and JSPI bootstrap gating implemented against the scratch ABI. The remaining work declares the wasm import surface with deterministic test stubs and adds browser smoke verification for the full host path.

Fixes #8.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (6)</summary>

- [x] Declare host imports and WAT test stubs <!-- type:spec -->
- [x] Add browser smoke verification for host shim <!-- type:spec -->
- [x] Gate bootstrap on JSPI support <!-- type:spec -->
- [x] Implement file picker and OPFS imports <!-- type:spec -->
- [x] Implement canvas resize and pointer imports <!-- type:spec -->
- [x] Define host scratch ABI offsets <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->