### PR TITLE
v0.1 #9 — WAT trace event extractor (closes #10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,23 @@ jobs:
       - name: Build
         run: bash tools/build.sh
 
+      - name: Derive generated trace seed
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            seed="${{ github.event.pull_request.base.sha }}"
+          else
+            seed="${{ github.event.before }}"
+          fi
+
+          if [ -z "${seed}" ] || [ "${seed}" = "0000000000000000000000000000000000000000" ]; then
+            seed="$(git rev-parse HEAD)"
+          fi
+
+          echo "TRACY_GENERATED_TRACE_SEED=${seed}" >> "$GITHUB_ENV"
+          echo "generated trace seed: ${seed}"
+
       - name: Test generated 100 MB trace extractor
         run: npm run test:generated-trace
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,56 @@ jobs:
         with:
           path: dist
 
+  generated-trace-extractor:
+    name: generated 100 MB trace extractor
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      WABT_VERSION: "1.0.37"
+      WABT_PLATFORM: ubuntu-20.04
+      WABT_DIR: ${{ github.workspace }}/.wabt/wabt-1.0.37
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Cache WABT
+        id: cache-wabt
+        uses: actions/cache@v4
+        with:
+          path: .wabt/wabt-${{ env.WABT_VERSION }}
+          key: wabt-${{ runner.os }}-${{ env.WABT_VERSION }}-${{ env.WABT_PLATFORM }}
+
+      - name: Install WABT
+        if: steps.cache-wabt.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p .wabt/download
+          base="https://github.com/WebAssembly/wabt/releases/download/${WABT_VERSION}"
+          archive="wabt-${WABT_VERSION}-${WABT_PLATFORM}.tar.gz"
+          curl -fsSL "${base}/${archive}" -o ".wabt/download/${archive}"
+          curl -fsSL "${base}/${archive}.sha256" -o ".wabt/download/${archive}.sha256"
+          (cd .wabt/download && sha256sum -c "${archive}.sha256")
+          mkdir -p .wabt
+          tar -xzf ".wabt/download/${archive}" -C .wabt
+
+      - name: Add WABT to PATH
+        run: echo "${WABT_DIR}/bin" >> "$GITHUB_PATH"
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      - name: Build
+        run: bash tools/build.sh
+
+      - name: Test generated 100 MB trace extractor
+        run: npm run test:generated-trace
+
   deploy:
     name: deploy
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/host/runtime.mjs
+++ b/host/runtime.mjs
@@ -1,4 +1,5 @@
 import { HOST_ASYNC_IMPORTS } from "./abi.mjs";
+import { instantiateWasmModule } from "./wasm-modules.mjs";
 
 const asyncHostImports = new Set(HOST_ASYNC_IMPORTS);
 
@@ -47,11 +48,8 @@ async function loadApp(memory, host) {
   }
 
   const imports = { env: { memory }, host: wrapAsyncHostImports(host) };
-  const { instance } = await WebAssembly.instantiateStreaming(
-    fetch("wasm/app.wasm"),
-    imports,
-  );
-  const { tracy_main, tracy_tick } = instance.exports;
+  const { exports } = await instantiateWasmModule("app", imports);
+  const { tracy_main, tracy_tick } = exports;
 
   tracy_main();
 

--- a/host/wasm-modules.mjs
+++ b/host/wasm-modules.mjs
@@ -1,0 +1,143 @@
+export const WASM_MODULES = Object.freeze({
+  app: Object.freeze({
+    wasmPath: "app.wasm",
+    aliases: Object.freeze(["app"]),
+    dependencies: Object.freeze([]),
+  }),
+  parser: Object.freeze({
+    wasmPath: "parser.wasm",
+    aliases: Object.freeze(["parser"]),
+    dependencies: Object.freeze(["std/mem", "parser_state", "std/hash", "std/strtab"]),
+  }),
+  parser_state: Object.freeze({
+    wasmPath: "parser_state.wasm",
+    aliases: Object.freeze(["parser_state"]),
+    dependencies: Object.freeze([]),
+  }),
+  "std/assert": Object.freeze({
+    wasmPath: "std/assert.wasm",
+    aliases: Object.freeze(["assert", "std/assert", "wat/std/assert"]),
+    dependencies: Object.freeze([]),
+  }),
+  "std/alloc": Object.freeze({
+    wasmPath: "std/alloc.wasm",
+    aliases: Object.freeze(["alloc", "std/alloc", "wat/std/alloc"]),
+    dependencies: Object.freeze([]),
+  }),
+  "std/array": Object.freeze({
+    wasmPath: "std/array.wasm",
+    aliases: Object.freeze(["array", "std/array", "wat/std/array"]),
+    dependencies: Object.freeze(["std/alloc"]),
+  }),
+  "std/hash": Object.freeze({
+    wasmPath: "std/hash.wasm",
+    aliases: Object.freeze(["hash", "std/hash", "wat/std/hash"]),
+    dependencies: Object.freeze(["std/alloc"]),
+  }),
+  "std/mem": Object.freeze({
+    wasmPath: "std/mem.wasm",
+    aliases: Object.freeze(["mem", "std/mem", "wat/std/mem"]),
+    dependencies: Object.freeze([]),
+  }),
+  "std/pool": Object.freeze({
+    wasmPath: "std/pool.wasm",
+    aliases: Object.freeze(["pool", "std/pool", "wat/std/pool"]),
+    dependencies: Object.freeze(["std/alloc"]),
+  }),
+  "std/ring": Object.freeze({
+    wasmPath: "std/ring.wasm",
+    aliases: Object.freeze(["ring", "std/ring", "wat/std/ring"]),
+    dependencies: Object.freeze(["std/alloc"]),
+  }),
+  "std/strtab": Object.freeze({
+    wasmPath: "std/strtab.wasm",
+    aliases: Object.freeze(["strtab", "std/strtab", "wat/std/strtab"]),
+    dependencies: Object.freeze(["std/alloc", "std/hash"]),
+  }),
+});
+
+function normalizePath(value) {
+  return String(value).replace(/\\/g, "/").replace(/^\.?\//, "");
+}
+
+export function wasmModuleIds() {
+  return Object.keys(WASM_MODULES);
+}
+
+export function wasmModule(id) {
+  const module = WASM_MODULES[id];
+  if (module === undefined) {
+    throw new Error(`unknown wasm module ${id}`);
+  }
+
+  return module;
+}
+
+export function wasmModuleAliases(id) {
+  return wasmModule(id).aliases;
+}
+
+export function wasmModuleDependencies(id) {
+  return wasmModule(id).dependencies;
+}
+
+export function wasmModulePath(id) {
+  return wasmModule(id).wasmPath;
+}
+
+export function wasmModuleUrl(id, baseUrl = "wasm/") {
+  return `${baseUrl.replace(/\/?$/, "/")}${wasmModulePath(id)}`;
+}
+
+async function defaultInstantiate(url, imports) {
+  const { instance } = await WebAssembly.instantiateStreaming(fetch(url), imports);
+  return instance.exports;
+}
+
+export async function instantiateWasmModule(
+  id,
+  baseImports,
+  { baseUrl = "wasm/", instantiate = defaultInstantiate } = {},
+) {
+  const imports = { ...baseImports };
+  const loaded = new Map();
+
+  async function load(moduleId) {
+    if (loaded.has(moduleId)) {
+      return loaded.get(moduleId);
+    }
+
+    for (const dependency of wasmModuleDependencies(moduleId)) {
+      const dependencyExports = await load(dependency);
+      for (const alias of wasmModuleAliases(dependency)) {
+        imports[alias] = dependencyExports;
+      }
+    }
+
+    const exports = await instantiate(wasmModuleUrl(moduleId, baseUrl), imports, moduleId);
+    loaded.set(moduleId, exports);
+
+    for (const alias of wasmModuleAliases(moduleId)) {
+      imports[alias] = exports;
+    }
+
+    return exports;
+  }
+
+  return {
+    exports: await load(id),
+    imports,
+  };
+}
+
+export function wasmModuleIdForPath(value) {
+  const normalized = normalizePath(value);
+
+  for (const [id, module] of Object.entries(WASM_MODULES)) {
+    if (normalized.endsWith(module.wasmPath)) {
+      return id;
+    }
+  }
+
+  return null;
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:bootstrap-lines": "bash tools/check-bootstrap-lines.sh",
     "test:wat": "node tools/watwat.js dist/wasm/*.test.wasm dist/wasm/std/*.test.wasm",
     "test:watwat-probe": "node tools/watwat.js --expect-failure probe_assert_eq_i32_failure \"deliberate i32 failure\" dist/wasm/watwat.test.wasm",
+    "test:generated-trace": "node tools/generated-trace-extractor-check.js",
     "test:assert-probes": "bash tools/test-assert-probes.sh",
     "test:coverage-selftest": "node tools/coverage-selftest.js",
     "test:coverage": "node tools/coverage-run.js --check dist/wasm-cov",

--- a/tools/generated-trace-extractor-check.js
+++ b/tools/generated-trace-extractor-check.js
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs/promises");
+const path = require("node:path");
+
+const MiB = 1024 * 1024;
+const targetBytes = Number.parseInt(
+  process.env.TRACY_GENERATED_TRACE_BYTES ?? String(100 * MiB),
+  10,
+);
+const seedText = process.env.TRACY_GENERATED_TRACE_SEED ?? "generated-trace-ci";
+const sourceId = 9001;
+const statePtr = 4096;
+const inputPtr = 1 * MiB;
+const tokenRecordBytes = 12;
+const tokenOutputSafetyRecords = 1024;
+const wasmRoot = path.resolve(__dirname, "../dist/wasm");
+const stdRoot = path.join(wasmRoot, "std");
+
+if (!Number.isInteger(targetBytes) || targetBytes <= 0) {
+  throw new Error("TRACY_GENERATED_TRACE_BYTES must be a positive integer");
+}
+
+function fnv1a(text) {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash >>> 0;
+}
+
+function createRandom(seed) {
+  let state = seed >>> 0;
+
+  return () => {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    return state;
+  };
+}
+
+function hexPad(random, len) {
+  let value = "";
+  while (value.length < len) {
+    value += random().toString(16).padStart(8, "0");
+  }
+  return value.slice(0, len);
+}
+
+function eventJson(index, random, padLen) {
+  const phases = ["B", "E", "X", "i", "M", "C"];
+  return JSON.stringify({
+    ph: phases[random() % phases.length],
+    name: `event-${random() % 256}`,
+    ts: index * 10 + (random() % 10),
+    dur: random() % 1000,
+    pid: random() % 32,
+    tid: random() % 512,
+    args: {
+      pad: hexPad(random, padLen),
+      flag: (random() & 1) === 1,
+    },
+  });
+}
+
+function finalEventJson(index, padLen) {
+  return JSON.stringify({
+    ph: "X",
+    name: "final",
+    ts: index * 10,
+    dur: 1,
+    pid: 0,
+    tid: 0,
+    args: {
+      pad: "0".repeat(padLen),
+      flag: true,
+    },
+  });
+}
+
+function buildTrace() {
+  const random = createRandom(fnv1a(seedText));
+  const chunks = [Buffer.from("[")];
+  let bytes = 1;
+  let count = 0;
+  const basePadLen = 384;
+
+  while (true) {
+    const prefixLen = count === 0 ? 0 : 1;
+    const suffixLen = 1;
+    const event = eventJson(count, random, basePadLen);
+    const eventLen = Buffer.byteLength(event);
+
+    if (bytes + prefixLen + eventLen + suffixLen > targetBytes) {
+      break;
+    }
+
+    if (prefixLen > 0) {
+      chunks.push(Buffer.from(","));
+      bytes += 1;
+    }
+
+    chunks.push(Buffer.from(event));
+    bytes += eventLen;
+    count += 1;
+  }
+
+  const prefixLen = count === 0 ? 0 : 1;
+  const finalOverhead = Buffer.byteLength(finalEventJson(count, 0));
+  const finalPadLen = targetBytes - bytes - prefixLen - finalOverhead - 1;
+  if (finalPadLen < 0) {
+    throw new Error(`target size ${targetBytes} is too small for a valid generated trace`);
+  }
+
+  if (count > 0) {
+    chunks.push(Buffer.from(","));
+    bytes += 1;
+  }
+
+  const finalEvent = finalEventJson(count, finalPadLen);
+  chunks.push(Buffer.from(finalEvent));
+  bytes += Buffer.byteLength(finalEvent);
+  count += 1;
+
+  chunks.push(Buffer.from("]"));
+  bytes += 1;
+
+  const trace = Buffer.concat(chunks);
+  if (trace.length !== targetBytes) {
+    throw new Error(`generated ${trace.length} bytes, expected ${targetBytes}`);
+  }
+
+  return { trace, count };
+}
+
+async function instantiateWasm(file, imports) {
+  const bytes = await fs.readFile(file);
+  const { instance } = await WebAssembly.instantiate(bytes, imports);
+  return instance.exports;
+}
+
+function pageCount(bytes) {
+  return Math.ceil(bytes / 65536);
+}
+
+async function instantiateParser(trace) {
+  const eventCountEstimate = Math.max(1, Math.ceil(trace.length / 470));
+  const recordCap = eventCountEstimate * 48 + tokenOutputSafetyRecords;
+  const outputPtr = (inputPtr + trace.length + 7) & ~7;
+  const outputBytes = recordCap * tokenRecordBytes;
+  const heapPtr = (outputPtr + outputBytes + 7) & ~7;
+  const heapEnd = heapPtr + 64 * MiB;
+  const memory = new WebAssembly.Memory({
+    initial: Math.max(pageCount(heapEnd), 1),
+    maximum: 32768,
+  });
+  const memoryBytes = new Uint8Array(memory.buffer);
+
+  memoryBytes.set(trace, inputPtr);
+
+  const env = { memory };
+  const host = {
+    opfs_source_read(readSourceId, offset, len, dest) {
+      if (readSourceId !== sourceId) {
+        return -1;
+      }
+
+      const start = Number(offset);
+      if (!Number.isInteger(start) || start < 0 || start >= trace.length) {
+        return 0;
+      }
+
+      const count = Math.max(0, Math.min(len, trace.length - start));
+      new Uint8Array(memory.buffer, dest, count).set(trace.subarray(start, start + count));
+      return count;
+    },
+  };
+  const alloc = await instantiateWasm(path.join(stdRoot, "alloc.wasm"), { env });
+  alloc.bump_init(heapPtr, heapEnd);
+  const hash = await instantiateWasm(path.join(stdRoot, "hash.wasm"), { env, alloc });
+  const strtab = await instantiateWasm(path.join(stdRoot, "strtab.wasm"), {
+    env,
+    alloc,
+    hash,
+  });
+  const mem = await instantiateWasm(path.join(stdRoot, "mem.wasm"), { env });
+  const parserState = await instantiateWasm(path.join(wasmRoot, "parser_state.wasm"), {
+    env,
+  });
+  const parser = await instantiateWasm(path.join(wasmRoot, "parser.wasm"), {
+    env,
+    host,
+    mem,
+    parser_state: parserState,
+    strtab,
+  });
+
+  return {
+    memory,
+    parser,
+    parserState,
+    outputPtr,
+    recordCap,
+  };
+}
+
+function readI32(memory, ptr) {
+  return new DataView(memory.buffer).getInt32(ptr, true);
+}
+
+async function main() {
+  const { trace, count: generatedCount } = buildTrace();
+  const { memory, parser, parserState, outputPtr, recordCap } = await instantiateParser(trace);
+
+  parserState.parser_state_init(statePtr, sourceId);
+  const status = parser.parser_tokenize_bytes(
+    statePtr,
+    inputPtr,
+    trace.length,
+    outputPtr,
+    recordCap,
+  );
+
+  if (status !== parserState.PARSER_STATUS_DONE.value) {
+    throw new Error(`parser status ${status}, expected ${parserState.PARSER_STATUS_DONE.value}`);
+  }
+
+  parser.extractor_init(outputPtr);
+
+  let extractedCount = 0;
+  while (parser.extractor_next() !== -1) {
+    extractedCount += 1;
+  }
+
+  if (extractedCount !== generatedCount) {
+    throw new Error(`extracted ${extractedCount} events, generated ${generatedCount}`);
+  }
+
+  const parserCount = readI32(
+    memory,
+    statePtr + parserState.PARSER_STATE_EVENT_COUNT_OFFSET.value,
+  );
+  if (parserCount !== generatedCount) {
+    throw new Error(`parser counted ${parserCount} events, generated ${generatedCount}`);
+  }
+
+  console.log(
+    `generated ${trace.length} bytes with ${generatedCount} events; extracted ${extractedCount}`,
+  );
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message || String(error));
+  process.exitCode = 1;
+});

