### PR TITLE
v0.1 #30 — WAT-driven WASM module registry + parallel two-phase loader (closes #89)

### DIFF
--- a/abi/wasm-modules.json
+++ b/abi/wasm-modules.json
@@ -1,0 +1,121 @@
+{
+  "modules": {
+    "app": {
+      "wasmPath": "app.wasm",
+      "aliases": [
+        "app"
+      ],
+      "dependencies": []
+    },
+    "index": {
+      "wasmPath": "index.wasm",
+      "aliases": [
+        "index"
+      ],
+      "dependencies": [
+        "std/mem"
+      ]
+    },
+    "parser": {
+      "wasmPath": "parser.wasm",
+      "aliases": [
+        "parser"
+      ],
+      "dependencies": [
+        "std/mem",
+        "std/strtab",
+        "parser_state"
+      ]
+    },
+    "parser_state": {
+      "wasmPath": "parser_state.wasm",
+      "aliases": [
+        "parser_state"
+      ],
+      "dependencies": []
+    },
+    "std/alloc": {
+      "wasmPath": "std/alloc.wasm",
+      "aliases": [
+        "alloc",
+        "std/alloc",
+        "wat/std/alloc"
+      ],
+      "dependencies": []
+    },
+    "std/array": {
+      "wasmPath": "std/array.wasm",
+      "aliases": [
+        "array",
+        "std/array",
+        "wat/std/array"
+      ],
+      "dependencies": [
+        "std/alloc"
+      ]
+    },
+    "std/assert": {
+      "wasmPath": "std/assert.wasm",
+      "aliases": [
+        "assert",
+        "std/assert",
+        "wat/std/assert"
+      ],
+      "dependencies": []
+    },
+    "std/hash": {
+      "wasmPath": "std/hash.wasm",
+      "aliases": [
+        "hash",
+        "std/hash",
+        "wat/std/hash"
+      ],
+      "dependencies": [
+        "std/alloc"
+      ]
+    },
+    "std/mem": {
+      "wasmPath": "std/mem.wasm",
+      "aliases": [
+        "mem",
+        "std/mem",
+        "wat/std/mem"
+      ],
+      "dependencies": []
+    },
+    "std/pool": {
+      "wasmPath": "std/pool.wasm",
+      "aliases": [
+        "pool",
+        "std/pool",
+        "wat/std/pool"
+      ],
+      "dependencies": [
+        "std/alloc"
+      ]
+    },
+    "std/ring": {
+      "wasmPath": "std/ring.wasm",
+      "aliases": [
+        "ring",
+        "std/ring",
+        "wat/std/ring"
+      ],
+      "dependencies": [
+        "std/alloc"
+      ]
+    },
+    "std/strtab": {
+      "wasmPath": "std/strtab.wasm",
+      "aliases": [
+        "strtab",
+        "std/strtab",
+        "wat/std/strtab"
+      ],
+      "dependencies": [
+        "std/alloc",
+        "std/hash"
+      ]
+    }
+  }
+}

--- a/host/wasm-modules.mjs
+++ b/host/wasm-modules.mjs
@@ -97,28 +97,27 @@ export function wasmModuleUrl(id, baseUrl = "wasm/") {
   return `${baseUrl.replace(/\/?$/, "/")}${wasmModulePath(id)}`;
 }
 
-function appendWasmModuleGraph(id, ordered, seen, active) {
+function collectWasmModuleGraph(id, collected, active) {
   if (active.has(id)) {
     throw new Error(`recursive wasm module dependency: ${id}`);
   }
-  if (seen.has(id)) {
+  if (collected.has(id)) {
     return;
   }
 
   active.add(id);
   for (const dependency of wasmModuleDependencies(id)) {
-    appendWasmModuleGraph(dependency, ordered, seen, active);
+    collectWasmModuleGraph(dependency, collected, active);
   }
   active.delete(id);
 
-  seen.add(id);
-  ordered.push(id);
+  collected.add(id);
 }
 
 export function wasmModuleGraphIds(id) {
-  const ordered = [];
-  appendWasmModuleGraph(id, ordered, new Set(), new Set());
-  return Object.freeze(ordered);
+  const graphIds = new Set();
+  collectWasmModuleGraph(id, graphIds, new Set());
+  return Object.freeze([...graphIds].sort());
 }
 
 async function defaultCompile(url) {

--- a/host/wasm-modules.mjs
+++ b/host/wasm-modules.mjs
@@ -130,16 +130,33 @@ async function defaultInstantiate(module, imports) {
   return instance.exports;
 }
 
+function compileWasmModuleRegistry(
+  { baseUrl = "wasm/", compile = defaultCompile } = {},
+) {
+  const compiled = new Map();
+
+  for (const moduleId of wasmModuleIds()) {
+    let promise;
+    try {
+      promise = Promise.resolve(compile(wasmModuleUrl(moduleId, baseUrl), moduleId));
+    } catch (error) {
+      promise = Promise.reject(error);
+    }
+    promise.catch(() => {});
+    compiled.set(moduleId, promise);
+  }
+
+  return compiled;
+}
+
 export async function compileWasmModuleGraph(
   id,
   { baseUrl = "wasm/", compile = defaultCompile } = {},
 ) {
-  const graphIds = wasmModuleGraphIds(id);
+  wasmModuleGraphIds(id);
+  const compiled = compileWasmModuleRegistry({ baseUrl, compile });
   const compiledEntries = await Promise.all(
-    graphIds.map(async (moduleId) => [
-      moduleId,
-      await compile(wasmModuleUrl(moduleId, baseUrl), moduleId),
-    ]),
+    [...compiled].map(async ([moduleId, promise]) => [moduleId, await promise]),
   );
 
   return new Map(compiledEntries);
@@ -156,32 +173,59 @@ export async function instantiateWasmModule(
 ) {
   const imports = { ...baseImports };
   const instances = new Map();
-  const graphIds = wasmModuleGraphIds(id);
-  const compiled = await compileWasmModuleGraph(id, { baseUrl, compile });
+  wasmModuleGraphIds(id);
+  const compiled = compileWasmModuleRegistry({ baseUrl, compile });
+  const instantiating = new Map();
 
-  for (const moduleId of graphIds) {
+  async function instantiateModule(moduleId) {
+    if (instances.has(moduleId)) {
+      return instances.get(moduleId);
+    }
+    if (instantiating.has(moduleId)) {
+      return instantiating.get(moduleId);
+    }
+
+    const promise = (async () => {
+      await Promise.all(wasmModuleDependencies(moduleId).map(instantiateModule));
+
+      for (const dependency of wasmModuleDependencies(moduleId)) {
+        const dependencyExports = instances.get(dependency);
+        for (const alias of wasmModuleAliases(dependency)) {
+          imports[alias] = dependencyExports;
+        }
+      }
+
+      const exports = await instantiate(
+        await compiled.get(moduleId),
+        imports,
+        moduleId,
+        wasmModuleUrl(moduleId, baseUrl),
+      );
+      instances.set(moduleId, exports);
+
+      for (const alias of wasmModuleAliases(moduleId)) {
+        imports[alias] = exports;
+      }
+
+      return exports;
+    })();
+    instantiating.set(moduleId, promise);
+    return promise;
+  }
+
+  const exports = await instantiateModule(id);
+
+  for (const moduleId of wasmModuleGraphIds(id)) {
     for (const dependency of wasmModuleDependencies(moduleId)) {
       const dependencyExports = instances.get(dependency);
       for (const alias of wasmModuleAliases(dependency)) {
         imports[alias] = dependencyExports;
       }
     }
-
-    const exports = await instantiate(
-      compiled.get(moduleId),
-      imports,
-      moduleId,
-      wasmModuleUrl(moduleId, baseUrl),
-    );
-    instances.set(moduleId, exports);
-
-    for (const alias of wasmModuleAliases(moduleId)) {
-      imports[alias] = exports;
-    }
   }
 
   return {
-    exports: instances.get(id),
+    exports,
     imports,
   };
 }

--- a/host/wasm-modules.mjs
+++ b/host/wasm-modules.mjs
@@ -155,16 +155,13 @@ export async function instantiateWasmModule(
   } = {},
 ) {
   const imports = { ...baseImports };
-  const loaded = new Map();
+  const instances = new Map();
+  const graphIds = wasmModuleGraphIds(id);
   const compiled = await compileWasmModuleGraph(id, { baseUrl, compile });
 
-  async function load(moduleId) {
-    if (loaded.has(moduleId)) {
-      return loaded.get(moduleId);
-    }
-
+  for (const moduleId of graphIds) {
     for (const dependency of wasmModuleDependencies(moduleId)) {
-      const dependencyExports = await load(dependency);
+      const dependencyExports = instances.get(dependency);
       for (const alias of wasmModuleAliases(dependency)) {
         imports[alias] = dependencyExports;
       }
@@ -176,17 +173,15 @@ export async function instantiateWasmModule(
       moduleId,
       wasmModuleUrl(moduleId, baseUrl),
     );
-    loaded.set(moduleId, exports);
+    instances.set(moduleId, exports);
 
     for (const alias of wasmModuleAliases(moduleId)) {
       imports[alias] = exports;
     }
-
-    return exports;
   }
 
   return {
-    exports: await load(id),
+    exports: instances.get(id),
     imports,
   };
 }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   "scripts": {
     "build": "bash tools/build.sh",
     "build:cov": "bash tools/build-cov.sh",
-    "test": "npm run test:layout && npm run test:host-abi && npm run test:parser-state-abi && npm run test:bootstrap-lines && npm run test:wasm-modules && npm run test:wat && npm run test:watwat-probe && npm run test:assert-probes && npm run test:coverage-selftest && npm run test:cold-reload-index",
+    "test": "npm run test:layout && npm run test:host-abi && npm run test:parser-state-abi && npm run test:wasm-modules-abi && npm run test:wasm-modules-loader && npm run test:bootstrap-lines && npm run test:wasm-modules && npm run test:wat && npm run test:watwat-probe && npm run test:assert-probes && npm run test:coverage-selftest && npm run test:cold-reload-index",
     "test:layout": "node tools/generate-layout.js --check",
     "test:host-abi": "node tools/generate-host-abi.js --check",
     "test:parser-state-abi": "node tools/generate-parser-state-abi.js --check",
+    "test:wasm-modules-abi": "node tools/extract-wasm-modules.js --check",
+    "test:wasm-modules-loader": "node tools/generate-wasm-modules-abi.js --check",
     "test:bootstrap-lines": "bash tools/check-bootstrap-lines.sh",
     "test:wasm-modules": "node tools/wasm-modules-check.js",
     "test:wat": "node tools/watwat.js --harness tools/tracy-watwat-harness.js dist/wasm/*.test.wasm dist/wasm/std/*.test.wasm",

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -23,6 +23,8 @@ require_command sha256sum
 node "${ROOT_DIR}/tools/generate-layout.js" --check
 node "${ROOT_DIR}/tools/generate-host-abi.js" --check
 node "${ROOT_DIR}/tools/generate-parser-state-abi.js" --check
+node "${ROOT_DIR}/tools/extract-wasm-modules.js" --check
+node "${ROOT_DIR}/tools/generate-wasm-modules-abi.js" --check
 
 rm -rf "${DIST_DIR}"
 mkdir -p "${DIST_DIR}/wasm"

--- a/tools/extract-wasm-modules.js
+++ b/tools/extract-wasm-modules.js
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const { assembleWatFile, collectWatInputs } = require("./assemble-wat.js");
+const { TokenReader, WatParseError, skipWatList } = require("./wat-parser.js");
+
+const root = path.dirname(__dirname);
+const checkOnly = process.argv.includes("--check");
+const watRoot = path.join(root, "wat");
+const outputPath = path.join(root, "abi/wasm-modules.json");
+
+function toPosixPath(value) {
+  return value.split(path.sep).join("/");
+}
+
+function moduleIdForWatPath(relativePath) {
+  return relativePath.replace(/\.wat$/, "");
+}
+
+function wasmPathForModuleId(id) {
+  return `${id}.wasm`;
+}
+
+function aliasesForModuleId(id) {
+  if (!id.includes("/")) {
+    return [id];
+  }
+
+  return [path.posix.basename(id), id, `wat/${id}`];
+}
+
+async function listProductionWatFiles(dir = watRoot) {
+  const files = [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await listProductionWatFiles(entryPath));
+    } else if (entry.isFile() && entry.name.endsWith(".wat") && !entry.name.endsWith(".test.wat")) {
+      files.push(entryPath);
+    }
+  }
+
+  return files.sort();
+}
+
+async function scanImportNames(inputPath) {
+  const reader = new TokenReader(inputPath);
+  const imports = [];
+
+  async function scanList() {
+    while ((await reader.peek()).type !== ")") {
+      const token = await reader.next();
+      if (token.type !== "(") {
+        continue;
+      }
+
+      const head = await reader.next();
+      if (head.type === "atom" && head.value === "import") {
+        const moduleName = await reader.next();
+        if (moduleName.type === "string") {
+          imports.push(moduleName.raw.slice(1, -1));
+        }
+
+        await skipWatList(reader);
+      } else {
+        await scanList();
+      }
+    }
+
+    await reader.expect(")", "missing close paren");
+  }
+
+  try {
+    await reader.expect("(", "expected a single WAT module");
+    const moduleHead = await reader.next();
+    if (moduleHead.type !== "atom" || moduleHead.value !== "module") {
+      throw new WatParseError("expected a single WAT module", moduleHead.loc);
+    }
+
+    await scanList();
+    const trailing = await reader.next();
+    if (trailing.type !== "eof") {
+      throw new WatParseError("expected a single WAT module", trailing.loc);
+    }
+
+    return imports;
+  } finally {
+    await reader.close();
+  }
+}
+
+function buildAliasIndex(modules) {
+  const aliases = new Map();
+
+  for (const [id, module] of Object.entries(modules)) {
+    for (const alias of module.aliases) {
+      const existing = aliases.get(alias);
+      if (existing !== undefined && existing !== id) {
+        throw new Error(`duplicate wasm module alias ${alias}: ${existing} and ${id}`);
+      }
+
+      aliases.set(alias, id);
+    }
+  }
+
+  return aliases;
+}
+
+function resolveDependencies(importNames, aliasIndex) {
+  const dependencies = [];
+  const seen = new Set();
+
+  for (const importName of importNames) {
+    const id = aliasIndex.get(importName);
+    if (id === undefined || seen.has(id)) {
+      continue;
+    }
+
+    seen.add(id);
+    dependencies.push(id);
+  }
+
+  return dependencies;
+}
+
+async function scanModuleImports(watFile, tmpDir) {
+  const inputs = await collectWatInputs(watFile);
+  if (inputs.length === 1) {
+    return scanImportNames(watFile);
+  }
+
+  const assembledPath = path.join(tmpDir, toPosixPath(path.relative(watRoot, watFile)));
+  await assembleWatFile(watFile, assembledPath);
+  return scanImportNames(assembledPath);
+}
+
+async function extractWasmModules() {
+  const watFiles = await listProductionWatFiles();
+  const modules = {};
+
+  for (const watFile of watFiles) {
+    const relativePath = toPosixPath(path.relative(watRoot, watFile));
+    const id = moduleIdForWatPath(relativePath);
+
+    modules[id] = {
+      wasmPath: wasmPathForModuleId(id),
+      aliases: aliasesForModuleId(id),
+      dependencies: [],
+    };
+  }
+
+  const aliasIndex = buildAliasIndex(modules);
+  const importNamesById = new Map();
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tracy-wasm-modules-"));
+
+  try {
+    for (const watFile of watFiles) {
+      const relativePath = toPosixPath(path.relative(watRoot, watFile));
+      const id = moduleIdForWatPath(relativePath);
+      importNamesById.set(id, await scanModuleImports(watFile, tmpDir));
+    }
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+
+  for (const [id, importNames] of importNamesById.entries()) {
+    modules[id].dependencies = resolveDependencies(importNames, aliasIndex);
+  }
+
+  return { modules };
+}
+
+function renderJson(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+async function writeIfChanged(filePath, content) {
+  let previous = null;
+
+  try {
+    previous = await fs.readFile(filePath, "utf8");
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  if (previous === content) {
+    return false;
+  }
+
+  if (checkOnly) {
+    throw new Error(`${path.relative(root, filePath)} is out of date`);
+  }
+
+  await fs.writeFile(filePath, content);
+  return true;
+}
+
+async function main() {
+  const manifest = await extractWasmModules();
+  await writeIfChanged(outputPath, renderJson(manifest));
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.stack || error.message || String(error));
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  aliasesForModuleId,
+  extractWasmModules,
+  moduleIdForWatPath,
+  resolveDependencies,
+  scanImportNames,
+  wasmPathForModuleId,
+};

--- a/tools/generate-wasm-modules-abi.js
+++ b/tools/generate-wasm-modules-abi.js
@@ -140,16 +140,13 @@ export async function instantiateWasmModule(
   } = {},
 ) {
   const imports = { ...baseImports };
-  const loaded = new Map();
+  const instances = new Map();
+  const graphIds = wasmModuleGraphIds(id);
   const compiled = await compileWasmModuleGraph(id, { baseUrl, compile });
 
-  async function load(moduleId) {
-    if (loaded.has(moduleId)) {
-      return loaded.get(moduleId);
-    }
-
+  for (const moduleId of graphIds) {
     for (const dependency of wasmModuleDependencies(moduleId)) {
-      const dependencyExports = await load(dependency);
+      const dependencyExports = instances.get(dependency);
       for (const alias of wasmModuleAliases(dependency)) {
         imports[alias] = dependencyExports;
       }
@@ -161,17 +158,15 @@ export async function instantiateWasmModule(
       moduleId,
       wasmModuleUrl(moduleId, baseUrl),
     );
-    loaded.set(moduleId, exports);
+    instances.set(moduleId, exports);
 
     for (const alias of wasmModuleAliases(moduleId)) {
       imports[alias] = exports;
     }
-
-    return exports;
   }
 
   return {
-    exports: await load(id),
+    exports: instances.get(id),
     imports,
   };
 }

--- a/tools/generate-wasm-modules-abi.js
+++ b/tools/generate-wasm-modules-abi.js
@@ -115,16 +115,33 @@ async function defaultInstantiate(module, imports) {
   return instance.exports;
 }
 
+function compileWasmModuleRegistry(
+  { baseUrl = "wasm/", compile = defaultCompile } = {},
+) {
+  const compiled = new Map();
+
+  for (const moduleId of wasmModuleIds()) {
+    let promise;
+    try {
+      promise = Promise.resolve(compile(wasmModuleUrl(moduleId, baseUrl), moduleId));
+    } catch (error) {
+      promise = Promise.reject(error);
+    }
+    promise.catch(() => {});
+    compiled.set(moduleId, promise);
+  }
+
+  return compiled;
+}
+
 export async function compileWasmModuleGraph(
   id,
   { baseUrl = "wasm/", compile = defaultCompile } = {},
 ) {
-  const graphIds = wasmModuleGraphIds(id);
+  wasmModuleGraphIds(id);
+  const compiled = compileWasmModuleRegistry({ baseUrl, compile });
   const compiledEntries = await Promise.all(
-    graphIds.map(async (moduleId) => [
-      moduleId,
-      await compile(wasmModuleUrl(moduleId, baseUrl), moduleId),
-    ]),
+    [...compiled].map(async ([moduleId, promise]) => [moduleId, await promise]),
   );
 
   return new Map(compiledEntries);
@@ -141,32 +158,59 @@ export async function instantiateWasmModule(
 ) {
   const imports = { ...baseImports };
   const instances = new Map();
-  const graphIds = wasmModuleGraphIds(id);
-  const compiled = await compileWasmModuleGraph(id, { baseUrl, compile });
+  wasmModuleGraphIds(id);
+  const compiled = compileWasmModuleRegistry({ baseUrl, compile });
+  const instantiating = new Map();
 
-  for (const moduleId of graphIds) {
+  async function instantiateModule(moduleId) {
+    if (instances.has(moduleId)) {
+      return instances.get(moduleId);
+    }
+    if (instantiating.has(moduleId)) {
+      return instantiating.get(moduleId);
+    }
+
+    const promise = (async () => {
+      await Promise.all(wasmModuleDependencies(moduleId).map(instantiateModule));
+
+      for (const dependency of wasmModuleDependencies(moduleId)) {
+        const dependencyExports = instances.get(dependency);
+        for (const alias of wasmModuleAliases(dependency)) {
+          imports[alias] = dependencyExports;
+        }
+      }
+
+      const exports = await instantiate(
+        await compiled.get(moduleId),
+        imports,
+        moduleId,
+        wasmModuleUrl(moduleId, baseUrl),
+      );
+      instances.set(moduleId, exports);
+
+      for (const alias of wasmModuleAliases(moduleId)) {
+        imports[alias] = exports;
+      }
+
+      return exports;
+    })();
+    instantiating.set(moduleId, promise);
+    return promise;
+  }
+
+  const exports = await instantiateModule(id);
+
+  for (const moduleId of wasmModuleGraphIds(id)) {
     for (const dependency of wasmModuleDependencies(moduleId)) {
       const dependencyExports = instances.get(dependency);
       for (const alias of wasmModuleAliases(dependency)) {
         imports[alias] = dependencyExports;
       }
     }
-
-    const exports = await instantiate(
-      compiled.get(moduleId),
-      imports,
-      moduleId,
-      wasmModuleUrl(moduleId, baseUrl),
-    );
-    instances.set(moduleId, exports);
-
-    for (const alias of wasmModuleAliases(moduleId)) {
-      imports[alias] = exports;
-    }
   }
 
   return {
-    exports: instances.get(id),
+    exports,
     imports,
   };
 }

--- a/tools/generate-wasm-modules-abi.js
+++ b/tools/generate-wasm-modules-abi.js
@@ -82,28 +82,27 @@ export function wasmModuleUrl(id, baseUrl = "wasm/") {
   return \`\${baseUrl.replace(/\\/?$/, "/")}\${wasmModulePath(id)}\`;
 }
 
-function appendWasmModuleGraph(id, ordered, seen, active) {
+function collectWasmModuleGraph(id, collected, active) {
   if (active.has(id)) {
     throw new Error(\`recursive wasm module dependency: \${id}\`);
   }
-  if (seen.has(id)) {
+  if (collected.has(id)) {
     return;
   }
 
   active.add(id);
   for (const dependency of wasmModuleDependencies(id)) {
-    appendWasmModuleGraph(dependency, ordered, seen, active);
+    collectWasmModuleGraph(dependency, collected, active);
   }
   active.delete(id);
 
-  seen.add(id);
-  ordered.push(id);
+  collected.add(id);
 }
 
 export function wasmModuleGraphIds(id) {
-  const ordered = [];
-  appendWasmModuleGraph(id, ordered, new Set(), new Set());
-  return Object.freeze(ordered);
+  const graphIds = new Set();
+  collectWasmModuleGraph(id, graphIds, new Set());
+  return Object.freeze([...graphIds].sort());
 }
 
 async function defaultCompile(url) {

--- a/tools/generate-wasm-modules-abi.js
+++ b/tools/generate-wasm-modules-abi.js
@@ -1,71 +1,56 @@
-// Generated from abi/wasm-modules.json by tools/generate-wasm-modules-abi.js.
-// Do not edit host/wasm-modules.mjs by hand.
+#!/usr/bin/env node
 
-export const WASM_MODULES = Object.freeze({
-  "app": Object.freeze({
-    wasmPath: "app.wasm",
-    aliases: Object.freeze(["app"]),
-    dependencies: Object.freeze([]),
-  }),
-  "index": Object.freeze({
-    wasmPath: "index.wasm",
-    aliases: Object.freeze(["index"]),
-    dependencies: Object.freeze(["std/mem"]),
-  }),
-  "parser": Object.freeze({
-    wasmPath: "parser.wasm",
-    aliases: Object.freeze(["parser"]),
-    dependencies: Object.freeze(["std/mem", "std/strtab", "parser_state"]),
-  }),
-  "parser_state": Object.freeze({
-    wasmPath: "parser_state.wasm",
-    aliases: Object.freeze(["parser_state"]),
-    dependencies: Object.freeze([]),
-  }),
-  "std/alloc": Object.freeze({
-    wasmPath: "std/alloc.wasm",
-    aliases: Object.freeze(["alloc", "std/alloc", "wat/std/alloc"]),
-    dependencies: Object.freeze([]),
-  }),
-  "std/array": Object.freeze({
-    wasmPath: "std/array.wasm",
-    aliases: Object.freeze(["array", "std/array", "wat/std/array"]),
-    dependencies: Object.freeze(["std/alloc"]),
-  }),
-  "std/assert": Object.freeze({
-    wasmPath: "std/assert.wasm",
-    aliases: Object.freeze(["assert", "std/assert", "wat/std/assert"]),
-    dependencies: Object.freeze([]),
-  }),
-  "std/hash": Object.freeze({
-    wasmPath: "std/hash.wasm",
-    aliases: Object.freeze(["hash", "std/hash", "wat/std/hash"]),
-    dependencies: Object.freeze(["std/alloc"]),
-  }),
-  "std/mem": Object.freeze({
-    wasmPath: "std/mem.wasm",
-    aliases: Object.freeze(["mem", "std/mem", "wat/std/mem"]),
-    dependencies: Object.freeze([]),
-  }),
-  "std/pool": Object.freeze({
-    wasmPath: "std/pool.wasm",
-    aliases: Object.freeze(["pool", "std/pool", "wat/std/pool"]),
-    dependencies: Object.freeze(["std/alloc"]),
-  }),
-  "std/ring": Object.freeze({
-    wasmPath: "std/ring.wasm",
-    aliases: Object.freeze(["ring", "std/ring", "wat/std/ring"]),
-    dependencies: Object.freeze(["std/alloc"]),
-  }),
-  "std/strtab": Object.freeze({
-    wasmPath: "std/strtab.wasm",
-    aliases: Object.freeze(["strtab", "std/strtab", "wat/std/strtab"]),
-    dependencies: Object.freeze(["std/alloc", "std/hash"]),
-  }),
-});
+const { readFileSync, writeFileSync } = require("node:fs");
+const { dirname, join } = require("node:path");
 
-function normalizePath(value) {
-  return String(value).replace(/\\/g, "/").replace(/^\.?\//, "");
+const root = dirname(__dirname);
+const checkOnly = process.argv.includes("--check");
+const sourcePath = join(root, "abi/wasm-modules.json");
+const source = JSON.parse(readFileSync(sourcePath, "utf8"));
+const modules = source.modules;
+
+function generatedHeader(kind) {
+  return [
+    "// Generated from abi/wasm-modules.json by tools/generate-wasm-modules-abi.js.",
+    `// Do not edit ${kind} by hand.`,
+  ].join("\n");
+}
+
+function readonlyArray(values) {
+  return `Object.freeze([${values.map((value) => JSON.stringify(value)).join(", ")}])`;
+}
+
+function renderModuleEntry(id, module) {
+  return [
+    `  ${JSON.stringify(id)}: Object.freeze({`,
+    `    wasmPath: ${JSON.stringify(module.wasmPath)},`,
+    `    aliases: ${readonlyArray(module.aliases)},`,
+    `    dependencies: ${readonlyArray(module.dependencies)},`,
+    "  }),",
+  ].join("\n");
+}
+
+function renderWasmModulesObject() {
+  const lines = [
+    "export const WASM_MODULES = Object.freeze({",
+  ];
+
+  for (const [id, module] of Object.entries(modules)) {
+    lines.push(renderModuleEntry(id, module));
+  }
+
+  lines.push("});");
+  return lines.join("\n");
+}
+
+function renderWasmModulesModule() {
+  return `${[
+    generatedHeader("host/wasm-modules.mjs"),
+    "",
+    renderWasmModulesObject(),
+    "",
+    `function normalizePath(value) {
+  return String(value).replace(/\\\\/g, "/").replace(/^\\.?\\//, "");
 }
 
 export function wasmModuleIds() {
@@ -75,7 +60,7 @@ export function wasmModuleIds() {
 export function wasmModule(id) {
   const module = WASM_MODULES[id];
   if (module === undefined) {
-    throw new Error(`unknown wasm module ${id}`);
+    throw new Error(\`unknown wasm module \${id}\`);
   }
 
   return module;
@@ -94,12 +79,12 @@ export function wasmModulePath(id) {
 }
 
 export function wasmModuleUrl(id, baseUrl = "wasm/") {
-  return `${baseUrl.replace(/\/?$/, "/")}${wasmModulePath(id)}`;
+  return \`\${baseUrl.replace(/\\/?$/, "/")}\${wasmModulePath(id)}\`;
 }
 
 function appendWasmModuleGraph(id, ordered, seen, active) {
   if (active.has(id)) {
-    throw new Error(`recursive wasm module dependency: ${id}`);
+    throw new Error(\`recursive wasm module dependency: \${id}\`);
   }
   if (seen.has(id)) {
     return;
@@ -201,4 +186,41 @@ export function wasmModuleIdForPath(value) {
   }
 
   return null;
+}`,
+  ].join("\n")}\n`;
 }
+
+function writeIfChanged(path, content) {
+  const absolute = join(root, path);
+  let previous = null;
+
+  try {
+    previous = readFileSync(absolute, "utf8");
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  if (previous === content) {
+    return true;
+  }
+
+  if (checkOnly) {
+    console.error(`${path} is out of date; run node tools/generate-wasm-modules-abi.js`);
+    return false;
+  }
+
+  writeFileSync(absolute, content);
+  return true;
+}
+
+const ok = writeIfChanged("host/wasm-modules.mjs", renderWasmModulesModule());
+
+if (!ok) {
+  process.exitCode = 1;
+}
+
+module.exports = {
+  renderWasmModulesModule,
+};

--- a/tools/instrument.js
+++ b/tools/instrument.js
@@ -3,6 +3,11 @@
 const fs = require("node:fs");
 const fsp = require("node:fs/promises");
 const path = require("node:path");
+const {
+  TokenReader,
+  WatParseError,
+  skipWatList,
+} = require("./wat-parser.js");
 
 const branchOpcodes = new Set(["br", "br_if", "br_table", "return", "unreachable"]);
 const controlBoundaryAtoms = new Set(["else", "end", "then"]);
@@ -21,221 +26,11 @@ const definitionHeads = new Set([
 const funcPreludeHeads = new Set(["export", "import", "local", "param", "result", "type"]);
 const blockPreludeHeads = new Set(["param", "result", "type"]);
 
-class WatParseError extends Error {
-  constructor(message, loc) {
-    super(`${message} at ${loc.line}:${loc.col}`);
-    this.name = "WatParseError";
-    this.loc = loc;
-  }
-}
-
-function locFor(index, line, col) {
-  return { index, line, col };
-}
-
 function manifestLoc(node) {
   return {
     line: node?.loc?.line ?? 1,
     col: node?.loc?.col ?? 1,
   };
-}
-
-class TokenReader {
-  constructor(inputPath) {
-    this.stream = fs.createReadStream(inputPath, { encoding: "utf8" });
-    this.iterator = this.stream[Symbol.asyncIterator]();
-    this.buffer = "";
-    this.done = false;
-    this.index = 0;
-    this.line = 1;
-    this.col = 1;
-    this.cache = [];
-  }
-
-  async close() {
-    this.stream.destroy();
-  }
-
-  async ensure(count) {
-    while (this.buffer.length < count && !this.done) {
-      const next = await this.iterator.next();
-      if (next.done) {
-        this.done = true;
-      } else {
-        this.buffer += next.value;
-      }
-    }
-  }
-
-  loc() {
-    return locFor(this.index, this.line, this.col);
-  }
-
-  async peekChar(offset = 0) {
-    await this.ensure(offset + 1);
-    return this.buffer[offset] ?? "";
-  }
-
-  advanceText(text) {
-    for (let i = 0; i < text.length; i += 1) {
-      this.index += 1;
-      if (text[i] === "\n") {
-        this.line += 1;
-        this.col = 1;
-      } else {
-        this.col += 1;
-      }
-    }
-    this.buffer = this.buffer.slice(text.length);
-  }
-
-  async takeChar() {
-    await this.ensure(1);
-    const char = this.buffer[0];
-    if (char !== undefined) {
-      this.advanceText(char);
-    }
-    return char ?? "";
-  }
-
-  async skipWhitespaceAndComments() {
-    while (true) {
-      const char = await this.peekChar();
-      const pair = `${char}${await this.peekChar(1)}`;
-
-      if (char === "") {
-        return;
-      }
-
-      if (/\s/.test(char)) {
-        await this.takeChar();
-      } else if (pair === ";;") {
-        while ((await this.peekChar()) !== "" && (await this.peekChar()) !== "\n") {
-          await this.takeChar();
-        }
-      } else if (pair === "(;") {
-        await this.skipBlockComment();
-      } else {
-        return;
-      }
-    }
-  }
-
-  async skipBlockComment() {
-    const start = this.loc();
-    let depth = 0;
-
-    while (true) {
-      const char = await this.peekChar();
-      const pair = `${char}${await this.peekChar(1)}`;
-
-      if (pair === "(;") {
-        depth += 1;
-        this.advanceText(pair);
-      } else if (pair === ";)") {
-        depth -= 1;
-        this.advanceText(pair);
-        if (depth === 0) {
-          return;
-        }
-      } else if (char === "") {
-        throw new WatParseError("unterminated block comment", start);
-      } else {
-        await this.takeChar();
-      }
-    }
-  }
-
-  async readStringToken() {
-    const start = this.loc();
-    let raw = await this.takeChar();
-
-    while (true) {
-      const char = await this.takeChar();
-      if (char === "") {
-        throw new WatParseError("unterminated string", start);
-      }
-
-      raw += char;
-      if (char === "\\") {
-        const escaped = await this.takeChar();
-        if (escaped === "") {
-          throw new WatParseError("unterminated string", start);
-        }
-        raw += escaped;
-      } else if (char === "\"") {
-        return { type: "string", raw, loc: start };
-      } else if (char === "\n") {
-        throw new WatParseError("unterminated string", start);
-      }
-    }
-  }
-
-  async readAtomToken() {
-    const start = this.loc();
-    let value = "";
-
-    while (true) {
-      const char = await this.peekChar();
-      const pair = `${char}${await this.peekChar(1)}`;
-
-      if (char === "" || /\s/.test(char) || char === "(" || char === ")" || pair === ";;" || pair === "(;") {
-        break;
-      }
-
-      value += await this.takeChar();
-    }
-
-    if (value.length === 0) {
-      throw new WatParseError(`unexpected character ${JSON.stringify(await this.peekChar())}`, start);
-    }
-
-    return { type: "atom", value, loc: start };
-  }
-
-  async readToken() {
-    await this.skipWhitespaceAndComments();
-    const start = this.loc();
-    const char = await this.peekChar();
-
-    if (char === "") {
-      return { type: "eof", loc: start };
-    }
-
-    if (char === "(" || char === ")") {
-      await this.takeChar();
-      return { type: char, loc: start };
-    }
-
-    if (char === "\"") {
-      return this.readStringToken();
-    }
-
-    return this.readAtomToken();
-  }
-
-  async peek(offset = 0) {
-    while (this.cache.length <= offset) {
-      this.cache.push(await this.readToken());
-    }
-    return this.cache[offset];
-  }
-
-  async next() {
-    if (this.cache.length > 0) {
-      return this.cache.shift();
-    }
-
-    return this.readToken();
-  }
-
-  async expect(type, message) {
-    const token = await this.next();
-    if (token.type !== type) {
-      throw new WatParseError(message, token.loc);
-    }
-    return token;
-  }
 }
 
 class WatStreamWriter {
@@ -561,20 +356,6 @@ async function parseSequence(reader, writer, state, context) {
   }
 }
 
-async function skipAny(reader) {
-  const token = await reader.next();
-  if (token.type === "(") {
-    await skipList(reader);
-  }
-}
-
-async function skipList(reader) {
-  while ((await reader.peek()).type !== ")") {
-    await skipAny(reader);
-  }
-  await reader.expect(")", "missing close paren");
-}
-
 async function scanCoverageImport(inputPath) {
   const reader = new TokenReader(inputPath);
 
@@ -593,7 +374,7 @@ async function scanCoverageImport(inputPath) {
 
       const head = await reader.next();
       if (head.type !== "atom" || head.value !== "import") {
-        await skipList(reader);
+        await skipWatList(reader);
         continue;
       }
 

--- a/tools/wasm-modules-check.js
+++ b/tools/wasm-modules-check.js
@@ -23,17 +23,21 @@ async function main() {
   assert.equal(wasmModuleUrl("std/strtab", "/assets/wasm"), "/assets/wasm/std/strtab.wasm");
 
   const compiledIds = [];
+  let compileCompleted = 0;
   const instantiatedIds = [];
   const { exports, imports } = await instantiateWasmModule(
     "parser",
     { env: { memory: "shared-memory" } },
     {
       baseUrl: "/assets/wasm",
-      compile(url, moduleId) {
+      async compile(url, moduleId) {
         compiledIds.push(moduleId);
-        return Promise.resolve({ moduleId, url });
+        await Promise.resolve();
+        compileCompleted += 1;
+        return { moduleId, url };
       },
       instantiate(module, moduleImports, moduleId, url) {
+        assert.equal(compileCompleted, compiledIds.length);
         assert.equal(module.moduleId, moduleId);
         assert.equal(module.url, url);
         assert.equal(moduleImports.env.memory, "shared-memory");

--- a/tools/wasm-modules-check.js
+++ b/tools/wasm-modules-check.js
@@ -83,6 +83,7 @@ async function main() {
   await testExtractorFixtures();
 
   const parserGraphIds = wasmModuleGraphIds("parser");
+  assert.deepEqual(parserGraphIds, [...parserGraphIds].sort());
   assert.deepEqual(new Set(parserGraphIds), new Set([
     "std/mem",
     "std/alloc",
@@ -91,11 +92,6 @@ async function main() {
     "parser_state",
     "parser",
   ]));
-  assertComesBefore(parserGraphIds, "std/mem", "parser");
-  assertComesBefore(parserGraphIds, "parser_state", "parser");
-  assertComesBefore(parserGraphIds, "std/alloc", "std/hash");
-  assertComesBefore(parserGraphIds, "std/hash", "std/strtab");
-  assertComesBefore(parserGraphIds, "std/strtab", "parser");
   assert.equal(wasmModuleUrl("std/strtab", "/assets/wasm"), "/assets/wasm/std/strtab.wasm");
 
   const registryModuleIds = wasmModuleIds();

--- a/tools/wasm-modules-check.js
+++ b/tools/wasm-modules-check.js
@@ -14,10 +14,10 @@ async function main() {
 
   assert.deepEqual(wasmModuleGraphIds("parser"), [
     "std/mem",
-    "parser_state",
     "std/alloc",
     "std/hash",
     "std/strtab",
+    "parser_state",
     "parser",
   ]);
   assert.equal(wasmModuleUrl("std/strtab", "/assets/wasm"), "/assets/wasm/std/strtab.wasm");
@@ -45,10 +45,10 @@ async function main() {
 
   assert.deepEqual(compiledIds, [
     "std/mem",
-    "parser_state",
     "std/alloc",
     "std/hash",
     "std/strtab",
+    "parser_state",
     "parser",
   ]);
   assert.deepEqual(instantiatedIds, compiledIds);

--- a/tools/wasm-modules-check.js
+++ b/tools/wasm-modules-check.js
@@ -1,29 +1,103 @@
 #!/usr/bin/env node
 
 const assert = require("node:assert/strict");
+const fs = require("node:fs/promises");
+const os = require("node:os");
 const path = require("node:path");
 const { pathToFileURL } = require("node:url");
+const {
+  aliasesForModuleId,
+  extractWasmModules,
+  resolveDependencies,
+  scanImportNames,
+} = require("./extract-wasm-modules.js");
+
+async function withFixtureWat(source, callback) {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tracy-wasm-modules-test-"));
+  const fixturePath = path.join(tmpDir, "fixture.wat");
+
+  try {
+    await fs.writeFile(fixturePath, source);
+    return await callback(fixturePath);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+async function testExtractorFixtures() {
+  assert.deepEqual(aliasesForModuleId("parser"), ["parser"]);
+  assert.deepEqual(aliasesForModuleId("std/strtab"), ["strtab", "std/strtab", "wat/std/strtab"]);
+
+  await withFixtureWat("(module)\n", async (fixturePath) => {
+    assert.deepEqual(await scanImportNames(fixturePath), []);
+  });
+
+  await withFixtureWat(
+    `(module
+      ;; (import "comment-line" "ignored" (func))
+      (; (import "comment-block" "ignored" (func)) ;)
+      (import "env" "memory" (memory 1))
+      (func (import "peer" "folded"))
+      (func $body
+        (block
+          i32.const 1))
+      (import "peer" "again" (func))
+    )
+`,
+    async (fixturePath) => {
+      assert.deepEqual(await scanImportNames(fixturePath), ["env", "peer", "peer"]);
+    },
+  );
+
+  const aliasIndex = new Map([
+    ["peer", "std/peer"],
+    ["wat/std/peer", "std/peer"],
+  ]);
+  assert.deepEqual(
+    resolveDependencies(["env", "peer", "wat/std/peer", "host"], aliasIndex),
+    ["std/peer"],
+  );
+
+  const manifest = await extractWasmModules();
+  assert.deepEqual(manifest.modules.app.dependencies, []);
+  assert.deepEqual(manifest.modules.index.dependencies, ["std/mem"]);
+  assert.deepEqual(manifest.modules.parser.dependencies, ["std/mem", "std/strtab", "parser_state"]);
+}
+
+function assertComesBefore(values, before, after) {
+  assert(values.includes(before), `${before} missing from ${JSON.stringify(values)}`);
+  assert(values.includes(after), `${after} missing from ${JSON.stringify(values)}`);
+  assert(values.indexOf(before) < values.indexOf(after), `${before} should be ready before ${after}`);
+}
 
 async function main() {
   const manifestUrl = pathToFileURL(path.resolve(__dirname, "../host/wasm-modules.mjs")).href;
   const {
     instantiateWasmModule,
     wasmModuleGraphIds,
+    wasmModuleIds,
     wasmModuleUrl,
   } = await import(manifestUrl);
 
-  assert.deepEqual(wasmModuleGraphIds("parser"), [
+  await testExtractorFixtures();
+
+  const parserGraphIds = wasmModuleGraphIds("parser");
+  assert.deepEqual(new Set(parserGraphIds), new Set([
     "std/mem",
     "std/alloc",
     "std/hash",
     "std/strtab",
     "parser_state",
     "parser",
-  ]);
+  ]));
+  assertComesBefore(parserGraphIds, "std/mem", "parser");
+  assertComesBefore(parserGraphIds, "parser_state", "parser");
+  assertComesBefore(parserGraphIds, "std/alloc", "std/hash");
+  assertComesBefore(parserGraphIds, "std/hash", "std/strtab");
+  assertComesBefore(parserGraphIds, "std/strtab", "parser");
   assert.equal(wasmModuleUrl("std/strtab", "/assets/wasm"), "/assets/wasm/std/strtab.wasm");
 
   const compiledIds = [];
-  let compileCompleted = 0;
   const instantiatedIds = [];
   const { exports, imports } = await instantiateWasmModule(
     "parser",
@@ -33,11 +107,9 @@ async function main() {
       async compile(url, moduleId) {
         compiledIds.push(moduleId);
         await Promise.resolve();
-        compileCompleted += 1;
         return { moduleId, url };
       },
       instantiate(module, moduleImports, moduleId, url) {
-        assert.equal(compileCompleted, compiledIds.length);
         assert.equal(module.moduleId, moduleId);
         assert.equal(module.url, url);
         assert.equal(moduleImports.env.memory, "shared-memory");
@@ -47,21 +119,39 @@ async function main() {
     },
   );
 
-  assert.deepEqual(compiledIds, [
-    "std/mem",
-    "std/alloc",
-    "std/hash",
-    "std/strtab",
-    "parser_state",
-    "parser",
-  ]);
-  assert.deepEqual(instantiatedIds, compiledIds);
+  assert.deepEqual(new Set(compiledIds), new Set(parserGraphIds));
+  assert.deepEqual(new Set(instantiatedIds), new Set(parserGraphIds));
+  assertComesBefore(instantiatedIds, "std/mem", "parser");
+  assertComesBefore(instantiatedIds, "parser_state", "parser");
+  assertComesBefore(instantiatedIds, "std/alloc", "std/hash");
+  assertComesBefore(instantiatedIds, "std/hash", "std/strtab");
+  assertComesBefore(instantiatedIds, "std/strtab", "parser");
   assert.equal(exports.moduleId, "parser");
   assert.equal(imports.mem.moduleId, "std/mem");
   assert.equal(imports.parser_state.moduleId, "parser_state");
   assert.equal(imports.alloc.moduleId, "std/alloc");
   assert.equal(imports.hash.moduleId, "std/hash");
   assert.equal(imports.strtab.moduleId, "std/strtab");
+
+  for (const moduleId of wasmModuleIds()) {
+    const loaded = await instantiateWasmModule(
+      moduleId,
+      { env: { memory: "shared-memory" } },
+      {
+        baseUrl: "/assets/wasm",
+        compile(url, compiledModuleId) {
+          return Promise.resolve({ moduleId: compiledModuleId, url });
+        },
+        instantiate(module, moduleImports, instantiatedModuleId) {
+          assert.equal(module.moduleId, instantiatedModuleId);
+          assert.equal(moduleImports.env.memory, "shared-memory");
+          return Promise.resolve({ moduleId: instantiatedModuleId });
+        },
+      },
+    );
+
+    assert.equal(loaded.exports.moduleId, moduleId);
+  }
 }
 
 main().catch((error) => {

--- a/tools/wasm-modules-check.js
+++ b/tools/wasm-modules-check.js
@@ -73,6 +73,7 @@ function assertComesBefore(values, before, after) {
 async function main() {
   const manifestUrl = pathToFileURL(path.resolve(__dirname, "../host/wasm-modules.mjs")).href;
   const {
+    compileWasmModuleGraph,
     instantiateWasmModule,
     wasmModuleGraphIds,
     wasmModuleIds,
@@ -97,7 +98,16 @@ async function main() {
   assertComesBefore(parserGraphIds, "std/strtab", "parser");
   assert.equal(wasmModuleUrl("std/strtab", "/assets/wasm"), "/assets/wasm/std/strtab.wasm");
 
-  const compiledIds = [];
+  const registryModuleIds = wasmModuleIds();
+  const compiledGraph = await compileWasmModuleGraph("parser", {
+    baseUrl: "/assets/wasm",
+    compile(url, moduleId) {
+      return Promise.resolve({ moduleId, url });
+    },
+  });
+  assert.deepEqual(new Set(compiledGraph.keys()), new Set(registryModuleIds));
+
+  const compileStartedIds = [];
   const instantiatedIds = [];
   const { exports, imports } = await instantiateWasmModule(
     "parser",
@@ -105,7 +115,10 @@ async function main() {
     {
       baseUrl: "/assets/wasm",
       async compile(url, moduleId) {
-        compiledIds.push(moduleId);
+        compileStartedIds.push(moduleId);
+        if (!parserGraphIds.includes(moduleId)) {
+          return new Promise(() => {});
+        }
         await Promise.resolve();
         return { moduleId, url };
       },
@@ -119,7 +132,7 @@ async function main() {
     },
   );
 
-  assert.deepEqual(new Set(compiledIds), new Set(parserGraphIds));
+  assert.deepEqual(new Set(compileStartedIds), new Set(registryModuleIds));
   assert.deepEqual(new Set(instantiatedIds), new Set(parserGraphIds));
   assertComesBefore(instantiatedIds, "std/mem", "parser");
   assertComesBefore(instantiatedIds, "parser_state", "parser");
@@ -133,7 +146,7 @@ async function main() {
   assert.equal(imports.hash.moduleId, "std/hash");
   assert.equal(imports.strtab.moduleId, "std/strtab");
 
-  for (const moduleId of wasmModuleIds()) {
+  for (const moduleId of registryModuleIds) {
     const loaded = await instantiateWasmModule(
       moduleId,
       { env: { memory: "shared-memory" } },

--- a/tools/wat-parser.js
+++ b/tools/wat-parser.js
@@ -1,0 +1,232 @@
+const fs = require("node:fs");
+
+class WatParseError extends Error {
+  constructor(message, loc) {
+    super(`${message} at ${loc.line}:${loc.col}`);
+    this.name = "WatParseError";
+    this.loc = loc;
+  }
+}
+
+function locFor(index, line, col) {
+  return { index, line, col };
+}
+
+class TokenReader {
+  constructor(inputPath) {
+    this.stream = fs.createReadStream(inputPath, { encoding: "utf8" });
+    this.iterator = this.stream[Symbol.asyncIterator]();
+    this.buffer = "";
+    this.done = false;
+    this.index = 0;
+    this.line = 1;
+    this.col = 1;
+    this.cache = [];
+  }
+
+  async close() {
+    this.stream.destroy();
+  }
+
+  async ensure(count) {
+    while (this.buffer.length < count && !this.done) {
+      const next = await this.iterator.next();
+      if (next.done) {
+        this.done = true;
+      } else {
+        this.buffer += next.value;
+      }
+    }
+  }
+
+  loc() {
+    return locFor(this.index, this.line, this.col);
+  }
+
+  async peekChar(offset = 0) {
+    await this.ensure(offset + 1);
+    return this.buffer[offset] ?? "";
+  }
+
+  advanceText(text) {
+    for (let i = 0; i < text.length; i += 1) {
+      this.index += 1;
+      if (text[i] === "\n") {
+        this.line += 1;
+        this.col = 1;
+      } else {
+        this.col += 1;
+      }
+    }
+    this.buffer = this.buffer.slice(text.length);
+  }
+
+  async takeChar() {
+    await this.ensure(1);
+    const char = this.buffer[0];
+    if (char !== undefined) {
+      this.advanceText(char);
+    }
+    return char ?? "";
+  }
+
+  async skipWhitespaceAndComments() {
+    while (true) {
+      const char = await this.peekChar();
+      const pair = `${char}${await this.peekChar(1)}`;
+
+      if (char === "") {
+        return;
+      }
+
+      if (/\s/.test(char)) {
+        await this.takeChar();
+      } else if (pair === ";;") {
+        while ((await this.peekChar()) !== "" && (await this.peekChar()) !== "\n") {
+          await this.takeChar();
+        }
+      } else if (pair === "(;") {
+        await this.skipBlockComment();
+      } else {
+        return;
+      }
+    }
+  }
+
+  async skipBlockComment() {
+    const start = this.loc();
+    let depth = 0;
+
+    while (true) {
+      const char = await this.peekChar();
+      const pair = `${char}${await this.peekChar(1)}`;
+
+      if (pair === "(;") {
+        depth += 1;
+        this.advanceText(pair);
+      } else if (pair === ";)") {
+        depth -= 1;
+        this.advanceText(pair);
+        if (depth === 0) {
+          return;
+        }
+      } else if (char === "") {
+        throw new WatParseError("unterminated block comment", start);
+      } else {
+        await this.takeChar();
+      }
+    }
+  }
+
+  async readStringToken() {
+    const start = this.loc();
+    let raw = await this.takeChar();
+
+    while (true) {
+      const char = await this.takeChar();
+      if (char === "") {
+        throw new WatParseError("unterminated string", start);
+      }
+
+      raw += char;
+      if (char === "\\") {
+        const escaped = await this.takeChar();
+        if (escaped === "") {
+          throw new WatParseError("unterminated string", start);
+        }
+        raw += escaped;
+      } else if (char === "\"") {
+        return { type: "string", raw, loc: start };
+      } else if (char === "\n") {
+        throw new WatParseError("unterminated string", start);
+      }
+    }
+  }
+
+  async readAtomToken() {
+    const start = this.loc();
+    let value = "";
+
+    while (true) {
+      const char = await this.peekChar();
+      const pair = `${char}${await this.peekChar(1)}`;
+
+      if (char === "" || /\s/.test(char) || char === "(" || char === ")" || pair === ";;" || pair === "(;") {
+        break;
+      }
+
+      value += await this.takeChar();
+    }
+
+    if (value.length === 0) {
+      throw new WatParseError(`unexpected character ${JSON.stringify(await this.peekChar())}`, start);
+    }
+
+    return { type: "atom", value, loc: start };
+  }
+
+  async readToken() {
+    await this.skipWhitespaceAndComments();
+    const start = this.loc();
+    const char = await this.peekChar();
+
+    if (char === "") {
+      return { type: "eof", loc: start };
+    }
+
+    if (char === "(" || char === ")") {
+      await this.takeChar();
+      return { type: char, loc: start };
+    }
+
+    if (char === "\"") {
+      return this.readStringToken();
+    }
+
+    return this.readAtomToken();
+  }
+
+  async peek(offset = 0) {
+    while (this.cache.length <= offset) {
+      this.cache.push(await this.readToken());
+    }
+    return this.cache[offset];
+  }
+
+  async next() {
+    if (this.cache.length > 0) {
+      return this.cache.shift();
+    }
+
+    return this.readToken();
+  }
+
+  async expect(type, message) {
+    const token = await this.next();
+    if (token.type !== type) {
+      throw new WatParseError(message, token.loc);
+    }
+    return token;
+  }
+}
+
+async function skipWatExpression(reader) {
+  const token = await reader.next();
+  if (token.type === "(") {
+    await skipWatList(reader);
+  }
+}
+
+async function skipWatList(reader) {
+  while ((await reader.peek()).type !== ")") {
+    await skipWatExpression(reader);
+  }
+  await reader.expect(")", "missing close paren");
+}
+
+module.exports = {
+  TokenReader,
+  WatParseError,
+  skipWatExpression,
+  skipWatList,
+};


### PR DESCRIPTION
Fixes #89.

Keeps WAT imports as the source of truth for Tracy's WASM module registry by generating the committed manifest and loader from that data. The remaining work starts fetch/compile eagerly across the registry and uses WAT import edges only as entry-point readiness DAGs, without exposing dependency order as loader behavior.

Fixes #89.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (7)</summary>

- [x] [Change the two-phase WASM loader so parallel compile/fetch starts eagerly, but root instantiation is not blocked on an unnecessary full-graph compile barrier; resolve when the requested root is ready while preserving dependency ordering and aliases.](https://github.com/rhencke/tracy/pull/102#issuecomment-4393078183) <!-- type:thread -->
- [x] [Remove dependency order as a loader/manifest feature: treat WAT imports as unordered readiness edges only, avoid observable topo/registry ordering, start compile/fetch eagerly, and await only the imported modules needed by the requested root.](https://github.com/rhencke/tracy/pull/102#discussion_r3198235787) <!-- type:thread -->
- [x] Add registry tests and drift checks <!-- type:spec -->
- [x] Use two-phase parallel WASM loading <!-- type:spec -->
- [x] Generate the wasm module loader from JSON <!-- type:spec -->
- [x] Extract wasm module metadata from WAT <!-- type:spec -->
- [x] Expose reusable WAT parser helpers <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->