--- a/tools/watwat.js
+++ b/tools/watwat.js
@@ -2,8 +2,11 @@
 
 const fs = require("node:fs/promises");
 const path = require("node:path");
+const { pathToFileURL } = require("node:url");
 
 const testNamePattern = /^test_/;
+const wasmModulesUrl = pathToFileURL(path.resolve(__dirname, "../host/wasm-modules.mjs")).href;
+const wasmModules = import(wasmModulesUrl);
 
 class WatwatFailure extends Error {
   constructor(code) {
@@ -158,14 +161,6 @@ function modulePathForTest(file) {
   return path.join(parsed.dir, `${parsed.name.replace(/\.test$/, "")}.wasm`);
 }
 
-function moduleImportAliases(file) {
-  const parsed = path.parse(file);
-  const name = parsed.name;
-  const parent = path.basename(parsed.dir);
-
-  return [name, `${parent}/${name}`, `wat/${parent}/${name}`];
-}
-
 function memoryMaximumPagesFor(file) {
   const constrainedSuites = new Set(["array.test.wasm", "hash.test.wasm", "pool.test.wasm"]);
 
@@ -278,15 +273,47 @@ function wasmRootFor(modulePath) {
   return path.basename(dir) === "std" ? path.dirname(dir) : dir;
 }
 
-async function instantiateDependency(moduleImports, aliases, imports, coverage, wasmPath, names) {
+function modulePathForId(rootDir, moduleId, wasmModulePath) {
+  return path.join(rootDir, wasmModulePath(moduleId));
+}
+
+async function instantiateManifestModule(
+  moduleId,
+  moduleImports,
+  aliases,
+  imports,
+  coverage,
+  rootDir,
+  manifest,
+  instantiated,
+) {
+  if (instantiated.has(moduleId)) {
+    return true;
+  }
+
+  const wasmPath = modulePathForId(rootDir, moduleId, manifest.wasmModulePath);
+
   try {
     await fs.access(wasmPath);
   } catch (error) {
     if (error.code === "ENOENT") {
-      return;
+      return false;
     }
 
     throw error;
+  }
+
+  for (const dependency of manifest.wasmModuleDependencies(moduleId)) {
+    await instantiateManifestModule(
+      dependency,
+      moduleImports,
+      aliases,
+      imports,
+      coverage,
+      rootDir,
+      manifest,
+      instantiated,
+    );
   }
 
   const bytes = await fs.readFile(wasmPath);
@@ -295,10 +322,13 @@ async function instantiateDependency(moduleImports, aliases, imports, coverage, 
     importsForModule(moduleImports, coverage, wasmPath),
   );
 
-  for (const name of names) {
-    moduleImports[name] = instance.exports;
-    aliases[name] = instance.exports;
+  for (const alias of manifest.wasmModuleAliases(moduleId)) {
+    moduleImports[alias] = instance.exports;
+    aliases[alias] = instance.exports;
   }
+
+  instantiated.add(moduleId);
+  return true;
 }
 
 async function instantiateSiblingModule(file, imports, coverage = null) {
@@ -319,101 +349,26 @@ async function instantiateSiblingModule(file, imports, coverage = null) {
   }
 
   const rootDir = wasmRootFor(modulePath);
-  const allocPath = path.join(rootDir, "std", "alloc.wasm");
+  const manifest = await wasmModules;
+  const moduleId = manifest.wasmModuleIdForPath(modulePath);
   const moduleImports = { ...imports };
   const aliases = {};
+  const instantiated = new Set();
 
-  if (path.basename(modulePath) !== "alloc.wasm") {
-    try {
-      await fs.access(allocPath);
-      const allocBytes = await fs.readFile(allocPath);
-      const { instance } = await WebAssembly.instantiate(
-        allocBytes,
-        importsForModule(imports, coverage, allocPath),
-      );
-      moduleImports.alloc = instance.exports;
-      aliases.alloc = instance.exports;
-      aliases["std/alloc"] = instance.exports;
-      aliases["wat/std/alloc"] = instance.exports;
-    } catch (error) {
-      if (error.code !== "ENOENT") {
-        throw error;
-      }
-    }
+  if (moduleId === null) {
+    return {};
   }
 
-  const hashPath = path.join(rootDir, "std", "hash.wasm");
-
-  if (path.basename(modulePath) === "strtab.wasm") {
-    try {
-      await fs.access(hashPath);
-      const hashBytes = await fs.readFile(hashPath);
-      const { instance } = await WebAssembly.instantiate(
-        hashBytes,
-        importsForModule(moduleImports, coverage, hashPath),
-      );
-      moduleImports.hash = instance.exports;
-      aliases.hash = instance.exports;
-      aliases["std/hash"] = instance.exports;
-      aliases["wat/std/hash"] = instance.exports;
-    } catch (error) {
-      if (error.code !== "ENOENT") {
-        throw error;
-      }
-    }
-  }
-
-  if (path.basename(modulePath) !== "mem.wasm") {
-    await instantiateDependency(
-      moduleImports,
-      aliases,
-      imports,
-      coverage,
-      path.join(rootDir, "std", "mem.wasm"),
-      ["mem", "std/mem", "wat/std/mem"],
-    );
-  }
-
-  if (path.basename(modulePath) !== "parser_state.wasm") {
-    await instantiateDependency(
-      moduleImports,
-      aliases,
-      imports,
-      coverage,
-      path.join(rootDir, "parser_state.wasm"),
-      ["parser_state"],
-    );
-  }
-
-  if (path.basename(modulePath) === "parser.wasm") {
-    await instantiateDependency(
-      moduleImports,
-      aliases,
-      imports,
-      coverage,
-      hashPath,
-      ["hash", "std/hash", "wat/std/hash"],
-    );
-
-    await instantiateDependency(
-      moduleImports,
-      aliases,
-      imports,
-      coverage,
-      path.join(rootDir, "std", "strtab.wasm"),
-      ["strtab", "std/strtab", "wat/std/strtab"],
-    );
-  }
-
-  const bytes = await fs.readFile(modulePath);
-  const { instance } = await WebAssembly.instantiate(
-    bytes,
-    importsForModule(moduleImports, coverage, modulePath),
+  await instantiateManifestModule(
+    moduleId,
+    moduleImports,
+    aliases,
+    imports,
+    coverage,
+    rootDir,
+    manifest,
+    instantiated,
   );
-
-  for (const name of moduleImportAliases(modulePath)) {
-    aliases[name] = instance.exports;
-  }
 
   return aliases;
 }

--- a/tools/watwat.js
+++ b/tools/watwat.js
@@ -318,7 +318,8 @@ async function instantiateSiblingModule(file, imports, coverage = null) {
     throw error;
   }
 
-  const allocPath = path.join(path.dirname(modulePath), "alloc.wasm");
+  const rootDir = wasmRootFor(modulePath);
+  const allocPath = path.join(rootDir, "std", "alloc.wasm");
   const moduleImports = { ...imports };
   const aliases = {};
 
@@ -341,7 +342,7 @@ async function instantiateSiblingModule(file, imports, coverage = null) {
     }
   }
 
-  const hashPath = path.join(path.dirname(modulePath), "hash.wasm");
+  const hashPath = path.join(rootDir, "std", "hash.wasm");
 
   if (path.basename(modulePath) === "strtab.wasm") {
     try {
@@ -362,8 +363,6 @@ async function instantiateSiblingModule(file, imports, coverage = null) {
     }
   }
 
-  const rootDir = wasmRootFor(modulePath);
-
   if (path.basename(modulePath) !== "mem.wasm") {
     await instantiateDependency(
       moduleImports,
@@ -383,6 +382,26 @@ async function instantiateSiblingModule(file, imports, coverage = null) {
       coverage,
       path.join(rootDir, "parser_state.wasm"),
       ["parser_state"],
+    );
+  }
+
+  if (path.basename(modulePath) === "parser.wasm") {
+    await instantiateDependency(
+      moduleImports,
+      aliases,
+      imports,
+      coverage,
+      hashPath,
+      ["hash", "std/hash", "wat/std/hash"],
+    );
+
+    await instantiateDependency(
+      moduleImports,
+      aliases,
+      imports,
+      coverage,
+      path.join(rootDir, "std", "strtab.wasm"),
+      ["strtab", "std/strtab", "wat/std/strtab"],
     );
   }
 

--- a/wat/parser.test.wat
+++ b/wat/parser.test.wat
@@ -6,6 +6,8 @@
     (func $assert_eq_i32 (param i32) (param i32) (param i32)))
   (import "watwat" "assert_eq_i64"
     (func $assert_eq_i64 (param i64) (param i64) (param i32)))
+  (import "watwat" "assert_eq_f64"
+    (func $assert_eq_f64 (param f64) (param f64) (param f64) (param i32)))
   (import "parser" "parser_parse"
     (func $parser_parse (param i32) (param i32) (result i32)))
   (import "parser" "parser_parse_with_budget"
@@ -34,6 +36,10 @@
     (func $extractor_init (param i32)))
   (import "parser" "extractor_next"
     (func $extractor_next (result i32)))
+  (import "alloc" "bump_init"
+    (func $bump_init (param i32) (param i32)))
+  (import "strtab" "strtab_intern"
+    (func $strtab_intern (param i32) (param i32) (result i32)))
   (import "parser_state" "parser_state_init"
     (func $parser_state_init (param i32) (param i32)))
   ;; @generated parser-state-imports parser-test:start
@@ -95,6 +101,8 @@
   (import "parser_state" "PARSER_EVENT_FIELD_TS" (global $PARSER_EVENT_FIELD_TS i32))
   ;; @generated parser-state-imports parser-test:end
 
+  (global $alloc_ready (mut i32) (i32.const 0))
+
   (data (i32.const 1024) "parser test failed")
   (data (i32.const 2048) "{\"a\":[true,false,null,-12.3e+4]}")
   (data (i32.const 2100) "{\0a@")
@@ -144,6 +152,9 @@
   (data (i32.const 2610) "{\22traceEvents\22:[{}]}")
   (data (i32.const 2632) "{\22other\22:[]}")
   (data (i32.const 2648) "[]")
+  (data (i32.const 2700) "[{\22ph\22:\22X\22,\22name\22:\22foo\22,\22ts\22:1,\22dur\22:2,\22pid\22:3,\22tid\22:4}]")
+  (data (i32.const 2780) "[{\22ph\22:\22B\22,\22name\22:\22bar\22,\22ts\22:5}]")
+  (data (i32.const 2820) "[{\22ph\22:\22i\22,\22name\22:\22baz\22,\22pid\22:\22proc\22,\22tid\22:\22thread\22}]")
 
   (func (export "message_for") (param $code i32) (result i32 i32)
     i32.const 1024
@@ -382,6 +393,18 @@
     end
   )
 
+  (func $ensure_alloc
+    global.get $alloc_ready
+    i32.eqz
+    if
+      i32.const 60000
+      i32.const 65536
+      call $bump_init
+      i32.const 1
+      global.set $alloc_ready
+    end
+  )
+
   (func (export "test_extractor_returns_minus_one_without_active_state")
     i32.const 57344
     call $extractor_init
@@ -389,6 +412,336 @@
     call $extractor_next
     i32.const -1
     i32.const 140
+    call $assert_eq_i32
+  )
+
+  (func $assert_event_base_fields (param $event_ptr i32) (param $phase i32) (param $name_ptr i32) (param $name_len i32) (param $ts f64) (param $dur f64) (param $pid i32) (param $tid i32) (param $code i32)
+    local.get $event_ptr
+    i32.load8_u
+    local.get $phase
+    local.get $code
+    call $assert_eq_i32
+
+    local.get $event_ptr
+    i32.const 4
+    i32.add
+    i32.load
+    local.get $name_ptr
+    local.get $name_len
+    call $strtab_intern
+    local.get $code
+    i32.const 1
+    i32.add
+    call $assert_eq_i32
+
+    local.get $event_ptr
+    i32.const 8
+    i32.add
+    f64.load
+    local.get $ts
+    f64.const 0.000001
+    local.get $code
+    i32.const 2
+    i32.add
+    call $assert_eq_f64
+
+    local.get $event_ptr
+    i32.const 16
+    i32.add
+    f64.load
+    local.get $dur
+    f64.const 0.000001
+    local.get $code
+    i32.const 3
+    i32.add
+    call $assert_eq_f64
+
+    local.get $event_ptr
+    i32.const 24
+    i32.add
+    i32.load
+    local.get $pid
+    local.get $code
+    i32.const 4
+    i32.add
+    call $assert_eq_i32
+
+    local.get $event_ptr
+    i32.const 28
+    i32.add
+    i32.load
+    local.get $tid
+    local.get $code
+    i32.const 5
+    i32.add
+    call $assert_eq_i32
+  )
+
+  (func (export "test_extractor_populates_full_form_event_fields")
+    (local $event_ptr i32)
+
+    call $ensure_alloc
+
+    i32.const 55296
+    i32.const 175
+    call $parser_state_init
+
+    i32.const 55296
+    i32.const 2700
+    i32.const 56
+    i32.const 57344
+    i32.const 64
+    call $parser_tokenize_bytes
+    global.get $PARSER_STATUS_DONE
+    i32.const 120
+    call $assert_eq_i32
+
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    local.tee $event_ptr
+    i32.const -1
+    i32.ne
+    i32.const 121
+    call $assert_true
+
+    local.get $event_ptr
+    i32.const 88
+    i32.const 2719
+    i32.const 3
+    f64.const 1
+    f64.const 2
+    i32.const 3
+    i32.const 4
+    i32.const 122
+    call $assert_event_base_fields
+
+    call $extractor_next
+    i32.const -1
+    i32.const 128
+    call $assert_eq_i32
+  )
+
+  (func (export "test_extractor_defaults_missing_optional_fields")
+    (local $event_ptr i32)
+
+    call $ensure_alloc
+
+    i32.const 55296
+    i32.const 176
+    call $parser_state_init
+
+    i32.const 55296
+    i32.const 2780
+    i32.const 32
+    i32.const 57344
+    i32.const 64
+    call $parser_tokenize_bytes
+    global.get $PARSER_STATUS_DONE
+    i32.const 130
+    call $assert_eq_i32
+
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    local.tee $event_ptr
+    i32.const -1
+    i32.ne
+    i32.const 131
+    call $assert_true
+
+    local.get $event_ptr
+    i32.const 66
+    i32.const 2799
+    i32.const 3
+    f64.const 5
+    f64.const 0
+    i32.const 0
+    i32.const 0
+    i32.const 132
+    call $assert_event_base_fields
+
+    call $extractor_next
+    i32.const -1
+    i32.const 138
+    call $assert_eq_i32
+  )
+
+  (func (export "test_extractor_interns_string_pid_and_tid")
+    (local $event_ptr i32)
+
+    call $ensure_alloc
+
+    i32.const 55296
+    i32.const 177
+    call $parser_state_init
+
+    i32.const 55296
+    i32.const 2820
+    i32.const 53
+    i32.const 57344
+    i32.const 64
+    call $parser_tokenize_bytes
+    global.get $PARSER_STATUS_DONE
+    i32.const 190
+    call $assert_eq_i32
+
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    local.tee $event_ptr
+    i32.const -1
+    i32.ne
+    i32.const 191
+    call $assert_true
+
+    local.get $event_ptr
+    i32.const 105
+    i32.const 2839
+    i32.const 3
+    f64.const 0
+    f64.const 0
+    i32.const 2851
+    i32.const 4
+    call $strtab_intern
+    i32.const 2864
+    i32.const 6
+    call $strtab_intern
+    i32.const 192
+    call $assert_event_base_fields
+
+    call $extractor_next
+    i32.const -1
+    i32.const 198
+    call $assert_eq_i32
+  )
+
+  (func $emit_manual_ts_event (param $number_ptr i32) (param $number_len i32)
+    i32.const 55296
+    i32.const 178
+    call $parser_state_init
+
+    i32.const 55296
+    i32.const 16
+    call $parser_token_output_reset
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_LBRACK
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_LBRACE
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_STRING
+    i32.const 2725
+    i32.const 2
+    call $parser_emit_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_COLON
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_NUMBER
+    local.get $number_ptr
+    local.get $number_len
+    call $parser_emit_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_RBRACE
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_RBRACK
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    call $parser_emit_eof_token
+    drop
+  )
+
+  (func (export "test_extractor_defaults_empty_number_payload")
+    (local $event_ptr i32)
+
+    i32.const 0
+    i32.const 0
+    call $emit_manual_ts_event
+
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    local.tee $event_ptr
+    i32.const -1
+    i32.ne
+    i32.const 200
+    call $assert_true
+
+    local.get $event_ptr
+    i32.const 8
+    i32.add
+    f64.load
+    f64.const 0
+    f64.const 0.000001
+    i32.const 201
+    call $assert_eq_f64
+
+    call $extractor_next
+    i32.const -1
+    i32.const 202
+    call $assert_eq_i32
+  )
+
+  (func (export "test_extractor_defaults_invalid_number_payload")
+    (local $event_ptr i32)
+
+    i32.const 2494
+    i32.const 1
+    call $emit_manual_ts_event
+
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    local.tee $event_ptr
+    i32.const -1
+    i32.ne
+    i32.const 203
+    call $assert_true
+
+    local.get $event_ptr
+    i32.const 8
+    i32.add
+    f64.load
+    f64.const 0
+    f64.const 0.000001
+    i32.const 204
+    call $assert_eq_f64
+
+    call $extractor_next
+    i32.const -1
+    i32.const 205
     call $assert_eq_i32
   )
 

--- a/wat/parser.test.wat
+++ b/wat/parser.test.wat
@@ -155,6 +155,8 @@
   (data (i32.const 2700) "[{\22ph\22:\22X\22,\22name\22:\22foo\22,\22ts\22:1,\22dur\22:2,\22pid\22:3,\22tid\22:4}]")
   (data (i32.const 2780) "[{\22ph\22:\22B\22,\22name\22:\22bar\22,\22ts\22:5}]")
   (data (i32.const 2820) "[{\22ph\22:\22i\22,\22name\22:\22baz\22,\22pid\22:\22proc\22,\22tid\22:\22thread\22}]")
+  (data (i32.const 2880) "[{\22unknown\22:{\22ph\22:\22B\22,\22nested\22:[{\22name\22:\22bad\22}]},\22ph\22:\22X\22,\22name\22:\22foo\22}]")
+  (data (i32.const 2962) "[{\22args\22:{\22a\22:[1,true]},\22name\22:\22arg\22}]")
 
   (func (export "message_for") (param $code i32) (result i32 i32)
     i32.const 1024
@@ -745,6 +747,661 @@
     call $assert_eq_i32
   )
 
+  (func (export "test_extractor_skips_unknown_nested_values")
+    (local $event_ptr i32)
+
+    call $ensure_alloc
+
+    i32.const 55296
+    i32.const 179
+    call $parser_state_init
+
+    i32.const 55296
+    i32.const 2880
+    i32.const 72
+    i32.const 57344
+    i32.const 64
+    call $parser_tokenize_bytes
+    global.get $PARSER_STATUS_DONE
+    i32.const 211
+    call $assert_eq_i32
+
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    local.tee $event_ptr
+    i32.const -1
+    i32.ne
+    i32.const 212
+    call $assert_true
+
+    local.get $event_ptr
+    i32.const 88
+    i32.const 2946
+    i32.const 3
+    f64.const 0
+    f64.const 0
+    i32.const 0
+    i32.const 0
+    i32.const 213
+    call $assert_event_base_fields
+
+    call $extractor_next
+    i32.const -1
+    i32.const 219
+    call $assert_eq_i32
+  )
+
+  (func (export "test_extractor_captures_args_raw_span")
+    (local $event_ptr i32)
+
+    call $ensure_alloc
+
+    i32.const 55296
+    i32.const 180
+    call $parser_state_init
+
+    i32.const 55296
+    i32.const 2962
+    i32.const 38
+    i32.const 57344
+    i32.const 64
+    call $parser_tokenize_bytes
+    global.get $PARSER_STATUS_DONE
+    i32.const 225
+    call $assert_eq_i32
+
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    local.tee $event_ptr
+    i32.const -1
+    i32.ne
+    i32.const 226
+    call $assert_true
+
+    local.get $event_ptr
+    i32.const 32
+    i32.add
+    i32.load
+    i32.const 2971
+    i32.const 227
+    call $assert_eq_i32
+
+    local.get $event_ptr
+    i32.const 36
+    i32.add
+    i32.load
+    i32.const 14
+    i32.const 228
+    call $assert_eq_i32
+
+    local.get $event_ptr
+    i32.const 0
+    i32.const 2994
+    i32.const 3
+    f64.const 0
+    f64.const 0
+    i32.const 0
+    i32.const 0
+    i32.const 229
+    call $assert_event_base_fields
+
+    call $extractor_next
+    i32.const -1
+    i32.const 235
+    call $assert_eq_i32
+  )
+
+  (func $emit_manual_malformed_middle_events
+    i32.const 55296
+    i32.const 181
+    call $parser_state_init
+
+    i32.const 55296
+    i32.const 32
+    call $parser_token_output_reset
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_LBRACK
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_LBRACE
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_STRING
+    i32.const 2987
+    i32.const 4
+    call $parser_emit_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_STRING
+    i32.const 2994
+    i32.const 3
+    call $parser_emit_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_RBRACE
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_COMMA
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_LBRACE
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_STRING
+    i32.const 2703
+    i32.const 2
+    call $parser_emit_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_COLON
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_STRING
+    i32.const 2708
+    i32.const 1
+    call $parser_emit_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_COMMA
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_STRING
+    i32.const 2712
+    i32.const 4
+    call $parser_emit_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_COLON
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_STRING
+    i32.const 2719
+    i32.const 3
+    call $parser_emit_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_RBRACE
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_RBRACK
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    call $parser_emit_eof_token
+    drop
+  )
+
+  (func $emit_recovery_prefix (param $source_id i32) (param $key_ptr i32) (param $key_len i32)
+    i32.const 55296
+    local.get $source_id
+    call $parser_state_init
+
+    i32.const 55296
+    i32.const 64
+    call $parser_token_output_reset
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_LBRACK
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_LBRACE
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_STRING
+    local.get $key_ptr
+    local.get $key_len
+    call $parser_emit_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_COLON
+    call $parser_emit_structural_token
+    drop
+  )
+
+  (func $emit_recovery_valid_tail
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_RBRACE
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_COMMA
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_LBRACE
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_STRING
+    i32.const 2703
+    i32.const 2
+    call $parser_emit_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_COLON
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_STRING
+    i32.const 2708
+    i32.const 1
+    call $parser_emit_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_RBRACE
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_RBRACK
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    call $parser_emit_eof_token
+    drop
+  )
+
+  (func (export "test_extractor_recovers_from_malformed_middle_event")
+    (local $event_ptr i32)
+
+    call $ensure_alloc
+
+    call $emit_manual_malformed_middle_events
+
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    local.tee $event_ptr
+    i32.const -1
+    i32.ne
+    i32.const 236
+    call $assert_true
+
+    local.get $event_ptr
+    i32.const 88
+    i32.const 2719
+    i32.const 3
+    f64.const 0
+    f64.const 0
+    i32.const 0
+    i32.const 0
+    i32.const 237
+    call $assert_event_base_fields
+
+    call $extractor_next
+    i32.const -1
+    i32.const 243
+    call $assert_eq_i32
+  )
+
+  (func (export "test_extractor_recovers_from_error_value")
+    (local $event_ptr i32)
+
+    i32.const 182
+    i32.const 2725
+    i32.const 2
+    call $emit_recovery_prefix
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_ERROR
+    i32.const 1
+    i32.const 1
+    call $parser_emit_token
+    drop
+
+    call $emit_recovery_valid_tail
+
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    local.tee $event_ptr
+    i32.const -1
+    i32.ne
+    i32.const 244
+    call $assert_true
+
+    local.get $event_ptr
+    i32.load8_u
+    i32.const 88
+    i32.const 245
+    call $assert_eq_i32
+  )
+
+  (func (export "test_extractor_waits_for_need_more_value")
+    i32.const 183
+    i32.const 2725
+    i32.const 2
+    call $emit_recovery_prefix
+
+    i32.const 55296
+    i32.const 57344
+    call $parser_emit_need_more_token
+    drop
+
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    i32.const -1
+    i32.const 246
+    call $assert_eq_i32
+  )
+
+  (func (export "test_extractor_recovers_from_invalid_value_token")
+    (local $event_ptr i32)
+
+    i32.const 184
+    i32.const 2725
+    i32.const 2
+    call $emit_recovery_prefix
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_COLON
+    call $parser_emit_structural_token
+    drop
+
+    call $emit_recovery_valid_tail
+
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    local.tee $event_ptr
+    i32.const -1
+    i32.ne
+    i32.const 247
+    call $assert_true
+
+    local.get $event_ptr
+    i32.load8_u
+    i32.const 88
+    i32.const 248
+    call $assert_eq_i32
+  )
+
+  (func (export "test_extractor_waits_for_args_need_more")
+    i32.const 185
+    i32.const 2965
+    i32.const 4
+    call $emit_recovery_prefix
+
+    i32.const 55296
+    i32.const 57344
+    call $parser_emit_need_more_token
+    drop
+
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    i32.const -1
+    i32.const 249
+    call $assert_eq_i32
+  )
+
+  (func (export "test_extractor_recovers_from_args_error_nested")
+    (local $event_ptr i32)
+
+    i32.const 186
+    i32.const 2965
+    i32.const 4
+    call $emit_recovery_prefix
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_LBRACK
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_ERROR
+    i32.const 1
+    i32.const 1
+    call $parser_emit_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_RBRACK
+    call $parser_emit_structural_token
+    drop
+
+    call $emit_recovery_valid_tail
+
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    local.tee $event_ptr
+    i32.const -1
+    i32.ne
+    i32.const 250
+    call $assert_true
+
+    local.get $event_ptr
+    i32.load8_u
+    i32.const 88
+    i32.const 251
+    call $assert_eq_i32
+  )
+
+  (func (export "test_extractor_waits_for_nested_need_more")
+    i32.const 187
+    i32.const 2965
+    i32.const 4
+    call $emit_recovery_prefix
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_LBRACK
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    call $parser_emit_need_more_token
+    drop
+
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    i32.const -1
+    i32.const 252
+    call $assert_eq_i32
+  )
+
+  (func (export "test_extractor_clamps_reversed_args_span")
+    (local $event_ptr i32)
+
+    i32.const 188
+    i32.const 2965
+    i32.const 4
+    call $emit_recovery_prefix
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_LBRACE
+    i32.const 4000
+    i32.const 1
+    call $parser_emit_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_RBRACE
+    i32.const 0
+    i32.const 0
+    call $parser_emit_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_RBRACE
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_RBRACK
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    call $parser_emit_eof_token
+    drop
+
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    local.tee $event_ptr
+    i32.const -1
+    i32.ne
+    i32.const 253
+    call $assert_true
+
+    local.get $event_ptr
+    i32.const 36
+    i32.add
+    i32.load
+    i32.const 0
+    i32.const 254
+    call $assert_eq_i32
+  )
+
+  (func (export "test_extractor_waits_for_unclosed_malformed_event")
+    i32.const 55296
+    i32.const 189
+    call $parser_state_init
+
+    i32.const 55296
+    i32.const 16
+    call $parser_token_output_reset
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_LBRACK
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_LBRACE
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_STRING
+    i32.const 2987
+    i32.const 4
+    call $parser_emit_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_STRING
+    i32.const 2994
+    i32.const 3
+    call $parser_emit_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    call $parser_emit_need_more_token
+    drop
+
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    i32.const -1
+    i32.const 255
+    call $assert_eq_i32
+  )
+
   (func (export "test_extractor_returns_zeroed_events_from_top_level_array")
     (local $event_ptr i32)
 
@@ -1134,8 +1791,8 @@
     i32.const 57344
     i32.const 0
     global.get $PARSER_JSON_TOKEN_LBRACE
-    i32.const 0
-    i32.const 0
+    i32.const 2048
+    i32.const 1
     i32.const 241
     call $assert_token_record
 
@@ -1150,16 +1807,16 @@
     i32.const 57344
     i32.const 2
     global.get $PARSER_JSON_TOKEN_COLON
-    i32.const 0
-    i32.const 0
+    i32.const 2052
+    i32.const 1
     i32.const 249
     call $assert_token_record
 
     i32.const 57344
     i32.const 3
     global.get $PARSER_JSON_TOKEN_LBRACK
-    i32.const 0
-    i32.const 0
+    i32.const 2053
+    i32.const 1
     i32.const 253
     call $assert_token_record
 
@@ -1198,16 +1855,16 @@
     i32.const 57344
     i32.const 11
     global.get $PARSER_JSON_TOKEN_RBRACK
-    i32.const 0
-    i32.const 0
+    i32.const 2078
+    i32.const 1
     i32.const 273
     call $assert_token_record
 
     i32.const 57344
     i32.const 12
     global.get $PARSER_JSON_TOKEN_RBRACE
-    i32.const 0
-    i32.const 0
+    i32.const 2079
+    i32.const 1
     i32.const 277
     call $assert_token_record
 
@@ -1252,8 +1909,8 @@
     i32.const 57344
     i32.const 0
     global.get $PARSER_JSON_TOKEN_LBRACE
-    i32.const 0
-    i32.const 0
+    i32.const 2100
+    i32.const 1
     i32.const 301
     call $assert_token_record
 

--- a/wat/parser.test.wat
+++ b/wat/parser.test.wat
@@ -30,6 +30,10 @@
     (func $parser_emit_yield_token (param i32) (param i32) (result i32)))
   (import "parser" "parser_emit_error_token"
     (func $parser_emit_error_token (param i32) (param i32) (param i32) (param i32) (result i32)))
+  (import "parser" "extractor_init"
+    (func $extractor_init (param i32)))
+  (import "parser" "extractor_next"
+    (func $extractor_next (result i32)))
   (import "parser_state" "parser_state_init"
     (func $parser_state_init (param i32) (param i32)))
   ;; @generated parser-state-imports parser-test:start
@@ -136,6 +140,10 @@
   (data (i32.const 2548) "1ex")
   (data (i32.const 2552) "1e+x")
   (data (i32.const 2558) ",")
+  (data (i32.const 2600) "[{},{}]")
+  (data (i32.const 2610) "{\22traceEvents\22:[{}]}")
+  (data (i32.const 2632) "{\22other\22:[]}")
+  (data (i32.const 2648) "[]")
 
   (func (export "message_for") (param $code i32) (result i32 i32)
     i32.const 1024
@@ -345,6 +353,216 @@
     end
 
     local.get $matches
+  )
+
+  (func $assert_zero_event_record (param $event_ptr i32) (param $code i32)
+    (local $i i32)
+
+    block $done
+      loop $loop
+        local.get $i
+        i32.const 40
+        i32.ge_u
+        br_if $done
+
+        local.get $event_ptr
+        local.get $i
+        i32.add
+        i32.load8_u
+        i32.const 0
+        local.get $code
+        call $assert_eq_i32
+
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+        br $loop
+      end
+    end
+  )
+
+  (func (export "test_extractor_returns_minus_one_without_active_state")
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    i32.const -1
+    i32.const 140
+    call $assert_eq_i32
+  )
+
+  (func (export "test_extractor_returns_zeroed_events_from_top_level_array")
+    (local $event_ptr i32)
+
+    i32.const 55296
+    i32.const 170
+    call $parser_state_init
+
+    i32.const 55296
+    i32.const 2600
+    i32.const 7
+    i32.const 57344
+    i32.const 16
+    call $parser_tokenize_bytes
+    global.get $PARSER_STATUS_DONE
+    i32.const 150
+    call $assert_eq_i32
+
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    local.tee $event_ptr
+    i32.const -1
+    i32.ne
+    i32.const 151
+    call $assert_true
+
+    local.get $event_ptr
+    i32.const 152
+    call $assert_zero_event_record
+
+    local.get $event_ptr
+    i32.const 99
+    i32.store8
+
+    call $extractor_next
+    local.tee $event_ptr
+    i32.const -1
+    i32.ne
+    i32.const 153
+    call $assert_true
+
+    local.get $event_ptr
+    i32.const 154
+    call $assert_zero_event_record
+
+    call $extractor_next
+    i32.const -1
+    i32.const 155
+    call $assert_eq_i32
+  )
+
+  (func (export "test_extractor_finds_trace_events_wrapper")
+    (local $event_ptr i32)
+
+    i32.const 55296
+    i32.const 171
+    call $parser_state_init
+
+    i32.const 55296
+    i32.const 2610
+    i32.const 20
+    i32.const 57344
+    i32.const 16
+    call $parser_tokenize_bytes
+    global.get $PARSER_STATUS_DONE
+    i32.const 160
+    call $assert_eq_i32
+
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    local.tee $event_ptr
+    i32.const -1
+    i32.ne
+    i32.const 161
+    call $assert_true
+
+    local.get $event_ptr
+    i32.const 162
+    call $assert_zero_event_record
+
+    call $extractor_next
+    i32.const -1
+    i32.const 163
+    call $assert_eq_i32
+  )
+
+  (func (export "test_extractor_ignores_non_trace_events_wrapper")
+    i32.const 55296
+    i32.const 172
+    call $parser_state_init
+
+    i32.const 55296
+    i32.const 2632
+    i32.const 12
+    i32.const 57344
+    i32.const 16
+    call $parser_tokenize_bytes
+    global.get $PARSER_STATUS_DONE
+    i32.const 164
+    call $assert_eq_i32
+
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    i32.const -1
+    i32.const 165
+    call $assert_eq_i32
+  )
+
+  (func (export "test_extractor_returns_minus_one_for_empty_array")
+    i32.const 55296
+    i32.const 173
+    call $parser_state_init
+
+    i32.const 55296
+    i32.const 2648
+    i32.const 2
+    i32.const 57344
+    i32.const 16
+    call $parser_tokenize_bytes
+    global.get $PARSER_STATUS_DONE
+    i32.const 166
+    call $assert_eq_i32
+
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    i32.const -1
+    i32.const 167
+    call $assert_eq_i32
+  )
+
+  (func (export "test_extractor_waits_for_incomplete_event_object")
+    i32.const 55296
+    i32.const 174
+    call $parser_state_init
+
+    i32.const 55296
+    i32.const 4
+    call $parser_token_output_reset
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_LBRACK
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    global.get $PARSER_JSON_TOKEN_LBRACE
+    call $parser_emit_structural_token
+    drop
+
+    i32.const 55296
+    i32.const 57344
+    call $parser_emit_need_more_token
+    drop
+
+    i32.const 57344
+    call $extractor_init
+
+    call $extractor_next
+    i32.const -1
+    i32.const 168
+    call $assert_eq_i32
   )
 
   (func (export "test_parser_writes_fixed_token_records")

--- a/wat/parser.wat
+++ b/wat/parser.wat
@@ -91,7 +91,14 @@
   (global $FLAG_AFTER_KEY i32 (i32.const 2))
   (global $DEFAULT_CHUNK_BYTES i32 (i32.const 4096))
   (global $DEFAULT_PARSE_OUTPUT_RECORDS i32 (i32.const 4096))
+  (global $EXTRACTOR_EVENT_BYTES i32 (i32.const 40))
+  (global $EXTRACTOR_EVENT_PTR i32 (i32.const 32768))
   (global $active_state (mut i32) (i32.const 0))
+  (global $extractor_token_base (mut i32) (i32.const 0))
+  (global $extractor_cursor (mut i32) (i32.const 0))
+  (global $extractor_in_trace_events (mut i32) (i32.const 0))
+  (global $extractor_after_trace_events_key (mut i32) (i32.const 0))
+  (global $extractor_after_trace_events_colon (mut i32) (i32.const 0))
 
   (func $field (param $state i32) (param $offset i32) (result i32)
     local.get $state
@@ -148,6 +155,369 @@
         br $loop
       end
     end
+  )
+
+  (func $zero_bytes (param $ptr i32) (param $len i32)
+    (local $i i32)
+
+    block $done
+      loop $loop
+        local.get $i
+        local.get $len
+        i32.ge_u
+        br_if $done
+
+        local.get $ptr
+        local.get $i
+        i32.add
+        i32.const 0
+        i32.store8
+
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+        br $loop
+      end
+    end
+  )
+
+  (func $extractor_record_ptr (param $index i32) (result i32)
+    global.get $extractor_token_base
+    local.get $index
+    global.get $PARSER_TOKEN_RECORD_BYTES
+    i32.mul
+    i32.add
+  )
+
+  (func $extractor_token_kind (param $index i32) (result i32)
+    local.get $index
+    call $extractor_record_ptr
+    i32.load
+  )
+
+  (func $extractor_token_payload_ptr (param $index i32) (result i32)
+    local.get $index
+    call $extractor_record_ptr
+    i32.const 4
+    i32.add
+    i32.load
+  )
+
+  (func $extractor_token_payload_len (param $index i32) (result i32)
+    local.get $index
+    call $extractor_record_ptr
+    i32.const 8
+    i32.add
+    i32.load
+  )
+
+  (func $extractor_token_count (result i32)
+    global.get $active_state
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    global.get $active_state
+    global.get $PARSER_STATE_OUTPUT_COUNT_OFFSET
+    call $load_i32
+  )
+
+  (func $extractor_token_matches_trace_events (param $index i32) (result i32)
+    (local $ptr i32)
+
+    local.get $index
+    call $extractor_token_payload_len
+    i32.const 11
+    i32.ne
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $index
+    call $extractor_token_payload_ptr
+    local.set $ptr
+
+    local.get $ptr
+    i32.load8_u
+    i32.const 116
+    i32.eq
+    local.get $ptr
+    i32.const 1
+    i32.add
+    i32.load8_u
+    i32.const 114
+    i32.eq
+    i32.and
+    local.get $ptr
+    i32.const 2
+    i32.add
+    i32.load8_u
+    i32.const 97
+    i32.eq
+    i32.and
+    local.get $ptr
+    i32.const 3
+    i32.add
+    i32.load8_u
+    i32.const 99
+    i32.eq
+    i32.and
+    local.get $ptr
+    i32.const 4
+    i32.add
+    i32.load8_u
+    i32.const 101
+    i32.eq
+    i32.and
+    local.get $ptr
+    i32.const 5
+    i32.add
+    i32.load8_u
+    i32.const 69
+    i32.eq
+    i32.and
+    local.get $ptr
+    i32.const 6
+    i32.add
+    i32.load8_u
+    i32.const 118
+    i32.eq
+    i32.and
+    local.get $ptr
+    i32.const 7
+    i32.add
+    i32.load8_u
+    i32.const 101
+    i32.eq
+    i32.and
+    local.get $ptr
+    i32.const 8
+    i32.add
+    i32.load8_u
+    i32.const 110
+    i32.eq
+    i32.and
+    local.get $ptr
+    i32.const 9
+    i32.add
+    i32.load8_u
+    i32.const 116
+    i32.eq
+    i32.and
+    local.get $ptr
+    i32.const 10
+    i32.add
+    i32.load8_u
+    i32.const 115
+    i32.eq
+    i32.and
+  )
+
+  (func $extractor_zero_event
+    global.get $EXTRACTOR_EVENT_PTR
+    global.get $EXTRACTOR_EVENT_BYTES
+    call $zero_bytes
+  )
+
+  (func $extractor_skip_object (param $start_index i32) (result i32)
+    (local $i i32)
+    (local $count i32)
+    (local $depth i32)
+    (local $kind i32)
+
+    local.get $start_index
+    local.set $i
+    call $extractor_token_count
+    local.set $count
+
+    block $done
+      loop $loop
+        local.get $i
+        local.get $count
+        i32.ge_u
+        br_if $done
+
+        local.get $i
+        call $extractor_token_kind
+        local.set $kind
+
+        local.get $kind
+        global.get $PARSER_JSON_TOKEN_LBRACE
+        i32.eq
+        if
+          local.get $depth
+          i32.const 1
+          i32.add
+          local.set $depth
+        end
+
+        local.get $kind
+        global.get $PARSER_JSON_TOKEN_RBRACE
+        i32.eq
+        if
+          local.get $depth
+          i32.const 1
+          i32.sub
+          local.tee $depth
+          i32.eqz
+          if
+            local.get $i
+            i32.const 1
+            i32.add
+            return
+          end
+        end
+
+        local.get $kind
+        global.get $PARSER_JSON_TOKEN_EOF
+        i32.eq
+        local.get $kind
+        global.get $PARSER_JSON_TOKEN_NEED_MORE
+        i32.eq
+        i32.or
+        if
+          i32.const -1
+          return
+        end
+
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+        br $loop
+      end
+    end
+
+    local.get $i
+  )
+
+  (func (export "extractor_init") (param $ring_ptr i32)
+    local.get $ring_ptr
+    global.set $extractor_token_base
+    i32.const 0
+    global.set $extractor_cursor
+    i32.const 0
+    global.set $extractor_in_trace_events
+    i32.const 0
+    global.set $extractor_after_trace_events_key
+    i32.const 0
+    global.set $extractor_after_trace_events_colon
+  )
+
+  (func (export "extractor_next") (result i32)
+    (local $count i32)
+    (local $kind i32)
+    (local $next_index i32)
+
+    call $extractor_token_count
+    local.set $count
+
+    block $done
+      loop $scan
+        global.get $extractor_cursor
+        local.get $count
+        i32.ge_u
+        br_if $done
+
+        global.get $extractor_cursor
+        call $extractor_token_kind
+        local.set $kind
+
+        local.get $kind
+        global.get $PARSER_JSON_TOKEN_EOF
+        i32.eq
+        local.get $kind
+        global.get $PARSER_JSON_TOKEN_NEED_MORE
+        i32.eq
+        i32.or
+        if
+          i32.const -1
+          return
+        end
+
+        global.get $extractor_in_trace_events
+        if
+          local.get $kind
+          global.get $PARSER_JSON_TOKEN_LBRACE
+          i32.eq
+          if
+            call $extractor_zero_event
+            global.get $extractor_cursor
+            call $extractor_skip_object
+            local.tee $next_index
+            i32.const -1
+            i32.eq
+            if
+              i32.const -1
+              return
+            end
+
+            local.get $next_index
+            global.set $extractor_cursor
+            global.get $EXTRACTOR_EVENT_PTR
+            return
+          end
+
+          local.get $kind
+          global.get $PARSER_JSON_TOKEN_RBRACK
+          i32.eq
+          if
+            i32.const 0
+            global.set $extractor_in_trace_events
+          end
+        else
+          local.get $kind
+          global.get $PARSER_JSON_TOKEN_LBRACK
+          i32.eq
+          if
+            global.get $extractor_after_trace_events_colon
+            if
+              i32.const 0
+              global.set $extractor_after_trace_events_colon
+            end
+
+            i32.const 1
+            global.set $extractor_in_trace_events
+          else
+            local.get $kind
+            global.get $PARSER_JSON_TOKEN_STRING
+            i32.eq
+            if
+              global.get $extractor_cursor
+              call $extractor_token_matches_trace_events
+              if
+                i32.const 1
+                global.set $extractor_after_trace_events_key
+              end
+            end
+
+            local.get $kind
+            global.get $PARSER_JSON_TOKEN_COLON
+            i32.eq
+            global.get $extractor_after_trace_events_key
+            i32.and
+            if
+              i32.const 0
+              global.set $extractor_after_trace_events_key
+              i32.const 1
+              global.set $extractor_after_trace_events_colon
+            end
+          end
+        end
+
+        global.get $extractor_cursor
+        i32.const 1
+        i32.add
+        global.set $extractor_cursor
+        br $scan
+      end
+    end
+
+    i32.const -1
   )
 
   (func (export "parser_save_state") (param $out_ptr i32)

--- a/wat/parser.wat
+++ b/wat/parser.wat
@@ -100,12 +100,14 @@
   (global $EXTRACTOR_FIELD_DUR i32 (i32.const 4))
   (global $EXTRACTOR_FIELD_PID i32 (i32.const 5))
   (global $EXTRACTOR_FIELD_TID i32 (i32.const 6))
+  (global $EXTRACTOR_FIELD_ARGS i32 (i32.const 7))
   (global $active_state (mut i32) (i32.const 0))
   (global $extractor_token_base (mut i32) (i32.const 0))
   (global $extractor_cursor (mut i32) (i32.const 0))
   (global $extractor_in_trace_events (mut i32) (i32.const 0))
   (global $extractor_after_trace_events_key (mut i32) (i32.const 0))
   (global $extractor_after_trace_events_colon (mut i32) (i32.const 0))
+  (global $extractor_discard_event (mut i32) (i32.const 0))
 
   (func $field (param $state i32) (param $offset i32) (result i32)
     local.get $state
@@ -467,7 +469,301 @@
       return
     end
 
+    local.get $index
+    i32.const 97
+    i32.const 114
+    i32.const 103
+    i32.const 115
+    call $extractor_payload_matches4
+    if
+      global.get $EXTRACTOR_FIELD_ARGS
+      return
+    end
+
     global.get $EXTRACTOR_FIELD_NONE
+  )
+
+  (func $extractor_is_scalar_value (param $kind i32) (result i32)
+    local.get $kind
+    global.get $PARSER_JSON_TOKEN_STRING
+    i32.eq
+    local.get $kind
+    global.get $PARSER_JSON_TOKEN_NUMBER
+    i32.eq
+    i32.or
+    local.get $kind
+    global.get $PARSER_JSON_TOKEN_TRUE
+    i32.eq
+    i32.or
+    local.get $kind
+    global.get $PARSER_JSON_TOKEN_FALSE
+    i32.eq
+    i32.or
+    local.get $kind
+    global.get $PARSER_JSON_TOKEN_NULL
+    i32.eq
+    i32.or
+  )
+
+  (func $extractor_token_end_ptr (param $index i32) (result i32)
+    local.get $index
+    call $extractor_token_payload_ptr
+    local.get $index
+    call $extractor_token_payload_len
+    i32.add
+  )
+
+  (func $extractor_capture_args_span (param $start_index i32) (param $end_index i32)
+    (local $start_ptr i32)
+    (local $end_ptr i32)
+
+    local.get $start_index
+    call $extractor_token_payload_ptr
+    local.set $start_ptr
+    local.get $end_index
+    call $extractor_token_end_ptr
+    local.set $end_ptr
+
+    global.get $EXTRACTOR_EVENT_PTR
+    i32.const 32
+    i32.add
+    local.get $start_ptr
+    i32.store
+
+    global.get $EXTRACTOR_EVENT_PTR
+    i32.const 36
+    i32.add
+    local.get $end_ptr
+    local.get $start_ptr
+    i32.ge_u
+    if (result i32)
+      local.get $end_ptr
+      local.get $start_ptr
+      i32.sub
+    else
+      i32.const 0
+    end
+    i32.store
+  )
+
+  (func $extractor_skip_value (param $start_index i32) (result i32)
+    (local $i i32)
+    (local $count i32)
+    (local $depth i32)
+    (local $kind i32)
+
+    local.get $start_index
+    call $extractor_token_kind
+    local.tee $kind
+    call $extractor_is_scalar_value
+    if
+      local.get $start_index
+      i32.const 1
+      i32.add
+      return
+    end
+
+    local.get $kind
+    global.get $PARSER_JSON_TOKEN_ERROR
+    i32.eq
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $kind
+    global.get $PARSER_JSON_TOKEN_EOF
+    i32.eq
+    local.get $kind
+    global.get $PARSER_JSON_TOKEN_NEED_MORE
+    i32.eq
+    i32.or
+    if
+      i32.const -1
+      return
+    end
+
+    local.get $kind
+    global.get $PARSER_JSON_TOKEN_LBRACE
+    i32.eq
+    local.get $kind
+    global.get $PARSER_JSON_TOKEN_LBRACK
+    i32.eq
+    i32.or
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    local.get $start_index
+    local.set $i
+    call $extractor_token_count
+    local.set $count
+
+    block $done
+      loop $loop
+        local.get $i
+        local.get $count
+        i32.ge_u
+        br_if $done
+
+        local.get $i
+        call $extractor_token_kind
+        local.set $kind
+
+        local.get $kind
+        global.get $PARSER_JSON_TOKEN_LBRACE
+        i32.eq
+        local.get $kind
+        global.get $PARSER_JSON_TOKEN_LBRACK
+        i32.eq
+        i32.or
+        if
+          local.get $depth
+          i32.const 1
+          i32.add
+          local.set $depth
+        end
+
+        local.get $kind
+        global.get $PARSER_JSON_TOKEN_RBRACE
+        i32.eq
+        local.get $kind
+        global.get $PARSER_JSON_TOKEN_RBRACK
+        i32.eq
+        i32.or
+        if
+          local.get $depth
+          i32.const 1
+          i32.sub
+          local.tee $depth
+          i32.eqz
+          if
+            local.get $i
+            i32.const 1
+            i32.add
+            return
+          end
+        end
+
+        local.get $kind
+        global.get $PARSER_JSON_TOKEN_ERROR
+        i32.eq
+        if
+          i32.const 0
+          return
+        end
+
+        local.get $kind
+        global.get $PARSER_JSON_TOKEN_EOF
+        i32.eq
+        local.get $kind
+        global.get $PARSER_JSON_TOKEN_NEED_MORE
+        i32.eq
+        i32.or
+        if
+          i32.const -1
+          return
+        end
+
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+        br $loop
+      end
+    end
+
+    i32.const -1
+  )
+
+  (func $extractor_skip_to_object_end (param $start_index i32) (result i32)
+    (local $i i32)
+    (local $count i32)
+    (local $depth i32)
+    (local $kind i32)
+
+    local.get $start_index
+    local.set $i
+    call $extractor_token_count
+    local.set $count
+    i32.const 1
+    local.set $depth
+
+    block $done
+      loop $loop
+        local.get $i
+        local.get $count
+        i32.ge_u
+        br_if $done
+
+        local.get $i
+        call $extractor_token_kind
+        local.set $kind
+
+        local.get $kind
+        global.get $PARSER_JSON_TOKEN_LBRACE
+        i32.eq
+        local.get $kind
+        global.get $PARSER_JSON_TOKEN_LBRACK
+        i32.eq
+        i32.or
+        if
+          local.get $depth
+          i32.const 1
+          i32.add
+          local.set $depth
+        end
+
+        local.get $kind
+        global.get $PARSER_JSON_TOKEN_RBRACK
+        i32.eq
+        if
+          local.get $depth
+          i32.const 1
+          i32.sub
+          local.set $depth
+        end
+
+        local.get $kind
+        global.get $PARSER_JSON_TOKEN_RBRACE
+        i32.eq
+        if
+          local.get $depth
+          i32.const 1
+          i32.sub
+          local.tee $depth
+          i32.eqz
+          if
+            local.get $i
+            i32.const 1
+            i32.add
+            return
+          end
+        end
+
+        local.get $kind
+        global.get $PARSER_JSON_TOKEN_EOF
+        i32.eq
+        local.get $kind
+        global.get $PARSER_JSON_TOKEN_NEED_MORE
+        i32.eq
+        i32.or
+        if
+          i32.const -1
+          return
+        end
+
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+        br $loop
+      end
+    end
+
+    i32.const -1
   )
 
   (func $extractor_parse_u32 (param $index i32) (result i32)
@@ -673,6 +969,8 @@
     (local $field_id i32)
     (local $after_key i32)
     (local $expect_key i32)
+    (local $value_index i32)
+    (local $next_index i32)
 
     local.get $start_index
     local.set $i
@@ -719,19 +1017,86 @@
             local.get $i
             i32.const 1
             i32.add
-            local.tee $i
+            local.tee $value_index
             local.get $count
             i32.lt_u
             if
               local.get $field_id
-              local.get $i
-              call $extractor_store_value
+              global.get $EXTRACTOR_FIELD_ARGS
+              i32.eq
+              if
+                local.get $value_index
+                call $extractor_skip_value
+                local.tee $next_index
+                i32.const -1
+                i32.eq
+                if
+                  i32.const -1
+                  return
+                end
+
+                local.get $next_index
+                i32.eqz
+                if
+                  i32.const 1
+                  global.set $extractor_discard_event
+                  local.get $value_index
+                  call $extractor_skip_to_object_end
+                  return
+                end
+
+                local.get $value_index
+                local.get $next_index
+                i32.const 1
+                i32.sub
+                call $extractor_capture_args_span
+              else
+                local.get $field_id
+                local.get $value_index
+                call $extractor_store_value
+
+                local.get $value_index
+                call $extractor_skip_value
+                local.tee $next_index
+                i32.const -1
+                i32.eq
+                if
+                  i32.const -1
+                  return
+                end
+
+                local.get $next_index
+                i32.eqz
+                if
+                  i32.const 1
+                  global.set $extractor_discard_event
+                  local.get $value_index
+                  call $extractor_skip_to_object_end
+                  return
+                end
+              end
+
+              local.get $next_index
+              i32.const 1
+              i32.sub
+              local.set $i
+              local.get $field_id
+              drop
               global.get $EXTRACTOR_FIELD_NONE
               local.set $field_id
               i32.const 0
               local.set $expect_key
             end
           else
+            local.get $after_key
+            if
+              i32.const 1
+              global.set $extractor_discard_event
+              local.get $i
+              call $extractor_skip_to_object_end
+              return
+            end
+
             local.get $expect_key
             local.get $kind
             global.get $PARSER_JSON_TOKEN_STRING
@@ -752,6 +1117,10 @@
         local.get $kind
         global.get $PARSER_JSON_TOKEN_LBRACE
         i32.eq
+        local.get $kind
+        global.get $PARSER_JSON_TOKEN_LBRACK
+        i32.eq
+        i32.or
         if
           local.get $depth
           i32.const 1
@@ -762,6 +1131,10 @@
         local.get $kind
         global.get $PARSER_JSON_TOKEN_RBRACE
         i32.eq
+        local.get $kind
+        global.get $PARSER_JSON_TOKEN_RBRACK
+        i32.eq
+        i32.or
         if
           local.get $depth
           i32.const 1
@@ -810,6 +1183,8 @@
     global.set $extractor_after_trace_events_key
     i32.const 0
     global.set $extractor_after_trace_events_colon
+    i32.const 0
+    global.set $extractor_discard_event
   )
 
   (func (export "extractor_next") (result i32)
@@ -850,6 +1225,8 @@
           i32.eq
           if
             call $extractor_zero_event
+            i32.const 0
+            global.set $extractor_discard_event
             global.get $extractor_cursor
             call $extractor_skip_object
             local.tee $next_index
@@ -862,6 +1239,13 @@
 
             local.get $next_index
             global.set $extractor_cursor
+            global.get $extractor_discard_event
+            if
+              i32.const 0
+              global.set $extractor_discard_event
+              br $scan
+            end
+
             global.get $EXTRACTOR_EVENT_PTR
             return
           end
@@ -1823,12 +2207,12 @@
     i32.const 0
   )
 
-  (func $emit_checked_structural_token (param $state i32) (param $out_ptr i32) (param $kind i32) (result i32)
+  (func $emit_checked_structural_token (param $state i32) (param $out_ptr i32) (param $kind i32) (param $token_ptr i32) (result i32)
     local.get $state
     local.get $out_ptr
     local.get $kind
-    i32.const 0
-    i32.const 0
+    local.get $token_ptr
+    i32.const 1
     call $emit_checked_token
   )
 
@@ -2344,6 +2728,7 @@
       local.get $state
       local.get $out_ptr
       global.get $PARSER_JSON_TOKEN_LBRACE
+      local.get $byte_ptr
       call $emit_checked_structural_token
       return
     end
@@ -2378,6 +2763,7 @@
       local.get $state
       local.get $out_ptr
       global.get $PARSER_JSON_TOKEN_RBRACE
+      local.get $byte_ptr
       call $emit_checked_structural_token
       return
     end
@@ -2404,6 +2790,7 @@
       local.get $state
       local.get $out_ptr
       global.get $PARSER_JSON_TOKEN_LBRACK
+      local.get $byte_ptr
       call $emit_checked_structural_token
       return
     end
@@ -2428,6 +2815,7 @@
       local.get $state
       local.get $out_ptr
       global.get $PARSER_JSON_TOKEN_RBRACK
+      local.get $byte_ptr
       call $emit_checked_structural_token
       return
     end
@@ -2454,6 +2842,7 @@
       local.get $state
       local.get $out_ptr
       global.get $PARSER_JSON_TOKEN_COLON
+      local.get $byte_ptr
       call $emit_checked_structural_token
       return
     end
@@ -2486,6 +2875,7 @@
       local.get $state
       local.get $out_ptr
       global.get $PARSER_JSON_TOKEN_COMMA
+      local.get $byte_ptr
       call $emit_checked_structural_token
       return
     end

--- a/wat/parser.wat
+++ b/wat/parser.wat
@@ -5,6 +5,8 @@
   ;; @generated host-imports parser:end
   (import "mem" "MEM_RING_BASE" (global $MEM_RING_BASE i32))
   (import "mem" "MEM_RING_SIZE" (global $MEM_RING_SIZE i32))
+  (import "strtab" "strtab_intern"
+    (func $strtab_intern (param i32) (param i32) (result i32)))
   ;; @generated parser-state-imports parser:start
   (import "parser_state" "PARSER_STATE_BYTES" (global $PARSER_STATE_BYTES i32))
   (import "parser_state" "PARSER_STACK_CAP" (global $PARSER_STACK_CAP i32))

--- a/wat/parser.wat
+++ b/wat/parser.wat
@@ -93,6 +93,13 @@
   (global $DEFAULT_PARSE_OUTPUT_RECORDS i32 (i32.const 4096))
   (global $EXTRACTOR_EVENT_BYTES i32 (i32.const 40))
   (global $EXTRACTOR_EVENT_PTR i32 (i32.const 32768))
+  (global $EXTRACTOR_FIELD_NONE i32 (i32.const 0))
+  (global $EXTRACTOR_FIELD_PHASE i32 (i32.const 1))
+  (global $EXTRACTOR_FIELD_NAME i32 (i32.const 2))
+  (global $EXTRACTOR_FIELD_TS i32 (i32.const 3))
+  (global $EXTRACTOR_FIELD_DUR i32 (i32.const 4))
+  (global $EXTRACTOR_FIELD_PID i32 (i32.const 5))
+  (global $EXTRACTOR_FIELD_TID i32 (i32.const 6))
   (global $active_state (mut i32) (i32.const 0))
   (global $extractor_token_base (mut i32) (i32.const 0))
   (global $extractor_cursor (mut i32) (i32.const 0))
@@ -317,6 +324,341 @@
     i32.and
   )
 
+  (func $extractor_token_byte (param $index i32) (param $offset i32) (result i32)
+    local.get $index
+    call $extractor_token_payload_ptr
+    local.get $offset
+    i32.add
+    i32.load8_u
+  )
+
+  (func $extractor_payload_matches2 (param $index i32) (param $a i32) (param $b i32) (result i32)
+    local.get $index
+    call $extractor_token_payload_len
+    i32.const 2
+    i32.eq
+    local.get $index
+    i32.const 0
+    call $extractor_token_byte
+    local.get $a
+    i32.eq
+    i32.and
+    local.get $index
+    i32.const 1
+    call $extractor_token_byte
+    local.get $b
+    i32.eq
+    i32.and
+  )
+
+  (func $extractor_payload_matches3 (param $index i32) (param $a i32) (param $b i32) (param $c i32) (result i32)
+    local.get $index
+    call $extractor_token_payload_len
+    i32.const 3
+    i32.eq
+    local.get $index
+    i32.const 0
+    call $extractor_token_byte
+    local.get $a
+    i32.eq
+    i32.and
+    local.get $index
+    i32.const 1
+    call $extractor_token_byte
+    local.get $b
+    i32.eq
+    i32.and
+    local.get $index
+    i32.const 2
+    call $extractor_token_byte
+    local.get $c
+    i32.eq
+    i32.and
+  )
+
+  (func $extractor_payload_matches4 (param $index i32) (param $a i32) (param $b i32) (param $c i32) (param $d i32) (result i32)
+    local.get $index
+    call $extractor_token_payload_len
+    i32.const 4
+    i32.eq
+    local.get $index
+    i32.const 0
+    call $extractor_token_byte
+    local.get $a
+    i32.eq
+    i32.and
+    local.get $index
+    i32.const 1
+    call $extractor_token_byte
+    local.get $b
+    i32.eq
+    i32.and
+    local.get $index
+    i32.const 2
+    call $extractor_token_byte
+    local.get $c
+    i32.eq
+    i32.and
+    local.get $index
+    i32.const 3
+    call $extractor_token_byte
+    local.get $d
+    i32.eq
+    i32.and
+  )
+
+  (func $extractor_classify_key (param $index i32) (result i32)
+    local.get $index
+    i32.const 112
+    i32.const 104
+    call $extractor_payload_matches2
+    if
+      global.get $EXTRACTOR_FIELD_PHASE
+      return
+    end
+
+    local.get $index
+    i32.const 116
+    i32.const 115
+    call $extractor_payload_matches2
+    if
+      global.get $EXTRACTOR_FIELD_TS
+      return
+    end
+
+    local.get $index
+    i32.const 100
+    i32.const 117
+    i32.const 114
+    call $extractor_payload_matches3
+    if
+      global.get $EXTRACTOR_FIELD_DUR
+      return
+    end
+
+    local.get $index
+    i32.const 112
+    i32.const 105
+    i32.const 100
+    call $extractor_payload_matches3
+    if
+      global.get $EXTRACTOR_FIELD_PID
+      return
+    end
+
+    local.get $index
+    i32.const 116
+    i32.const 105
+    i32.const 100
+    call $extractor_payload_matches3
+    if
+      global.get $EXTRACTOR_FIELD_TID
+      return
+    end
+
+    local.get $index
+    i32.const 110
+    i32.const 97
+    i32.const 109
+    i32.const 101
+    call $extractor_payload_matches4
+    if
+      global.get $EXTRACTOR_FIELD_NAME
+      return
+    end
+
+    global.get $EXTRACTOR_FIELD_NONE
+  )
+
+  (func $extractor_parse_u32 (param $index i32) (result i32)
+    (local $ptr i32)
+    (local $len i32)
+    (local $i i32)
+    (local $byte i32)
+    (local $value i32)
+
+    local.get $index
+    call $extractor_token_payload_ptr
+    local.set $ptr
+    local.get $index
+    call $extractor_token_payload_len
+    local.tee $len
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+
+    block $done
+      loop $loop
+        local.get $i
+        local.get $len
+        i32.ge_u
+        br_if $done
+
+        local.get $ptr
+        local.get $i
+        i32.add
+        i32.load8_u
+        local.tee $byte
+        i32.const 48
+        i32.lt_u
+        local.get $byte
+        i32.const 57
+        i32.gt_u
+        i32.or
+        if
+          i32.const 0
+          return
+        end
+
+        local.get $value
+        i32.const 10
+        i32.mul
+        local.get $byte
+        i32.const 48
+        i32.sub
+        i32.add
+        local.set $value
+
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+        br $loop
+      end
+    end
+
+    local.get $value
+  )
+
+  (func $extractor_store_value (param $field_id i32) (param $value_index i32)
+    (local $kind i32)
+
+    local.get $value_index
+    call $extractor_token_kind
+    local.set $kind
+
+    local.get $field_id
+    global.get $EXTRACTOR_FIELD_PHASE
+    i32.eq
+    local.get $kind
+    global.get $PARSER_JSON_TOKEN_STRING
+    i32.eq
+    i32.and
+    if
+      global.get $EXTRACTOR_EVENT_PTR
+      local.get $value_index
+      i32.const 0
+      call $extractor_token_byte
+      i32.store8
+      return
+    end
+
+    local.get $field_id
+    global.get $EXTRACTOR_FIELD_NAME
+    i32.eq
+    local.get $kind
+    global.get $PARSER_JSON_TOKEN_STRING
+    i32.eq
+    i32.and
+    if
+      global.get $EXTRACTOR_EVENT_PTR
+      i32.const 4
+      i32.add
+      local.get $value_index
+      call $extractor_token_payload_ptr
+      local.get $value_index
+      call $extractor_token_payload_len
+      call $strtab_intern
+      i32.store
+      return
+    end
+
+    local.get $field_id
+    global.get $EXTRACTOR_FIELD_TS
+    i32.eq
+    local.get $kind
+    global.get $PARSER_JSON_TOKEN_NUMBER
+    i32.eq
+    i32.and
+    if
+      global.get $EXTRACTOR_EVENT_PTR
+      i32.const 8
+      i32.add
+      local.get $value_index
+      call $extractor_parse_u32
+      f64.convert_i32_u
+      f64.store
+      return
+    end
+
+    local.get $field_id
+    global.get $EXTRACTOR_FIELD_DUR
+    i32.eq
+    local.get $kind
+    global.get $PARSER_JSON_TOKEN_NUMBER
+    i32.eq
+    i32.and
+    if
+      global.get $EXTRACTOR_EVENT_PTR
+      i32.const 16
+      i32.add
+      local.get $value_index
+      call $extractor_parse_u32
+      f64.convert_i32_u
+      f64.store
+      return
+    end
+
+    local.get $field_id
+    global.get $EXTRACTOR_FIELD_PID
+    i32.eq
+    if
+      global.get $EXTRACTOR_EVENT_PTR
+      i32.const 24
+      i32.add
+      local.get $kind
+      global.get $PARSER_JSON_TOKEN_STRING
+      i32.eq
+      if (result i32)
+        local.get $value_index
+        call $extractor_token_payload_ptr
+        local.get $value_index
+        call $extractor_token_payload_len
+        call $strtab_intern
+      else
+        local.get $value_index
+        call $extractor_parse_u32
+      end
+      i32.store
+      return
+    end
+
+    local.get $field_id
+    global.get $EXTRACTOR_FIELD_TID
+    i32.eq
+    if
+      global.get $EXTRACTOR_EVENT_PTR
+      i32.const 28
+      i32.add
+      local.get $kind
+      global.get $PARSER_JSON_TOKEN_STRING
+      i32.eq
+      if (result i32)
+        local.get $value_index
+        call $extractor_token_payload_ptr
+        local.get $value_index
+        call $extractor_token_payload_len
+        call $strtab_intern
+      else
+        local.get $value_index
+        call $extractor_parse_u32
+      end
+      i32.store
+    end
+  )
+
   (func $extractor_zero_event
     global.get $EXTRACTOR_EVENT_PTR
     global.get $EXTRACTOR_EVENT_BYTES
@@ -328,11 +670,16 @@
     (local $count i32)
     (local $depth i32)
     (local $kind i32)
+    (local $field_id i32)
+    (local $after_key i32)
+    (local $expect_key i32)
 
     local.get $start_index
     local.set $i
     call $extractor_token_count
     local.set $count
+    i32.const 1
+    local.set $expect_key
 
     block $done
       loop $loop
@@ -344,6 +691,63 @@
         local.get $i
         call $extractor_token_kind
         local.set $kind
+
+        local.get $depth
+        i32.const 1
+        i32.eq
+        if
+          local.get $kind
+          global.get $PARSER_JSON_TOKEN_COMMA
+          i32.eq
+          if
+            i32.const 1
+            local.set $expect_key
+            i32.const 0
+            local.set $after_key
+            global.get $EXTRACTOR_FIELD_NONE
+            local.set $field_id
+          end
+
+          local.get $after_key
+          local.get $kind
+          global.get $PARSER_JSON_TOKEN_COLON
+          i32.eq
+          i32.and
+          if
+            i32.const 0
+            local.set $after_key
+            local.get $i
+            i32.const 1
+            i32.add
+            local.tee $i
+            local.get $count
+            i32.lt_u
+            if
+              local.get $field_id
+              local.get $i
+              call $extractor_store_value
+              global.get $EXTRACTOR_FIELD_NONE
+              local.set $field_id
+              i32.const 0
+              local.set $expect_key
+            end
+          else
+            local.get $expect_key
+            local.get $kind
+            global.get $PARSER_JSON_TOKEN_STRING
+            i32.eq
+            i32.and
+            if
+              local.get $i
+              call $extractor_classify_key
+              local.set $field_id
+              i32.const 1
+              local.set $after_key
+              i32.const 0
+              local.set $expect_key
+            end
+          end
+        end
 
         local.get $kind
         global.get $PARSER_JSON_TOKEN_LBRACE


### PR DESCRIPTION
Finishes the generated 100 MB Chrome trace CI check by deriving reproducible random seeds from the right commit on PR and main runs while preserving event-count verification and the checked-in generator. It also moves WAT dependency and load-order knowledge into a shared source consumed by both watwat and the browser runtime.

Fixes #10.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (7)</summary>

- [x] [Update the generated 100 MB Chrome trace CI test so random valid trace events are seeded reproducibly: PR runs derive the seed from the main branch head commit ID, and main runs derive it from the prior commit.](https://github.com/rhencke/tracy/pull/86#discussion_r3196364126) <!-- type:thread -->
- [x] [Move WAT module dependency and load-order knowledge out of tools/watwat.js into a shared manifest or loader used by both watwat and the browser runtime, then update watwat to consume that shared source instead of hard-coding repo structure.](https://github.com/rhencke/tracy/pull/86#discussion_r3196403943) <!-- type:thread -->
- [x] [Add an automatic generated 100 MB trace extractor CI test that runs in a separate GitHub Actions job with a timeout and verifies extracted event count without checking a large fixture into the repository.](https://github.com/rhencke/tracy/pull/86#issuecomment-4389165381) <!-- type:thread -->
- [x] Recover from unknown and malformed event values <!-- type:spec -->
- [x] Extract typed Chrome trace fields <!-- type:spec -->
- [x] Add extractor cursor and event ABI <!-- type:spec -->
- [x] Wire parser extractor dependencies <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->