### PR TITLE
v0.1 #36 — Background-thread ingest: parser + index builder in a Web Worker (closes #95)

### DIFF
--- a/abi/wasm-modules.json
+++ b/abi/wasm-modules.json
@@ -1,6 +1,7 @@
 {
   "modules": {
     "app": {
+      "thread": "main",
       "wasmPath": "app.wasm",
       "aliases": [
         "app"
@@ -8,6 +9,7 @@
       "dependencies": []
     },
     "index": {
+      "thread": "worker",
       "wasmPath": "index.wasm",
       "aliases": [
         "index"
@@ -17,6 +19,7 @@
       ]
     },
     "parser": {
+      "thread": "worker",
       "wasmPath": "parser.wasm",
       "aliases": [
         "parser"
@@ -28,6 +31,7 @@
       ]
     },
     "parser_state": {
+      "thread": "worker",
       "wasmPath": "parser_state.wasm",
       "aliases": [
         "parser_state"
@@ -35,6 +39,7 @@
       "dependencies": []
     },
     "std/alloc": {
+      "thread": "shared",
       "wasmPath": "std/alloc.wasm",
       "aliases": [
         "alloc",
@@ -44,6 +49,7 @@
       "dependencies": []
     },
     "std/array": {
+      "thread": "shared",
       "wasmPath": "std/array.wasm",
       "aliases": [
         "array",
@@ -55,6 +61,7 @@
       ]
     },
     "std/assert": {
+      "thread": "shared",
       "wasmPath": "std/assert.wasm",
       "aliases": [
         "assert",
@@ -64,6 +71,7 @@
       "dependencies": []
     },
     "std/hash": {
+      "thread": "shared",
       "wasmPath": "std/hash.wasm",
       "aliases": [
         "hash",
@@ -75,6 +83,7 @@
       ]
     },
     "std/mem": {
+      "thread": "shared",
       "wasmPath": "std/mem.wasm",
       "aliases": [
         "mem",
@@ -84,6 +93,7 @@
       "dependencies": []
     },
     "std/pool": {
+      "thread": "shared",
       "wasmPath": "std/pool.wasm",
       "aliases": [
         "pool",
@@ -95,6 +105,7 @@
       ]
     },
     "std/ring": {
+      "thread": "shared",
       "wasmPath": "std/ring.wasm",
       "aliases": [
         "ring",
@@ -106,6 +117,7 @@
       ]
     },
     "std/strtab": {
+      "thread": "shared",
       "wasmPath": "std/strtab.wasm",
       "aliases": [
         "strtab",

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1,4 +1,4 @@
-import { makeShim } from "./host/shim.mjs";
+import { makeMainThreadHost } from "./host/shim.mjs";
 import { runApp } from "./host/runtime.mjs";
 
 const memory = new WebAssembly.Memory({
@@ -7,4 +7,4 @@ const memory = new WebAssembly.Memory({
   shared: false,
 });
 
-runApp(memory, makeShim(memory));
+runApp(memory, makeMainThreadHost(memory));

--- a/host/ingest-worker-runtime.mjs
+++ b/host/ingest-worker-runtime.mjs
@@ -1,0 +1,305 @@
+import { makeWorkerThreadHost } from "./shim.mjs";
+import { HOST_IMPORT_NAME } from "./abi.mjs";
+import { instantiateWasmModuleForThread } from "./wasm-modules.mjs";
+
+export const INGEST_WORKER_MESSAGE = Object.freeze({
+  COMPLETE: "complete",
+  COVERED_RANGE: "covered_range",
+  ERROR: "error",
+  PROGRESS: "progress",
+  START: "start",
+});
+
+const WORKER_THREAD = "worker";
+const DEFAULT_MEMORY_INITIAL_PAGES = 8272;
+const DEFAULT_MEMORY_MAXIMUM_PAGES = 32768;
+const DEFAULT_STATE_PTR = 4096;
+const DEFAULT_WRITER_PAGE_PTR = 65536;
+const DEFAULT_DICT_EPOCH = 1;
+const DEFAULT_CHUNK_BYTES = 0;
+const DEFAULT_BYTE_BUDGET = 8192;
+const DEFAULT_NAME_PTR = 2048;
+const DEFAULT_COVERED_RANGE_INTERVAL_MS = 33;
+const TOKEN_OUTPUT_BASE = 5 * 1024 * 1024;
+
+function globalValue(value) {
+  return value instanceof WebAssembly.Global ? value.value : value;
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function makeDefaultMemory() {
+  return new WebAssembly.Memory({
+    initial: DEFAULT_MEMORY_INITIAL_PAGES,
+    maximum: DEFAULT_MEMORY_MAXIMUM_PAGES,
+  });
+}
+
+function writeName(memory, ptr, value) {
+  const encoded = new TextEncoder().encode(value);
+  const bytes = new Uint8Array(memory.buffer);
+  const end = ptr + encoded.byteLength;
+
+  if (end > bytes.byteLength) {
+    throw new Error(`worker ingest name does not fit in memory at ${ptr}`);
+  }
+
+  bytes.set(encoded, ptr);
+  return encoded.byteLength;
+}
+
+async function openNamedHostResource(memory, host, hostImport, name, namePtr) {
+  if (typeof name !== "string" || name.length === 0) {
+    throw new Error(`${hostImport} requires a non-empty name`);
+  }
+
+  const len = writeName(memory, namePtr, name);
+  return host[hostImport](namePtr, len);
+}
+
+function initAllocator(imports) {
+  const alloc = imports.alloc;
+  const mem = imports.mem;
+
+  if (alloc?.bump_init === undefined || mem === undefined) {
+    return;
+  }
+
+  alloc.bump_init(
+    globalValue(mem.MEM_HEAP_BASE),
+    globalValue(mem.MEM_STACK_BASE),
+  );
+}
+
+function readI64AsNumber(view, ptr) {
+  return Number(view.getBigUint64(ptr, true));
+}
+
+function parserFileOffset(memory, parserState, statePtr) {
+  const offset = globalValue(parserState.PARSER_STATE_FILE_OFFSET_OFFSET);
+  return readI64AsNumber(new DataView(memory.buffer), statePtr + offset);
+}
+
+function parserEventCount(memory, parserState, statePtr) {
+  const offset = globalValue(parserState.PARSER_STATE_EVENT_COUNT_OFFSET);
+  return new DataView(memory.buffer).getInt32(statePtr + offset, true);
+}
+
+function postCoveredRangeIfDue(state, force = false) {
+  const now = state.now();
+  if (!force && now - state.lastCoveredRangeAt < state.coveredRangeIntervalMs) {
+    return;
+  }
+
+  state.lastCoveredRangeAt = now;
+  state.postMessage({
+    type: INGEST_WORKER_MESSAGE.COVERED_RANGE,
+    start: 0,
+    end: parserFileOffset(state.memory, state.parserState, state.statePtr),
+  });
+}
+
+function postProgress(state, phase) {
+  state.postMessage({
+    type: INGEST_WORKER_MESSAGE.PROGRESS,
+    phase,
+    fileOffset: parserFileOffset(state.memory, state.parserState, state.statePtr),
+    parsedEvents: parserEventCount(state.memory, state.parserState, state.statePtr),
+    indexedEvents: state.index?.index_writer_committed_events?.() ?? 0,
+    committedPages: state.index?.index_writer_committed_pages?.() ?? 0,
+  });
+}
+
+async function instantiateIngestModules(options, memory, host) {
+  const instantiate =
+    options.instantiateWasmModuleForThread ?? instantiateWasmModuleForThread;
+  const moduleOptions = {
+    baseUrl: options.baseUrl ?? "wasm/",
+  };
+
+  if (options.compile !== undefined) {
+    moduleOptions.compile = options.compile;
+  }
+  if (options.instantiate !== undefined) {
+    moduleOptions.instantiate = options.instantiate;
+  }
+
+  const parserLoaded = await instantiate(
+    "parser",
+    WORKER_THREAD,
+    { env: { memory }, host },
+    moduleOptions,
+  );
+  const indexLoaded = await instantiate(
+    "index",
+    WORKER_THREAD,
+    { env: { memory }, host },
+    moduleOptions,
+  );
+
+  initAllocator(parserLoaded.imports);
+
+  return {
+    index: indexLoaded.exports,
+    parser: parserLoaded.exports,
+    parserState: parserLoaded.imports.parser_state,
+  };
+}
+
+async function resolveSourceId({ data, host, memory, namePtr }) {
+  if (Number.isInteger(data.sourceId)) {
+    return data.sourceId;
+  }
+
+  return openNamedHostResource(
+    memory,
+    host,
+    HOST_IMPORT_NAME.OPFS_SOURCE_OPEN,
+    data.sourceName,
+    namePtr,
+  );
+}
+
+async function resolveIndexId({ data, host, memory, namePtr }) {
+  if (Number.isInteger(data.indexId)) {
+    return data.indexId;
+  }
+
+  if (data.createIndex === false) {
+    return openNamedHostResource(
+      memory,
+      host,
+      HOST_IMPORT_NAME.OPFS_INDEX_OPEN,
+      data.indexName,
+      namePtr,
+    );
+  }
+
+  return openNamedHostResource(
+    memory,
+    host,
+    HOST_IMPORT_NAME.OPFS_INDEX_CREATE,
+    data.indexName,
+    namePtr,
+  );
+}
+
+export async function runWorkerIngest(data, options = {}) {
+  const memory = (options.memoryFactory ?? makeDefaultMemory)();
+  const host = (options.hostFactory ?? makeWorkerThreadHost)(memory);
+  const { parser, parserState, index } = await instantiateIngestModules(
+    options,
+    memory,
+    host,
+  );
+  const postMessage = options.postMessage ?? globalThis.postMessage?.bind(globalThis);
+
+  if (typeof postMessage !== "function") {
+    throw new Error("worker ingest runtime requires postMessage");
+  }
+
+  const statePtr = data.statePtr ?? DEFAULT_STATE_PTR;
+  const writerPagePtr = data.writerPagePtr ?? DEFAULT_WRITER_PAGE_PTR;
+  const dictEpoch = data.dictEpoch ?? DEFAULT_DICT_EPOCH;
+  const chunkBytes = data.chunkBytes ?? DEFAULT_CHUNK_BYTES;
+  const byteBudget = data.byteBudget ?? DEFAULT_BYTE_BUDGET;
+  const namePtr = data.namePtr ?? DEFAULT_NAME_PTR;
+  const sourceId = await resolveSourceId({ data, host, memory, namePtr });
+  const indexId = await resolveIndexId({ data, host, memory, namePtr });
+  const workerState = {
+    coveredRangeIntervalMs:
+      data.coveredRangeIntervalMs ?? DEFAULT_COVERED_RANGE_INTERVAL_MS,
+    index,
+    lastCoveredRangeAt: Number.NEGATIVE_INFINITY,
+    memory,
+    now: options.now ?? (() => performance.now()),
+    parserState,
+    postMessage,
+    statePtr,
+  };
+
+  parserState.parser_state_init(statePtr, sourceId);
+  index.index_writer_init(indexId, writerPagePtr, dictEpoch);
+  postProgress(workerState, "parse");
+
+  while (true) {
+    const status = parser.parser_parse_with_budget(
+      statePtr,
+      chunkBytes,
+      byteBudget,
+    );
+
+    postCoveredRangeIfDue(workerState);
+    if (status === globalValue(parserState.PARSER_STATUS_DONE)) {
+      break;
+    }
+    if (status !== globalValue(parserState.PARSER_STATUS_YIELDED)) {
+      throw new Error(`parser failed with status ${status}`);
+    }
+  }
+
+  postCoveredRangeIfDue(workerState, true);
+  postProgress(workerState, "index");
+  parser.extractor_init(data.tokenOutputPtr ?? TOKEN_OUTPUT_BASE);
+
+  let extractedEvents = 0;
+  while (true) {
+    const eventPtr = parser.extractor_next();
+    if (eventPtr === -1) {
+      break;
+    }
+
+    const appendStatus = index.index_add_event(eventPtr);
+    if (appendStatus !== globalValue(index.INDEX_INGEST_STATUS_OK)) {
+      throw new Error(`index ingest failed with status ${appendStatus}`);
+    }
+
+    extractedEvents += 1;
+  }
+
+  const flushStatus = index.index_writer_flush();
+  if (flushStatus !== globalValue(index.INDEX_WRITER_STATUS_OK)) {
+    throw new Error(`index flush failed with status ${flushStatus}`);
+  }
+
+  const result = {
+    committedEvents: index.index_writer_committed_events(),
+    committedPages: index.index_writer_committed_pages(),
+    extractedEvents,
+    indexedEvents: index.index_writer_committed_events(),
+    sourceId,
+    indexId,
+  };
+
+  postProgress(workerState, "complete");
+  postMessage({
+    type: INGEST_WORKER_MESSAGE.COMPLETE,
+    ...result,
+  });
+
+  return result;
+}
+
+export function createIngestWorkerMessageHandler(options = {}) {
+  const postMessage = options.postMessage ?? globalThis.postMessage?.bind(globalThis);
+  const runIngest = options.runWorkerIngest ?? runWorkerIngest;
+
+  return async function handleIngestWorkerMessage(event) {
+    const data = event?.data ?? event;
+
+    if (data?.type !== INGEST_WORKER_MESSAGE.START) {
+      return;
+    }
+
+    try {
+      await runIngest(data, { ...options, postMessage });
+    } catch (error) {
+      postMessage({
+        type: INGEST_WORKER_MESSAGE.ERROR,
+        message: errorMessage(error),
+      });
+    }
+  };
+}

--- a/host/opfs-source.mjs
+++ b/host/opfs-source.mjs
@@ -7,6 +7,49 @@ function makeUnsupportedHostImport(name, reason) {
   };
 }
 
+function makeHostImports(source, importNames) {
+  return Object.fromEntries(importNames.map((name) => [name, source[name]]));
+}
+
+const OPFS_SOURCE_IMPORTS = Object.freeze([
+  HOST_IMPORT_NAME.OPFS_CREATE_FROM_FILE,
+  HOST_IMPORT_NAME.OPFS_READ_CHUNK,
+  HOST_IMPORT_NAME.OPFS_SOURCE_FROM_FILE,
+  HOST_IMPORT_NAME.OPFS_SOURCE_NAME,
+  HOST_IMPORT_NAME.OPFS_SOURCE_NAME_LEN,
+  HOST_IMPORT_NAME.OPFS_SOURCE_OPEN,
+  HOST_IMPORT_NAME.OPFS_SOURCE_READ,
+  HOST_IMPORT_NAME.OPFS_SOURCE_SIZE,
+]);
+
+const OPFS_INDEX_READER_IMPORTS = Object.freeze([
+  HOST_IMPORT_NAME.OPFS_INDEX_OPEN,
+  HOST_IMPORT_NAME.OPFS_INDEX_READ,
+  HOST_IMPORT_NAME.OPFS_INDEX_SIZE,
+]);
+
+const OPFS_INDEX_WRITER_IMPORTS = Object.freeze([
+  HOST_IMPORT_NAME.OPFS_INDEX_CREATE,
+  HOST_IMPORT_NAME.OPFS_INDEX_FLUSH,
+  HOST_IMPORT_NAME.OPFS_INDEX_WRITE,
+]);
+
+const OPFS_MAIN_IMPORTS = Object.freeze([
+  ...OPFS_SOURCE_IMPORTS,
+  ...OPFS_INDEX_READER_IMPORTS,
+]);
+
+const OPFS_WORKER_IMPORTS = Object.freeze([
+  ...OPFS_SOURCE_IMPORTS,
+  ...OPFS_INDEX_READER_IMPORTS,
+  ...OPFS_INDEX_WRITER_IMPORTS,
+]);
+
+const WORKER_UNSUPPORTED_FILE_IMPORTS = Object.freeze([
+  HOST_IMPORT_NAME.OPFS_CREATE_FROM_FILE,
+  HOST_IMPORT_NAME.OPFS_SOURCE_FROM_FILE,
+]);
+
 export function makeOpfsSourceHost(memoryView, files = new Map()) {
   const sources = new Map();
   const indexes = new Map();
@@ -342,7 +385,7 @@ export function makeOpfsSourceHost(memoryView, files = new Map()) {
     }
   }
 
-  const sourceHost = {
+  const opfsHost = {
     [HOST_IMPORT_NAME.OPFS_CREATE_FROM_FILE]: opfsSourceFromFile,
     [HOST_IMPORT_NAME.OPFS_READ_CHUNK]: opfsSourceRead,
     [HOST_IMPORT_NAME.OPFS_SOURCE_FROM_FILE]: opfsSourceFromFile,
@@ -351,68 +394,33 @@ export function makeOpfsSourceHost(memoryView, files = new Map()) {
     [HOST_IMPORT_NAME.OPFS_SOURCE_OPEN]: opfsSourceOpen,
     [HOST_IMPORT_NAME.OPFS_SOURCE_READ]: opfsSourceRead,
     [HOST_IMPORT_NAME.OPFS_SOURCE_SIZE]: opfsSourceSize,
-  };
-
-  const indexReaderHost = {
     [HOST_IMPORT_NAME.OPFS_INDEX_OPEN]: opfsIndexOpen,
     [HOST_IMPORT_NAME.OPFS_INDEX_READ]: opfsIndexRead,
     [HOST_IMPORT_NAME.OPFS_INDEX_SIZE]: opfsIndexSize,
-  };
-
-  const indexWriterHost = {
     [HOST_IMPORT_NAME.OPFS_INDEX_CREATE]: opfsIndexCreate,
     [HOST_IMPORT_NAME.OPFS_INDEX_FLUSH]: opfsIndexFlush,
     [HOST_IMPORT_NAME.OPFS_INDEX_WRITE]: opfsIndexWrite,
   };
 
-  return {
-    ...sourceHost,
-    ...indexReaderHost,
-    ...indexWriterHost,
-  };
+  return makeHostImports(opfsHost, OPFS_WORKER_IMPORTS);
 }
 
 export function makeOpfsMainHost(memoryView, files = new Map()) {
   const opfsHost = makeOpfsSourceHost(memoryView, files);
 
-  return {
-    [HOST_IMPORT_NAME.OPFS_CREATE_FROM_FILE]: opfsHost[HOST_IMPORT_NAME.OPFS_CREATE_FROM_FILE],
-    [HOST_IMPORT_NAME.OPFS_READ_CHUNK]: opfsHost[HOST_IMPORT_NAME.OPFS_READ_CHUNK],
-    [HOST_IMPORT_NAME.OPFS_SOURCE_FROM_FILE]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_FROM_FILE],
-    [HOST_IMPORT_NAME.OPFS_SOURCE_NAME]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_NAME],
-    [HOST_IMPORT_NAME.OPFS_SOURCE_NAME_LEN]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_NAME_LEN],
-    [HOST_IMPORT_NAME.OPFS_SOURCE_OPEN]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_OPEN],
-    [HOST_IMPORT_NAME.OPFS_SOURCE_READ]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_READ],
-    [HOST_IMPORT_NAME.OPFS_SOURCE_SIZE]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_SIZE],
-    [HOST_IMPORT_NAME.OPFS_INDEX_OPEN]: opfsHost[HOST_IMPORT_NAME.OPFS_INDEX_OPEN],
-    [HOST_IMPORT_NAME.OPFS_INDEX_READ]: opfsHost[HOST_IMPORT_NAME.OPFS_INDEX_READ],
-    [HOST_IMPORT_NAME.OPFS_INDEX_SIZE]: opfsHost[HOST_IMPORT_NAME.OPFS_INDEX_SIZE],
-  };
+  return makeHostImports(opfsHost, OPFS_MAIN_IMPORTS);
 }
 
 export function makeOpfsWorkerHost(memoryView) {
   const opfsHost = makeOpfsSourceHost(memoryView);
+  const workerHost = makeHostImports(opfsHost, OPFS_WORKER_IMPORTS);
 
-  return {
-    [HOST_IMPORT_NAME.OPFS_CREATE_FROM_FILE]: makeUnsupportedHostImport(
-      HOST_IMPORT_NAME.OPFS_CREATE_FROM_FILE,
+  for (const name of WORKER_UNSUPPORTED_FILE_IMPORTS) {
+    workerHost[name] = makeUnsupportedHostImport(
+      name,
       "file handles are owned by the main thread",
-    ),
-    [HOST_IMPORT_NAME.OPFS_READ_CHUNK]: opfsHost[HOST_IMPORT_NAME.OPFS_READ_CHUNK],
-    [HOST_IMPORT_NAME.OPFS_SOURCE_FROM_FILE]: makeUnsupportedHostImport(
-      HOST_IMPORT_NAME.OPFS_SOURCE_FROM_FILE,
-      "file handles are owned by the main thread",
-    ),
-    [HOST_IMPORT_NAME.OPFS_SOURCE_NAME]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_NAME],
-    [HOST_IMPORT_NAME.OPFS_SOURCE_NAME_LEN]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_NAME_LEN],
-    [HOST_IMPORT_NAME.OPFS_SOURCE_OPEN]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_OPEN],
-    [HOST_IMPORT_NAME.OPFS_SOURCE_READ]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_READ],
-    [HOST_IMPORT_NAME.OPFS_SOURCE_SIZE]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_SIZE],
-    [HOST_IMPORT_NAME.OPFS_INDEX_CREATE]: opfsHost[HOST_IMPORT_NAME.OPFS_INDEX_CREATE],
-    [HOST_IMPORT_NAME.OPFS_INDEX_FLUSH]: opfsHost[HOST_IMPORT_NAME.OPFS_INDEX_FLUSH],
-    [HOST_IMPORT_NAME.OPFS_INDEX_OPEN]: opfsHost[HOST_IMPORT_NAME.OPFS_INDEX_OPEN],
-    [HOST_IMPORT_NAME.OPFS_INDEX_READ]: opfsHost[HOST_IMPORT_NAME.OPFS_INDEX_READ],
-    [HOST_IMPORT_NAME.OPFS_INDEX_SIZE]: opfsHost[HOST_IMPORT_NAME.OPFS_INDEX_SIZE],
-    [HOST_IMPORT_NAME.OPFS_INDEX_WRITE]: opfsHost[HOST_IMPORT_NAME.OPFS_INDEX_WRITE],
-  };
+    );
+  }
+
+  return workerHost;
 }

--- a/host/opfs-source.mjs
+++ b/host/opfs-source.mjs
@@ -1,7 +1,13 @@
 import { HOST_IMPORT_NAME } from "./abi.mjs";
 import { u64ToNumber } from "./memory.mjs";
 
-export function makeOpfsSourceHost(memoryView, files) {
+function makeUnsupportedHostImport(name, reason) {
+  return () => {
+    throw new Error(`${name}: ${reason}`);
+  };
+}
+
+export function makeOpfsSourceHost(memoryView, files = new Map()) {
   const sources = new Map();
   const indexes = new Map();
   let nextSourceId = 1;
@@ -336,13 +342,7 @@ export function makeOpfsSourceHost(memoryView, files) {
     }
   }
 
-  return {
-    [HOST_IMPORT_NAME.OPFS_INDEX_CREATE]: opfsIndexCreate,
-    [HOST_IMPORT_NAME.OPFS_INDEX_FLUSH]: opfsIndexFlush,
-    [HOST_IMPORT_NAME.OPFS_INDEX_OPEN]: opfsIndexOpen,
-    [HOST_IMPORT_NAME.OPFS_INDEX_READ]: opfsIndexRead,
-    [HOST_IMPORT_NAME.OPFS_INDEX_SIZE]: opfsIndexSize,
-    [HOST_IMPORT_NAME.OPFS_INDEX_WRITE]: opfsIndexWrite,
+  const sourceHost = {
     [HOST_IMPORT_NAME.OPFS_CREATE_FROM_FILE]: opfsSourceFromFile,
     [HOST_IMPORT_NAME.OPFS_READ_CHUNK]: opfsSourceRead,
     [HOST_IMPORT_NAME.OPFS_SOURCE_FROM_FILE]: opfsSourceFromFile,
@@ -351,5 +351,68 @@ export function makeOpfsSourceHost(memoryView, files) {
     [HOST_IMPORT_NAME.OPFS_SOURCE_OPEN]: opfsSourceOpen,
     [HOST_IMPORT_NAME.OPFS_SOURCE_READ]: opfsSourceRead,
     [HOST_IMPORT_NAME.OPFS_SOURCE_SIZE]: opfsSourceSize,
+  };
+
+  const indexReaderHost = {
+    [HOST_IMPORT_NAME.OPFS_INDEX_OPEN]: opfsIndexOpen,
+    [HOST_IMPORT_NAME.OPFS_INDEX_READ]: opfsIndexRead,
+    [HOST_IMPORT_NAME.OPFS_INDEX_SIZE]: opfsIndexSize,
+  };
+
+  const indexWriterHost = {
+    [HOST_IMPORT_NAME.OPFS_INDEX_CREATE]: opfsIndexCreate,
+    [HOST_IMPORT_NAME.OPFS_INDEX_FLUSH]: opfsIndexFlush,
+    [HOST_IMPORT_NAME.OPFS_INDEX_WRITE]: opfsIndexWrite,
+  };
+
+  return {
+    ...sourceHost,
+    ...indexReaderHost,
+    ...indexWriterHost,
+  };
+}
+
+export function makeOpfsMainHost(memoryView, files = new Map()) {
+  const opfsHost = makeOpfsSourceHost(memoryView, files);
+
+  return {
+    [HOST_IMPORT_NAME.OPFS_CREATE_FROM_FILE]: opfsHost[HOST_IMPORT_NAME.OPFS_CREATE_FROM_FILE],
+    [HOST_IMPORT_NAME.OPFS_READ_CHUNK]: opfsHost[HOST_IMPORT_NAME.OPFS_READ_CHUNK],
+    [HOST_IMPORT_NAME.OPFS_SOURCE_FROM_FILE]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_FROM_FILE],
+    [HOST_IMPORT_NAME.OPFS_SOURCE_NAME]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_NAME],
+    [HOST_IMPORT_NAME.OPFS_SOURCE_NAME_LEN]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_NAME_LEN],
+    [HOST_IMPORT_NAME.OPFS_SOURCE_OPEN]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_OPEN],
+    [HOST_IMPORT_NAME.OPFS_SOURCE_READ]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_READ],
+    [HOST_IMPORT_NAME.OPFS_SOURCE_SIZE]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_SIZE],
+    [HOST_IMPORT_NAME.OPFS_INDEX_OPEN]: opfsHost[HOST_IMPORT_NAME.OPFS_INDEX_OPEN],
+    [HOST_IMPORT_NAME.OPFS_INDEX_READ]: opfsHost[HOST_IMPORT_NAME.OPFS_INDEX_READ],
+    [HOST_IMPORT_NAME.OPFS_INDEX_SIZE]: opfsHost[HOST_IMPORT_NAME.OPFS_INDEX_SIZE],
+  };
+}
+
+export function makeOpfsWorkerHost(memoryView) {
+  const opfsHost = makeOpfsSourceHost(memoryView);
+
+  return {
+    [HOST_IMPORT_NAME.OPFS_CREATE_FROM_FILE]: makeUnsupportedHostImport(
+      HOST_IMPORT_NAME.OPFS_CREATE_FROM_FILE,
+      "file handles are owned by the main thread",
+    ),
+    [HOST_IMPORT_NAME.OPFS_READ_CHUNK]: opfsHost[HOST_IMPORT_NAME.OPFS_READ_CHUNK],
+    [HOST_IMPORT_NAME.OPFS_SOURCE_FROM_FILE]: makeUnsupportedHostImport(
+      HOST_IMPORT_NAME.OPFS_SOURCE_FROM_FILE,
+      "file handles are owned by the main thread",
+    ),
+    [HOST_IMPORT_NAME.OPFS_SOURCE_NAME]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_NAME],
+    [HOST_IMPORT_NAME.OPFS_SOURCE_NAME_LEN]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_NAME_LEN],
+    [HOST_IMPORT_NAME.OPFS_SOURCE_OPEN]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_OPEN],
+    [HOST_IMPORT_NAME.OPFS_SOURCE_READ]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_READ],
+    [HOST_IMPORT_NAME.OPFS_SOURCE_SIZE]: opfsHost[HOST_IMPORT_NAME.OPFS_SOURCE_SIZE],
+    [HOST_IMPORT_NAME.OPFS_INDEX_CREATE]: opfsHost[HOST_IMPORT_NAME.OPFS_INDEX_CREATE],
+    [HOST_IMPORT_NAME.OPFS_INDEX_FLUSH]: opfsHost[HOST_IMPORT_NAME.OPFS_INDEX_FLUSH],
+    [HOST_IMPORT_NAME.OPFS_INDEX_OPEN]: opfsHost[HOST_IMPORT_NAME.OPFS_INDEX_OPEN],
+    [HOST_IMPORT_NAME.OPFS_INDEX_READ]: opfsHost[HOST_IMPORT_NAME.OPFS_INDEX_READ],
+    [HOST_IMPORT_NAME.OPFS_INDEX_SIZE]: opfsHost[HOST_IMPORT_NAME.OPFS_INDEX_SIZE],
+    [HOST_IMPORT_NAME.OPFS_INDEX_WRITE]: opfsHost[HOST_IMPORT_NAME.OPFS_INDEX_WRITE],
   };
 }

--- a/host/runtime.mjs
+++ b/host/runtime.mjs
@@ -1,7 +1,137 @@
 import { HOST_ASYNC_IMPORTS } from "./abi.mjs";
-import { instantiateWasmModule } from "./wasm-modules.mjs";
+import { INGEST_WORKER_MESSAGE } from "./ingest-worker-runtime.mjs";
+import { instantiateWasmModuleForThread } from "./wasm-modules.mjs";
 
 const asyncHostImports = new Set(HOST_ASYNC_IMPORTS);
+const MAIN_THREAD = "main";
+const WORKER_URL = "worker.bundle.js";
+
+function cloneWorkerStatus(status) {
+  return {
+    coveredRange: status.coveredRange,
+    error: status.error,
+    progress: status.progress,
+    result: status.result,
+    state: status.state,
+  };
+}
+
+function notifyWorkerStatus(status, options, message) {
+  const snapshot = cloneWorkerStatus(status);
+
+  options.onWorkerStatus?.(snapshot, message);
+  return snapshot;
+}
+
+export function createIngestWorkerController(options = {}) {
+  const WorkerCtor = options.Worker ?? globalThis.Worker;
+  const status = {
+    coveredRange: null,
+    error: null,
+    progress: null,
+    result: null,
+    state: "idle",
+  };
+
+  if (typeof WorkerCtor !== "function") {
+    status.state = "unavailable";
+    status.error = "module workers are unavailable";
+    notifyWorkerStatus(status, options, null);
+
+    return {
+      start() {
+        notifyWorkerStatus(status, options, null);
+        return false;
+      },
+      status() {
+        return cloneWorkerStatus(status);
+      },
+      terminate() {},
+      worker: null,
+    };
+  }
+
+  let worker;
+  try {
+    worker = new WorkerCtor(options.workerUrl ?? WORKER_URL, { type: "module" });
+  } catch (error) {
+    status.state = "error";
+    status.error = error instanceof Error ? error.message : String(error);
+    notifyWorkerStatus(status, options, null);
+
+    return {
+      start() {
+        notifyWorkerStatus(status, options, null);
+        return false;
+      },
+      status() {
+        return cloneWorkerStatus(status);
+      },
+      terminate() {},
+      worker: null,
+    };
+  }
+
+  function handleWorkerMessage(event) {
+    const message = event?.data ?? event;
+
+    if (message?.type === INGEST_WORKER_MESSAGE.PROGRESS) {
+      status.progress = message;
+      status.state = "running";
+    } else if (message?.type === INGEST_WORKER_MESSAGE.COVERED_RANGE) {
+      status.coveredRange = message;
+      status.state = "running";
+    } else if (message?.type === INGEST_WORKER_MESSAGE.COMPLETE) {
+      status.result = message;
+      status.state = "complete";
+    } else if (message?.type === INGEST_WORKER_MESSAGE.ERROR) {
+      status.error = message.message ?? "worker ingest failed";
+      status.state = "error";
+    } else {
+      return;
+    }
+
+    notifyWorkerStatus(status, options, message);
+  }
+
+  function handleWorkerError(event) {
+    status.state = "error";
+    status.error = event?.message ?? "ingest worker failed";
+    notifyWorkerStatus(status, options, event);
+  }
+
+  if (typeof worker.addEventListener === "function") {
+    worker.addEventListener("message", handleWorkerMessage);
+    worker.addEventListener("error", handleWorkerError);
+    worker.addEventListener("messageerror", handleWorkerError);
+  } else {
+    worker.onmessage = handleWorkerMessage;
+    worker.onerror = handleWorkerError;
+  }
+
+  return {
+    start(data = {}) {
+      status.state = "running";
+      status.error = null;
+      status.result = null;
+      notifyWorkerStatus(status, options, null);
+      worker.postMessage({
+        ...data,
+        type: INGEST_WORKER_MESSAGE.START,
+      });
+      return true;
+    },
+    status() {
+      return cloneWorkerStatus(status);
+    },
+    terminate() {
+      worker.terminate?.();
+      status.state = "terminated";
+      notifyWorkerStatus(status, options, null);
+    },
+    worker,
+  };
+}
 
 function supportsJSPI() {
   return typeof WebAssembly.Suspending === "function";
@@ -39,7 +169,7 @@ function wrapAsyncHostImports(host) {
   );
 }
 
-async function loadApp(memory, host) {
+async function loadApp(memory, host, options = {}) {
   if (!supportsJSPI()) {
     showError(
       "tracy needs a browser with WebAssembly JavaScript Promise Integration (JSPI) enabled.",
@@ -48,7 +178,12 @@ async function loadApp(memory, host) {
   }
 
   const imports = { env: { memory }, host: wrapAsyncHostImports(host) };
-  const { exports } = await instantiateWasmModule("app", imports);
+  const instantiate = options.instantiateWasmModuleForThread ?? instantiateWasmModuleForThread;
+  const { exports } = await instantiate("app", MAIN_THREAD, imports, {
+    baseUrl: options.baseUrl ?? "wasm/",
+    compile: options.compile,
+    instantiate: options.instantiate,
+  });
   const { tracy_main, tracy_tick } = exports;
 
   tracy_main();
@@ -59,11 +194,22 @@ async function loadApp(memory, host) {
   };
 
   requestAnimationFrame(loop);
+
+  if (options.ingest !== undefined) {
+    options.ingestWorker?.start(
+      options.ingest === true ? {} : options.ingest,
+    );
+  }
 }
 
-export function runApp(memory, host) {
-  loadApp(memory, host).catch((error) => {
+export function runApp(memory, host, options = {}) {
+  const ingestWorker =
+    options.ingestWorker ?? createIngestWorkerController(options.worker ?? {});
+
+  loadApp(memory, host, { ...options, ingestWorker }).catch((error) => {
     console.error(error);
     showError("tracy failed to load the WebAssembly viewer.");
   });
+
+  return ingestWorker;
 }

--- a/host/shim.mjs
+++ b/host/shim.mjs
@@ -1,18 +1,45 @@
 import { makeCanvasHost } from "./canvas.mjs";
 import { makeFilePickerHost } from "./file-picker.mjs";
 import { makeMemoryView } from "./memory.mjs";
-import { makeOpfsSourceHost } from "./opfs-source.mjs";
+import {
+  makeOpfsMainHost,
+  makeOpfsSourceHost,
+  makeOpfsWorkerHost,
+} from "./opfs-source.mjs";
 import { makePointerHost } from "./pointer.mjs";
 
-export function makeShim(memory) {
+function makeBrowserHost(memoryView) {
   const canvas = document.getElementById("tracy");
-  const memoryView = makeMemoryView(memory);
   const { files, ...fileHost } = makeFilePickerHost(memoryView);
 
   return {
+    files,
     ...makeCanvasHost(canvas, memoryView),
     ...fileHost,
-    ...makeOpfsSourceHost(memoryView, files),
     ...makePointerHost(canvas, memoryView),
+  };
+}
+
+export function makeMainThreadHost(memory) {
+  const memoryView = makeMemoryView(memory);
+  const { files, ...browserHost } = makeBrowserHost(memoryView);
+
+  return {
+    ...browserHost,
+    ...makeOpfsMainHost(memoryView, files),
+  };
+}
+
+export function makeWorkerThreadHost(memory) {
+  return makeOpfsWorkerHost(makeMemoryView(memory));
+}
+
+export function makeShim(memory) {
+  const memoryView = makeMemoryView(memory);
+  const { files, ...browserHost } = makeBrowserHost(memoryView);
+
+  return {
+    ...browserHost,
+    ...makeOpfsSourceHost(memoryView, files),
   };
 }

--- a/host/wasm-modules.mjs
+++ b/host/wasm-modules.mjs
@@ -3,61 +3,73 @@
 
 export const WASM_MODULES = Object.freeze({
   "app": Object.freeze({
+    thread: "main",
     wasmPath: "app.wasm",
     aliases: Object.freeze(["app"]),
     dependencies: Object.freeze([]),
   }),
   "index": Object.freeze({
+    thread: "worker",
     wasmPath: "index.wasm",
     aliases: Object.freeze(["index"]),
     dependencies: Object.freeze(["std/mem"]),
   }),
   "parser": Object.freeze({
+    thread: "worker",
     wasmPath: "parser.wasm",
     aliases: Object.freeze(["parser"]),
     dependencies: Object.freeze(["std/mem", "std/strtab", "parser_state"]),
   }),
   "parser_state": Object.freeze({
+    thread: "worker",
     wasmPath: "parser_state.wasm",
     aliases: Object.freeze(["parser_state"]),
     dependencies: Object.freeze([]),
   }),
   "std/alloc": Object.freeze({
+    thread: "shared",
     wasmPath: "std/alloc.wasm",
     aliases: Object.freeze(["alloc", "std/alloc", "wat/std/alloc"]),
     dependencies: Object.freeze([]),
   }),
   "std/array": Object.freeze({
+    thread: "shared",
     wasmPath: "std/array.wasm",
     aliases: Object.freeze(["array", "std/array", "wat/std/array"]),
     dependencies: Object.freeze(["std/alloc"]),
   }),
   "std/assert": Object.freeze({
+    thread: "shared",
     wasmPath: "std/assert.wasm",
     aliases: Object.freeze(["assert", "std/assert", "wat/std/assert"]),
     dependencies: Object.freeze([]),
   }),
   "std/hash": Object.freeze({
+    thread: "shared",
     wasmPath: "std/hash.wasm",
     aliases: Object.freeze(["hash", "std/hash", "wat/std/hash"]),
     dependencies: Object.freeze(["std/alloc"]),
   }),
   "std/mem": Object.freeze({
+    thread: "shared",
     wasmPath: "std/mem.wasm",
     aliases: Object.freeze(["mem", "std/mem", "wat/std/mem"]),
     dependencies: Object.freeze([]),
   }),
   "std/pool": Object.freeze({
+    thread: "shared",
     wasmPath: "std/pool.wasm",
     aliases: Object.freeze(["pool", "std/pool", "wat/std/pool"]),
     dependencies: Object.freeze(["std/alloc"]),
   }),
   "std/ring": Object.freeze({
+    thread: "shared",
     wasmPath: "std/ring.wasm",
     aliases: Object.freeze(["ring", "std/ring", "wat/std/ring"]),
     dependencies: Object.freeze(["std/alloc"]),
   }),
   "std/strtab": Object.freeze({
+    thread: "shared",
     wasmPath: "std/strtab.wasm",
     aliases: Object.freeze(["strtab", "std/strtab", "wat/std/strtab"]),
     dependencies: Object.freeze(["std/alloc", "std/hash"]),
@@ -66,6 +78,14 @@ export const WASM_MODULES = Object.freeze({
 
 function normalizePath(value) {
   return String(value).replace(/\\/g, "/").replace(/^\.?\//, "");
+}
+
+const WASM_MODULE_THREADS = Object.freeze(["main", "worker", "shared"]);
+
+function assertWasmModuleThread(thread) {
+  if (!WASM_MODULE_THREADS.includes(thread)) {
+    throw new Error(`unknown wasm module thread ${thread}`);
+  }
 }
 
 export function wasmModuleIds() {
@@ -89,12 +109,29 @@ export function wasmModuleDependencies(id) {
   return wasmModule(id).dependencies;
 }
 
+export function wasmModuleThread(id) {
+  return wasmModule(id).thread;
+}
+
 export function wasmModulePath(id) {
   return wasmModule(id).wasmPath;
 }
 
 export function wasmModuleUrl(id, baseUrl = "wasm/") {
   return `${baseUrl.replace(/\/?$/, "/")}${wasmModulePath(id)}`;
+}
+
+export function wasmModuleRunsOnThread(id, thread) {
+  assertWasmModuleThread(thread);
+  const moduleThread = wasmModuleThread(id);
+  return moduleThread === thread || moduleThread === "shared";
+}
+
+export function wasmModuleIdsForThread(thread) {
+  assertWasmModuleThread(thread);
+  return Object.freeze(
+    wasmModuleIds().filter((id) => wasmModuleRunsOnThread(id, thread)),
+  );
 }
 
 function collectWasmModuleGraph(id, collected, active) {
@@ -120,6 +157,23 @@ export function wasmModuleGraphIds(id) {
   return Object.freeze([...graphIds].sort());
 }
 
+export function wasmModuleGraphIdsForThread(id, thread) {
+  if (!wasmModuleRunsOnThread(id, thread)) {
+    throw new Error(`wasm module ${id} does not run on ${thread}`);
+  }
+
+  const graphIds = wasmModuleGraphIds(id);
+  for (const moduleId of graphIds) {
+    if (!wasmModuleRunsOnThread(moduleId, thread)) {
+      throw new Error(
+        `wasm module ${id} depends on ${moduleId}, which does not run on ${thread}`,
+      );
+    }
+  }
+
+  return graphIds;
+}
+
 async function defaultCompile(url) {
   return WebAssembly.compileStreaming(fetch(url));
 }
@@ -130,11 +184,11 @@ async function defaultInstantiate(module, imports) {
 }
 
 function compileWasmModuleRegistry(
-  { baseUrl = "wasm/", compile = defaultCompile } = {},
+  { baseUrl = "wasm/", compile = defaultCompile, moduleIds = wasmModuleIds() } = {},
 ) {
   const compiled = new Map();
 
-  for (const moduleId of wasmModuleIds()) {
+  for (const moduleId of moduleIds) {
     let promise;
     try {
       promise = Promise.resolve(compile(wasmModuleUrl(moduleId, baseUrl), moduleId));
@@ -154,6 +208,24 @@ export async function compileWasmModuleGraph(
 ) {
   wasmModuleGraphIds(id);
   const compiled = compileWasmModuleRegistry({ baseUrl, compile });
+  const compiledEntries = await Promise.all(
+    [...compiled].map(async ([moduleId, promise]) => [moduleId, await promise]),
+  );
+
+  return new Map(compiledEntries);
+}
+
+export async function compileWasmModuleGraphForThread(
+  id,
+  thread,
+  { baseUrl = "wasm/", compile = defaultCompile } = {},
+) {
+  wasmModuleGraphIdsForThread(id, thread);
+  const compiled = compileWasmModuleRegistry({
+    baseUrl,
+    compile,
+    moduleIds: wasmModuleIdsForThread(thread),
+  });
   const compiledEntries = await Promise.all(
     [...compiled].map(async ([moduleId, promise]) => [moduleId, await promise]),
   );
@@ -215,6 +287,79 @@ export async function instantiateWasmModule(
   const exports = await instantiateModule(id);
 
   for (const moduleId of wasmModuleGraphIds(id)) {
+    for (const dependency of wasmModuleDependencies(moduleId)) {
+      const dependencyExports = instances.get(dependency);
+      for (const alias of wasmModuleAliases(dependency)) {
+        imports[alias] = dependencyExports;
+      }
+    }
+  }
+
+  return {
+    exports,
+    imports,
+  };
+}
+
+export async function instantiateWasmModuleForThread(
+  id,
+  thread,
+  baseImports,
+  {
+    baseUrl = "wasm/",
+    compile = defaultCompile,
+    instantiate = defaultInstantiate,
+  } = {},
+) {
+  const imports = { ...baseImports };
+  const instances = new Map();
+  wasmModuleGraphIdsForThread(id, thread);
+  const compiled = compileWasmModuleRegistry({
+    baseUrl,
+    compile,
+    moduleIds: wasmModuleIdsForThread(thread),
+  });
+  const instantiating = new Map();
+
+  async function instantiateModule(moduleId) {
+    if (instances.has(moduleId)) {
+      return instances.get(moduleId);
+    }
+    if (instantiating.has(moduleId)) {
+      return instantiating.get(moduleId);
+    }
+
+    const promise = (async () => {
+      await Promise.all(wasmModuleDependencies(moduleId).map(instantiateModule));
+
+      for (const dependency of wasmModuleDependencies(moduleId)) {
+        const dependencyExports = instances.get(dependency);
+        for (const alias of wasmModuleAliases(dependency)) {
+          imports[alias] = dependencyExports;
+        }
+      }
+
+      const exports = await instantiate(
+        await compiled.get(moduleId),
+        imports,
+        moduleId,
+        wasmModuleUrl(moduleId, baseUrl),
+      );
+      instances.set(moduleId, exports);
+
+      for (const alias of wasmModuleAliases(moduleId)) {
+        imports[alias] = exports;
+      }
+
+      return exports;
+    })();
+    instantiating.set(moduleId, promise);
+    return promise;
+  }
+
+  const exports = await instantiateModule(id);
+
+  for (const moduleId of wasmModuleGraphIdsForThread(id, thread)) {
     for (const dependency of wasmModuleDependencies(moduleId)) {
       const dependencyExports = instances.get(dependency);
       for (const alias of wasmModuleAliases(dependency)) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "bash tools/build.sh",
     "build:cov": "bash tools/build-cov.sh",
-    "test": "npm run test:layout && npm run test:host-abi && npm run test:parser-state-abi && npm run test:wasm-modules-abi && npm run test:wasm-modules-loader && npm run test:bootstrap-lines && npm run test:wasm-modules && npm run test:host-shim && npm run test:ingest-worker-runtime && npm run test:wat && npm run test:watwat-probe && npm run test:assert-probes && npm run test:coverage-selftest && npm run test:cold-reload-index",
+    "test": "npm run test:layout && npm run test:host-abi && npm run test:parser-state-abi && npm run test:wasm-modules-abi && npm run test:wasm-modules-loader && npm run test:bootstrap-lines && npm run test:wasm-modules && npm run test:host-shim && npm run test:ingest-worker-runtime && npm run test:runtime-worker && npm run test:wat && npm run test:watwat-probe && npm run test:assert-probes && npm run test:coverage-selftest && npm run test:cold-reload-index",
     "test:layout": "node tools/generate-layout.js --check",
     "test:host-abi": "node tools/generate-host-abi.js --check",
     "test:parser-state-abi": "node tools/generate-parser-state-abi.js --check",
@@ -15,6 +15,7 @@
     "test:wasm-modules": "node tools/wasm-modules-check.js",
     "test:host-shim": "node tools/host-shim-check.js",
     "test:ingest-worker-runtime": "node tools/ingest-worker-runtime-check.js",
+    "test:runtime-worker": "node tools/runtime-worker-orchestration-check.js",
     "test:wat": "node tools/watwat.js --harness tools/tracy-watwat-harness.js dist/wasm/*.test.wasm dist/wasm/std/*.test.wasm",
     "test:watwat-probe": "node tools/watwat.js --expect-failure probe_assert_eq_i32_failure \"deliberate i32 failure\" dist/wasm/watwat.test.wasm",
     "test:generated-trace": "node tools/generated-trace-extractor-check.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "bash tools/build.sh",
     "build:cov": "bash tools/build-cov.sh",
-    "test": "npm run test:layout && npm run test:host-abi && npm run test:parser-state-abi && npm run test:wasm-modules-abi && npm run test:wasm-modules-loader && npm run test:bootstrap-lines && npm run test:wasm-modules && npm run test:wat && npm run test:watwat-probe && npm run test:assert-probes && npm run test:coverage-selftest && npm run test:cold-reload-index",
+    "test": "npm run test:layout && npm run test:host-abi && npm run test:parser-state-abi && npm run test:wasm-modules-abi && npm run test:wasm-modules-loader && npm run test:bootstrap-lines && npm run test:wasm-modules && npm run test:host-shim && npm run test:wat && npm run test:watwat-probe && npm run test:assert-probes && npm run test:coverage-selftest && npm run test:cold-reload-index",
     "test:layout": "node tools/generate-layout.js --check",
     "test:host-abi": "node tools/generate-host-abi.js --check",
     "test:parser-state-abi": "node tools/generate-parser-state-abi.js --check",
@@ -13,6 +13,7 @@
     "test:wasm-modules-loader": "node tools/generate-wasm-modules-abi.js --check",
     "test:bootstrap-lines": "bash tools/check-bootstrap-lines.sh",
     "test:wasm-modules": "node tools/wasm-modules-check.js",
+    "test:host-shim": "node tools/host-shim-check.js",
     "test:wat": "node tools/watwat.js --harness tools/tracy-watwat-harness.js dist/wasm/*.test.wasm dist/wasm/std/*.test.wasm",
     "test:watwat-probe": "node tools/watwat.js --expect-failure probe_assert_eq_i32_failure \"deliberate i32 failure\" dist/wasm/watwat.test.wasm",
     "test:generated-trace": "node tools/generated-trace-extractor-check.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "bash tools/build.sh",
     "build:cov": "bash tools/build-cov.sh",
-    "test": "npm run test:layout && npm run test:host-abi && npm run test:parser-state-abi && npm run test:wasm-modules-abi && npm run test:wasm-modules-loader && npm run test:bootstrap-lines && npm run test:wasm-modules && npm run test:host-shim && npm run test:ingest-worker-runtime && npm run test:runtime-worker && npm run test:wat && npm run test:watwat-probe && npm run test:assert-probes && npm run test:coverage-selftest && npm run test:cold-reload-index",
+    "test": "npm run test:layout && npm run test:host-abi && npm run test:parser-state-abi && npm run test:wasm-modules-abi && npm run test:wasm-modules-loader && npm run test:bootstrap-lines && npm run test:wasm-modules && npm run test:host-shim && npm run test:ingest-worker-runtime && npm run test:runtime-worker && npm run test:worker-bundle && npm run test:wat && npm run test:watwat-probe && npm run test:assert-probes && npm run test:coverage-selftest && npm run test:cold-reload-index",
     "test:layout": "node tools/generate-layout.js --check",
     "test:host-abi": "node tools/generate-host-abi.js --check",
     "test:parser-state-abi": "node tools/generate-parser-state-abi.js --check",
@@ -16,6 +16,7 @@
     "test:host-shim": "node tools/host-shim-check.js",
     "test:ingest-worker-runtime": "node tools/ingest-worker-runtime-check.js",
     "test:runtime-worker": "node tools/runtime-worker-orchestration-check.js",
+    "test:worker-bundle": "node tools/worker-bundle-check.js",
     "test:wat": "node tools/watwat.js --harness tools/tracy-watwat-harness.js dist/wasm/*.test.wasm dist/wasm/std/*.test.wasm",
     "test:watwat-probe": "node tools/watwat.js --expect-failure probe_assert_eq_i32_failure \"deliberate i32 failure\" dist/wasm/watwat.test.wasm",
     "test:generated-trace": "node tools/generated-trace-extractor-check.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "bash tools/build.sh",
     "build:cov": "bash tools/build-cov.sh",
-    "test": "npm run test:layout && npm run test:host-abi && npm run test:parser-state-abi && npm run test:wasm-modules-abi && npm run test:wasm-modules-loader && npm run test:bootstrap-lines && npm run test:wasm-modules && npm run test:host-shim && npm run test:wat && npm run test:watwat-probe && npm run test:assert-probes && npm run test:coverage-selftest && npm run test:cold-reload-index",
+    "test": "npm run test:layout && npm run test:host-abi && npm run test:parser-state-abi && npm run test:wasm-modules-abi && npm run test:wasm-modules-loader && npm run test:bootstrap-lines && npm run test:wasm-modules && npm run test:host-shim && npm run test:ingest-worker-runtime && npm run test:wat && npm run test:watwat-probe && npm run test:assert-probes && npm run test:coverage-selftest && npm run test:cold-reload-index",
     "test:layout": "node tools/generate-layout.js --check",
     "test:host-abi": "node tools/generate-host-abi.js --check",
     "test:parser-state-abi": "node tools/generate-parser-state-abi.js --check",
@@ -14,6 +14,7 @@
     "test:bootstrap-lines": "bash tools/check-bootstrap-lines.sh",
     "test:wasm-modules": "node tools/wasm-modules-check.js",
     "test:host-shim": "node tools/host-shim-check.js",
+    "test:ingest-worker-runtime": "node tools/ingest-worker-runtime-check.js",
     "test:wat": "node tools/watwat.js --harness tools/tracy-watwat-harness.js dist/wasm/*.test.wasm dist/wasm/std/*.test.wasm",
     "test:watwat-probe": "node tools/watwat.js --expect-failure probe_assert_eq_i32_failure \"deliberate i32 failure\" dist/wasm/watwat.test.wasm",
     "test:generated-trace": "node tools/generated-trace-extractor-check.js",

--- a/shim.js
+++ b/shim.js
@@ -1,4 +1,4 @@
-export { makeShim } from "./host/shim.mjs";
+export { makeMainThreadHost, makeShim, makeWorkerThreadHost } from "./host/shim.mjs";
 export * from "./host/abi.mjs";
 export * from "./host/canvas.mjs";
 export * from "./host/pointer.mjs";

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -57,6 +57,13 @@ esbuild "${ROOT_DIR}/bootstrap.js" \
   --sourcemap \
   --outfile="${DIST_DIR}/bootstrap.bundle.js"
 
+esbuild "${ROOT_DIR}/worker.js" \
+  --bundle \
+  --format=esm \
+  --minify \
+  --sourcemap \
+  --outfile="${DIST_DIR}/worker.bundle.js"
+
 cp "${ROOT_DIR}/index.html" "${DIST_DIR}/index.html"
 cp "${ROOT_DIR}/manifest.webmanifest" "${DIST_DIR}/manifest.webmanifest"
 

--- a/tools/extract-wasm-modules.js
+++ b/tools/extract-wasm-modules.js
@@ -10,6 +10,7 @@ const root = path.dirname(__dirname);
 const checkOnly = process.argv.includes("--check");
 const watRoot = path.join(root, "wat");
 const outputPath = path.join(root, "abi/wasm-modules.json");
+const validThreads = new Set(["main", "worker", "shared"]);
 
 function toPosixPath(value) {
   return value.split(path.sep).join("/");
@@ -29,6 +30,39 @@ function aliasesForModuleId(id) {
   }
 
   return [path.posix.basename(id), id, `wat/${id}`];
+}
+
+async function scanThreadMarker(inputPath) {
+  const source = await fs.readFile(inputPath, "utf8");
+  const markers = [];
+
+  for (const [index, line] of source.split(/\r?\n/).entries()) {
+    if (!/;;\s*@thread\b/.test(line)) {
+      continue;
+    }
+
+    const match = line.match(/^\s*;;\s*@thread\s+(\S+)\s*$/);
+    if (match === null) {
+      throw new Error(`${inputPath}:${index + 1}: malformed @thread marker`);
+    }
+
+    markers.push({ thread: match[1], line: index + 1 });
+  }
+
+  if (markers.length === 0) {
+    throw new Error(`${inputPath}: missing @thread marker`);
+  }
+
+  if (markers.length > 1) {
+    throw new Error(`${inputPath}:${markers[1].line}: duplicate @thread marker`);
+  }
+
+  const [{ thread, line }] = markers;
+  if (!validThreads.has(thread)) {
+    throw new Error(`${inputPath}:${line}: invalid @thread marker ${thread}`);
+  }
+
+  return thread;
 }
 
 async function listProductionWatFiles(dir = watRoot) {
@@ -147,6 +181,7 @@ async function extractWasmModules() {
     const id = moduleIdForWatPath(relativePath);
 
     modules[id] = {
+      thread: await scanThreadMarker(watFile),
       wasmPath: wasmPathForModuleId(id),
       aliases: aliasesForModuleId(id),
       dependencies: [],
@@ -219,5 +254,6 @@ module.exports = {
   moduleIdForWatPath,
   resolveDependencies,
   scanImportNames,
+  scanThreadMarker,
   wasmPathForModuleId,
 };

--- a/tools/generate-layout.js
+++ b/tools/generate-layout.js
@@ -37,7 +37,7 @@ function generatedHeader(kind) {
 }
 
 function renderMemWat() {
-  const lines = ["(module"];
+  const lines = ["(module", "  ;; @thread shared"];
   for (const entry of constantEntries()) {
     lines.push(
       `  (global $${entry.name} (export "${entry.name}") i32 (i32.const ${watValue(entry)}))`,

--- a/tools/generate-wasm-modules-abi.js
+++ b/tools/generate-wasm-modules-abi.js
@@ -23,6 +23,7 @@ function readonlyArray(values) {
 function renderModuleEntry(id, module) {
   return [
     `  ${JSON.stringify(id)}: Object.freeze({`,
+    `    thread: ${JSON.stringify(module.thread)},`,
     `    wasmPath: ${JSON.stringify(module.wasmPath)},`,
     `    aliases: ${readonlyArray(module.aliases)},`,
     `    dependencies: ${readonlyArray(module.dependencies)},`,
@@ -53,6 +54,14 @@ function renderWasmModulesModule() {
   return String(value).replace(/\\\\/g, "/").replace(/^\\.?\\//, "");
 }
 
+const WASM_MODULE_THREADS = Object.freeze(["main", "worker", "shared"]);
+
+function assertWasmModuleThread(thread) {
+  if (!WASM_MODULE_THREADS.includes(thread)) {
+    throw new Error(\`unknown wasm module thread \${thread}\`);
+  }
+}
+
 export function wasmModuleIds() {
   return Object.keys(WASM_MODULES);
 }
@@ -74,12 +83,29 @@ export function wasmModuleDependencies(id) {
   return wasmModule(id).dependencies;
 }
 
+export function wasmModuleThread(id) {
+  return wasmModule(id).thread;
+}
+
 export function wasmModulePath(id) {
   return wasmModule(id).wasmPath;
 }
 
 export function wasmModuleUrl(id, baseUrl = "wasm/") {
   return \`\${baseUrl.replace(/\\/?$/, "/")}\${wasmModulePath(id)}\`;
+}
+
+export function wasmModuleRunsOnThread(id, thread) {
+  assertWasmModuleThread(thread);
+  const moduleThread = wasmModuleThread(id);
+  return moduleThread === thread || moduleThread === "shared";
+}
+
+export function wasmModuleIdsForThread(thread) {
+  assertWasmModuleThread(thread);
+  return Object.freeze(
+    wasmModuleIds().filter((id) => wasmModuleRunsOnThread(id, thread)),
+  );
 }
 
 function collectWasmModuleGraph(id, collected, active) {
@@ -105,6 +131,23 @@ export function wasmModuleGraphIds(id) {
   return Object.freeze([...graphIds].sort());
 }
 
+export function wasmModuleGraphIdsForThread(id, thread) {
+  if (!wasmModuleRunsOnThread(id, thread)) {
+    throw new Error(\`wasm module \${id} does not run on \${thread}\`);
+  }
+
+  const graphIds = wasmModuleGraphIds(id);
+  for (const moduleId of graphIds) {
+    if (!wasmModuleRunsOnThread(moduleId, thread)) {
+      throw new Error(
+        \`wasm module \${id} depends on \${moduleId}, which does not run on \${thread}\`,
+      );
+    }
+  }
+
+  return graphIds;
+}
+
 async function defaultCompile(url) {
   return WebAssembly.compileStreaming(fetch(url));
 }
@@ -115,11 +158,11 @@ async function defaultInstantiate(module, imports) {
 }
 
 function compileWasmModuleRegistry(
-  { baseUrl = "wasm/", compile = defaultCompile } = {},
+  { baseUrl = "wasm/", compile = defaultCompile, moduleIds = wasmModuleIds() } = {},
 ) {
   const compiled = new Map();
 
-  for (const moduleId of wasmModuleIds()) {
+  for (const moduleId of moduleIds) {
     let promise;
     try {
       promise = Promise.resolve(compile(wasmModuleUrl(moduleId, baseUrl), moduleId));
@@ -139,6 +182,24 @@ export async function compileWasmModuleGraph(
 ) {
   wasmModuleGraphIds(id);
   const compiled = compileWasmModuleRegistry({ baseUrl, compile });
+  const compiledEntries = await Promise.all(
+    [...compiled].map(async ([moduleId, promise]) => [moduleId, await promise]),
+  );
+
+  return new Map(compiledEntries);
+}
+
+export async function compileWasmModuleGraphForThread(
+  id,
+  thread,
+  { baseUrl = "wasm/", compile = defaultCompile } = {},
+) {
+  wasmModuleGraphIdsForThread(id, thread);
+  const compiled = compileWasmModuleRegistry({
+    baseUrl,
+    compile,
+    moduleIds: wasmModuleIdsForThread(thread),
+  });
   const compiledEntries = await Promise.all(
     [...compiled].map(async ([moduleId, promise]) => [moduleId, await promise]),
   );
@@ -200,6 +261,79 @@ export async function instantiateWasmModule(
   const exports = await instantiateModule(id);
 
   for (const moduleId of wasmModuleGraphIds(id)) {
+    for (const dependency of wasmModuleDependencies(moduleId)) {
+      const dependencyExports = instances.get(dependency);
+      for (const alias of wasmModuleAliases(dependency)) {
+        imports[alias] = dependencyExports;
+      }
+    }
+  }
+
+  return {
+    exports,
+    imports,
+  };
+}
+
+export async function instantiateWasmModuleForThread(
+  id,
+  thread,
+  baseImports,
+  {
+    baseUrl = "wasm/",
+    compile = defaultCompile,
+    instantiate = defaultInstantiate,
+  } = {},
+) {
+  const imports = { ...baseImports };
+  const instances = new Map();
+  wasmModuleGraphIdsForThread(id, thread);
+  const compiled = compileWasmModuleRegistry({
+    baseUrl,
+    compile,
+    moduleIds: wasmModuleIdsForThread(thread),
+  });
+  const instantiating = new Map();
+
+  async function instantiateModule(moduleId) {
+    if (instances.has(moduleId)) {
+      return instances.get(moduleId);
+    }
+    if (instantiating.has(moduleId)) {
+      return instantiating.get(moduleId);
+    }
+
+    const promise = (async () => {
+      await Promise.all(wasmModuleDependencies(moduleId).map(instantiateModule));
+
+      for (const dependency of wasmModuleDependencies(moduleId)) {
+        const dependencyExports = instances.get(dependency);
+        for (const alias of wasmModuleAliases(dependency)) {
+          imports[alias] = dependencyExports;
+        }
+      }
+
+      const exports = await instantiate(
+        await compiled.get(moduleId),
+        imports,
+        moduleId,
+        wasmModuleUrl(moduleId, baseUrl),
+      );
+      instances.set(moduleId, exports);
+
+      for (const alias of wasmModuleAliases(moduleId)) {
+        imports[alias] = exports;
+      }
+
+      return exports;
+    })();
+    instantiating.set(moduleId, promise);
+    return promise;
+  }
+
+  const exports = await instantiateModule(id);
+
+  for (const moduleId of wasmModuleGraphIdsForThread(id, thread)) {
     for (const dependency of wasmModuleDependencies(moduleId)) {
       const dependencyExports = instances.get(dependency);
       for (const alias of wasmModuleAliases(dependency)) {

--- a/tools/host-shim-check.js
+++ b/tools/host-shim-check.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+const assert = require("node:assert/strict");
+const { pathToFileURL } = require("node:url");
+const path = require("node:path");
+
+function installBrowserStubs() {
+  const canvasContext = {
+    set fillStyle(value) {
+      this.lastFillStyle = value;
+    },
+    fillRect() {},
+    setTransform() {},
+  };
+  const canvas = {
+    clientWidth: 320,
+    clientHeight: 240,
+    hidden: false,
+    width: 0,
+    height: 0,
+    getBoundingClientRect() {
+      return { left: 0, top: 0 };
+    },
+    getContext() {
+      return canvasContext;
+    },
+    addEventListener() {},
+  };
+
+  globalThis.document = {
+    body: {
+      appendChild() {},
+    },
+    createElement() {
+      return {
+        addEventListener() {},
+        removeAttribute() {},
+        removeEventListener() {},
+        set hidden(value) {
+          this.isHidden = value;
+        },
+      };
+    },
+    getElementById(id) {
+      return id === "tracy" ? canvas : null;
+    },
+  };
+  globalThis.window = {
+    devicePixelRatio: 1,
+    addEventListener() {},
+    removeEventListener() {},
+  };
+}
+
+function hostKeys(host) {
+  return new Set(Object.keys(host));
+}
+
+async function main() {
+  installBrowserStubs();
+
+  const shimUrl = pathToFileURL(path.resolve(__dirname, "../host/shim.mjs")).href;
+  const abiUrl = pathToFileURL(path.resolve(__dirname, "../host/abi.mjs")).href;
+  const {
+    makeMainThreadHost,
+    makeShim,
+    makeWorkerThreadHost,
+  } = await import(shimUrl);
+  const { HOST_IMPORT_NAME } = await import(abiUrl);
+  const memory = new WebAssembly.Memory({ initial: 1 });
+
+  const mainHost = makeMainThreadHost(memory);
+  const workerHost = makeWorkerThreadHost(memory);
+  const legacyHost = makeShim(memory);
+  const mainKeys = hostKeys(mainHost);
+  const workerKeys = hostKeys(workerHost);
+
+  for (const name of [
+    HOST_IMPORT_NAME.CANVAS_GET_SIZE,
+    HOST_IMPORT_NAME.CANVAS_LISTEN_RESIZE,
+    HOST_IMPORT_NAME.FILE_PICKER_OPEN,
+    HOST_IMPORT_NAME.POINTER_LISTEN,
+  ]) {
+    assert(mainKeys.has(name), `main host missing ${name}`);
+    assert(!workerKeys.has(name), `worker host should not expose ${name}`);
+  }
+
+  for (const name of [
+    HOST_IMPORT_NAME.OPFS_SOURCE_OPEN,
+    HOST_IMPORT_NAME.OPFS_SOURCE_READ,
+    HOST_IMPORT_NAME.OPFS_INDEX_CREATE,
+    HOST_IMPORT_NAME.OPFS_INDEX_OPEN,
+    HOST_IMPORT_NAME.OPFS_INDEX_READ,
+    HOST_IMPORT_NAME.OPFS_INDEX_WRITE,
+    HOST_IMPORT_NAME.OPFS_INDEX_FLUSH,
+    HOST_IMPORT_NAME.OPFS_INDEX_SIZE,
+  ]) {
+    assert(workerKeys.has(name), `worker host missing ${name}`);
+    assert(Object.hasOwn(legacyHost, name), `legacy host missing ${name}`);
+  }
+
+  assert(mainKeys.has(HOST_IMPORT_NAME.OPFS_INDEX_OPEN), "main host missing index open");
+  assert(mainKeys.has(HOST_IMPORT_NAME.OPFS_INDEX_READ), "main host missing index read");
+  assert(mainKeys.has(HOST_IMPORT_NAME.OPFS_INDEX_SIZE), "main host missing index size");
+  assert(!mainKeys.has(HOST_IMPORT_NAME.OPFS_INDEX_WRITE), "main host should not expose index write");
+  assert(!mainKeys.has(HOST_IMPORT_NAME.OPFS_INDEX_FLUSH), "main host should not expose index flush");
+
+  assert.throws(
+    () => workerHost[HOST_IMPORT_NAME.OPFS_SOURCE_FROM_FILE](1),
+    /file handles are owned by the main thread/,
+  );
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message || String(error));
+  process.exitCode = 1;
+});

--- a/tools/ingest-worker-runtime-check.js
+++ b/tools/ingest-worker-runtime-check.js
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+
+function moduleUrl(relativePath) {
+  return pathToFileURL(path.resolve(__dirname, "..", relativePath)).href;
+}
+
+function decodeString(memory, ptr, len) {
+  return new TextDecoder().decode(new Uint8Array(memory.buffer, ptr, len));
+}
+
+function makeParserExports(memory, parserState) {
+  const parseOffsets = [16, 32, 48];
+  const parseEventCounts = [1, 2, 3];
+  let parseCalls = 0;
+  let nextEvent = 0;
+
+  function writeParserState(statePtr, index) {
+    const view = new DataView(memory.buffer);
+    view.setBigUint64(
+      statePtr + parserState.PARSER_STATE_FILE_OFFSET_OFFSET,
+      BigInt(parseOffsets[index]),
+      true,
+    );
+    view.setInt32(
+      statePtr + parserState.PARSER_STATE_EVENT_COUNT_OFFSET,
+      parseEventCounts[index],
+      true,
+    );
+  }
+
+  return {
+    extractor_init(ptr) {
+      assert.equal(ptr, 7000);
+    },
+    extractor_next() {
+      if (nextEvent >= 3) {
+        return -1;
+      }
+
+      nextEvent += 1;
+      return 8000 + nextEvent;
+    },
+    parser_parse_with_budget(statePtr, chunkBytes, byteBudget) {
+      assert.equal(chunkBytes, 0);
+      assert.equal(byteBudget, 9);
+      writeParserState(statePtr, parseCalls);
+      parseCalls += 1;
+      return parseCalls < parseOffsets.length
+        ? parserState.PARSER_STATUS_YIELDED
+        : parserState.PARSER_STATUS_DONE;
+    },
+  };
+}
+
+function makeIndexExports() {
+  const events = [];
+
+  return {
+    INDEX_INGEST_STATUS_OK: 0,
+    INDEX_WRITER_STATUS_OK: 0,
+    index_add_event(eventPtr) {
+      events.push(eventPtr);
+      return 0;
+    },
+    index_writer_committed_events() {
+      return events.length;
+    },
+    index_writer_committed_pages() {
+      return events.length === 0 ? 0 : 1;
+    },
+    index_writer_flush() {
+      assert.equal(events.length, 3);
+      return 0;
+    },
+    index_writer_init(indexId, writerPagePtr, dictEpoch) {
+      assert.equal(indexId, 22);
+      assert.equal(writerPagePtr, 6000);
+      assert.equal(dictEpoch, 5);
+    },
+  };
+}
+
+async function checkWorkerRuntime() {
+  const runtime = await import(moduleUrl("host/ingest-worker-runtime.mjs"));
+  const abi = await import(moduleUrl("host/abi.mjs"));
+  const memory = new WebAssembly.Memory({ initial: 2 });
+  const parserState = {
+    PARSER_STATE_EVENT_COUNT_OFFSET: 8,
+    PARSER_STATE_FILE_OFFSET_OFFSET: 0,
+    PARSER_STATUS_DONE: 2,
+    PARSER_STATUS_YIELDED: 1,
+    parser_state_init(statePtr, sourceId) {
+      assert.equal(statePtr, 1000);
+      assert.equal(sourceId, 11);
+    },
+  };
+  const instantiated = [];
+  const hostCalls = [];
+  const host = {
+    [abi.HOST_IMPORT_NAME.OPFS_SOURCE_OPEN](namePtr, nameLen) {
+      hostCalls.push(["source", decodeString(memory, namePtr, nameLen)]);
+      return 11;
+    },
+    [abi.HOST_IMPORT_NAME.OPFS_INDEX_CREATE](namePtr, nameLen) {
+      hostCalls.push(["index", decodeString(memory, namePtr, nameLen)]);
+      return 22;
+    },
+  };
+  const messages = [];
+  const times = [0, 10, 20, 34, 35, 36];
+
+  const result = await runtime.runWorkerIngest(
+    {
+      byteBudget: 9,
+      coveredRangeIntervalMs: 33,
+      dictEpoch: 5,
+      indexName: "indexes/trace.idx",
+      statePtr: 1000,
+      sourceName: "sources/trace.json",
+      tokenOutputPtr: 7000,
+      writerPagePtr: 6000,
+      type: runtime.INGEST_WORKER_MESSAGE.START,
+    },
+    {
+      hostFactory: () => host,
+      instantiateWasmModuleForThread: async (id, thread, imports) => {
+        instantiated.push({ id, thread, hasMemory: imports.env.memory === memory });
+        if (id === "parser") {
+          return {
+            exports: makeParserExports(memory, parserState),
+            imports: {
+              alloc: {
+                bump_init() {},
+              },
+              mem: {
+                MEM_HEAP_BASE: 1024,
+                MEM_STACK_BASE: 2048,
+              },
+              parser_state: parserState,
+            },
+          };
+        }
+        if (id === "index") {
+          return {
+            exports: makeIndexExports(),
+            imports: {},
+          };
+        }
+
+        throw new Error(`unexpected module ${id}`);
+      },
+      memoryFactory: () => memory,
+      now: () => times.shift() ?? 100,
+      postMessage: (message) => messages.push(message),
+    },
+  );
+
+  assert.deepEqual(instantiated, [
+    { id: "parser", thread: "worker", hasMemory: true },
+    { id: "index", thread: "worker", hasMemory: true },
+  ]);
+  assert.deepEqual(hostCalls, [
+    ["source", "sources/trace.json"],
+    ["index", "indexes/trace.idx"],
+  ]);
+  assert.equal(result.committedEvents, 3);
+  assert.equal(result.extractedEvents, 3);
+
+  const coveredRangeMessages = messages.filter(
+    (message) => message.type === runtime.INGEST_WORKER_MESSAGE.COVERED_RANGE,
+  );
+  assert.deepEqual(
+    coveredRangeMessages.map((message) => message.end),
+    [16, 48],
+  );
+  assert.equal(
+    messages.at(-1).type,
+    runtime.INGEST_WORKER_MESSAGE.COMPLETE,
+    "complete should be the final worker message",
+  );
+  assert.deepEqual(
+    messages
+      .filter((message) => message.type === runtime.INGEST_WORKER_MESSAGE.PROGRESS)
+      .map((message) => message.phase),
+    ["parse", "index", "complete"],
+  );
+}
+
+async function checkMessageHandler() {
+  const runtime = await import(moduleUrl("host/ingest-worker-runtime.mjs"));
+  const messages = [];
+  const handled = [];
+  const handleMessage = runtime.createIngestWorkerMessageHandler({
+    postMessage: (message) => messages.push(message),
+    runWorkerIngest: async (data) => {
+      handled.push(data);
+      throw new Error("kaboom");
+    },
+  });
+
+  await handleMessage({ data: { type: "ignored" } });
+  assert.equal(handled.length, 0);
+  assert.equal(messages.length, 0);
+
+  await handleMessage({ data: { type: runtime.INGEST_WORKER_MESSAGE.START } });
+  assert.equal(handled.length, 1);
+  assert.deepEqual(messages, [
+    {
+      type: runtime.INGEST_WORKER_MESSAGE.ERROR,
+      message: "kaboom",
+    },
+  ]);
+}
+
+async function main() {
+  await checkWorkerRuntime();
+  await checkMessageHandler();
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message || String(error));
+  process.exitCode = 1;
+});

--- a/tools/runtime-worker-orchestration-check.js
+++ b/tools/runtime-worker-orchestration-check.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+
+function moduleUrl(relativePath) {
+  return pathToFileURL(path.resolve(__dirname, "..", relativePath)).href;
+}
+
+function installBrowserStubs() {
+  const frames = [];
+
+  globalThis.document = {
+    body: {
+      appendChild() {},
+    },
+    createElement() {
+      return {
+        setAttribute() {},
+        style: {},
+      };
+    },
+    getElementById() {
+      return {
+        hidden: false,
+      };
+    },
+  };
+  globalThis.requestAnimationFrame = (callback) => {
+    frames.push(callback);
+    return frames.length;
+  };
+  globalThis.WebAssembly.Suspending = class Suspending {
+    constructor(fn) {
+      return fn;
+    }
+  };
+
+  return { frames };
+}
+
+class FakeWorker {
+  static instances = [];
+
+  constructor(url, options) {
+    this.events = new Map();
+    this.options = options;
+    this.posted = [];
+    this.url = url;
+    FakeWorker.instances.push(this);
+  }
+
+  addEventListener(type, callback) {
+    this.events.set(type, callback);
+  }
+
+  emit(type, data) {
+    this.events.get(type)?.({ data });
+  }
+
+  postMessage(message) {
+    this.posted.push(message);
+  }
+
+  terminate() {
+    this.terminated = true;
+  }
+}
+
+async function checkRuntimeOrchestratesWorker() {
+  const { frames } = installBrowserStubs();
+  const runtime = await import(moduleUrl("host/runtime.mjs"));
+  const workerMessages = [];
+  const instantiateCalls = [];
+  const ticks = [];
+  const memory = new WebAssembly.Memory({ initial: 1 });
+  const host = {};
+  const workerStatus = [];
+
+  const controller = runtime.runApp(memory, host, {
+    ingest: {
+      indexName: "indexes/trace.idx",
+      sourceName: "sources/trace.json",
+    },
+    instantiateWasmModuleForThread: async (id, thread, imports) => {
+      instantiateCalls.push({ id, thread, memory: imports.env.memory });
+      return {
+        exports: {
+          tracy_main() {
+            ticks.push("main");
+          },
+          tracy_tick(ts) {
+            ticks.push(ts);
+          },
+        },
+      };
+    },
+    worker: {
+      Worker: FakeWorker,
+      onWorkerStatus(status, message) {
+        workerStatus.push({ status, message });
+      },
+      workerUrl: "worker.bundle.js",
+    },
+  });
+
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.equal(FakeWorker.instances.length, 1);
+  const worker = FakeWorker.instances[0];
+  assert.equal(worker.url, "worker.bundle.js");
+  assert.deepEqual(worker.options, { type: "module" });
+  assert.deepEqual(instantiateCalls, [
+    { id: "app", thread: "main", memory },
+  ]);
+  assert.equal(frames.length, 1, "requestAnimationFrame should be scheduled");
+  assert.deepEqual(worker.posted, [
+    {
+      indexName: "indexes/trace.idx",
+      sourceName: "sources/trace.json",
+      type: "start",
+    },
+  ]);
+  assert.equal(controller.status().state, "running");
+
+  worker.emit("message", {
+    type: "progress",
+    phase: "parse",
+    fileOffset: 32,
+  });
+  worker.emit("message", {
+    type: "covered_range",
+    start: 0,
+    end: 32,
+  });
+  worker.emit("message", {
+    type: "complete",
+    committedEvents: 7,
+  });
+
+  frames[0](123);
+  assert.deepEqual(ticks, ["main", 123]);
+  assert.equal(controller.status().state, "complete");
+  assert.equal(controller.status().result.committedEvents, 7);
+  assert.equal(workerStatus.at(-1).status.state, "complete");
+
+  const controllerWithError = runtime.createIngestWorkerController({
+    Worker: FakeWorker,
+    onWorkerStatus(status, message) {
+      workerMessages.push({ status, message });
+    },
+  });
+  const errorWorker = FakeWorker.instances.at(-1);
+
+  errorWorker.events.get("error")({ message: "worker crashed" });
+  assert.equal(controllerWithError.status().state, "error");
+  assert.equal(controllerWithError.status().error, "worker crashed");
+  assert.equal(workerMessages.at(-1).status.state, "error");
+}
+
+checkRuntimeOrchestratesWorker().catch((error) => {
+  console.error(error.stack || error.message || String(error));
+  process.exitCode = 1;
+});

--- a/tools/wasm-modules-check.js
+++ b/tools/wasm-modules-check.js
@@ -10,6 +10,7 @@ const {
   extractWasmModules,
   resolveDependencies,
   scanImportNames,
+  scanThreadMarker,
 } = require("./extract-wasm-modules.js");
 
 async function withFixtureWat(source, callback) {
@@ -30,6 +31,22 @@ async function testExtractorFixtures() {
 
   await withFixtureWat("(module)\n", async (fixturePath) => {
     assert.deepEqual(await scanImportNames(fixturePath), []);
+  });
+
+  await withFixtureWat(";; @thread worker\n(module)\n", async (fixturePath) => {
+    assert.equal(await scanThreadMarker(fixturePath), "worker");
+  });
+
+  await withFixtureWat(";; @thread main\n;; @thread worker\n(module)\n", async (fixturePath) => {
+    await assert.rejects(scanThreadMarker(fixturePath), /duplicate @thread marker/);
+  });
+
+  await withFixtureWat(";; @thread render\n(module)\n", async (fixturePath) => {
+    await assert.rejects(scanThreadMarker(fixturePath), /invalid @thread marker render/);
+  });
+
+  await withFixtureWat("(module)\n", async (fixturePath) => {
+    await assert.rejects(scanThreadMarker(fixturePath), /missing @thread marker/);
   });
 
   await withFixtureWat(
@@ -59,6 +76,10 @@ async function testExtractorFixtures() {
   );
 
   const manifest = await extractWasmModules();
+  assert.equal(manifest.modules.app.thread, "main");
+  assert.equal(manifest.modules.index.thread, "worker");
+  assert.equal(manifest.modules.parser.thread, "worker");
+  assert.equal(manifest.modules["std/mem"].thread, "shared");
   assert.deepEqual(manifest.modules.app.dependencies, []);
   assert.deepEqual(manifest.modules.index.dependencies, ["std/mem"]);
   assert.deepEqual(manifest.modules.parser.dependencies, ["std/mem", "std/strtab", "parser_state"]);

--- a/tools/wasm-modules-check.js
+++ b/tools/wasm-modules-check.js
@@ -95,9 +95,15 @@ async function main() {
   const manifestUrl = pathToFileURL(path.resolve(__dirname, "../host/wasm-modules.mjs")).href;
   const {
     compileWasmModuleGraph,
+    compileWasmModuleGraphForThread,
+    instantiateWasmModuleForThread,
     instantiateWasmModule,
     wasmModuleGraphIds,
+    wasmModuleGraphIdsForThread,
     wasmModuleIds,
+    wasmModuleIdsForThread,
+    wasmModuleRunsOnThread,
+    wasmModuleThread,
     wasmModuleUrl,
   } = await import(manifestUrl);
 
@@ -113,6 +119,42 @@ async function main() {
     "parser_state",
     "parser",
   ]));
+  assert.equal(wasmModuleThread("app"), "main");
+  assert.equal(wasmModuleThread("parser"), "worker");
+  assert.equal(wasmModuleThread("std/mem"), "shared");
+  assert.equal(wasmModuleRunsOnThread("app", "main"), true);
+  assert.equal(wasmModuleRunsOnThread("app", "worker"), false);
+  assert.equal(wasmModuleRunsOnThread("std/mem", "main"), true);
+  assert.equal(wasmModuleRunsOnThread("std/mem", "worker"), true);
+  assert.deepEqual(new Set(wasmModuleIdsForThread("main")), new Set([
+    "app",
+    "std/alloc",
+    "std/array",
+    "std/assert",
+    "std/hash",
+    "std/mem",
+    "std/pool",
+    "std/ring",
+    "std/strtab",
+  ]));
+  assert.deepEqual(new Set(wasmModuleIdsForThread("worker")), new Set([
+    "index",
+    "parser",
+    "parser_state",
+    "std/alloc",
+    "std/array",
+    "std/assert",
+    "std/hash",
+    "std/mem",
+    "std/pool",
+    "std/ring",
+    "std/strtab",
+  ]));
+  assert.deepEqual(new Set(wasmModuleGraphIdsForThread("parser", "worker")), new Set(parserGraphIds));
+  assert.throws(
+    () => wasmModuleGraphIdsForThread("parser", "main"),
+    /wasm module parser does not run on main/,
+  );
   assert.equal(wasmModuleUrl("std/strtab", "/assets/wasm"), "/assets/wasm/std/strtab.wasm");
 
   const registryModuleIds = wasmModuleIds();
@@ -123,6 +165,30 @@ async function main() {
     },
   });
   assert.deepEqual(new Set(compiledGraph.keys()), new Set(registryModuleIds));
+
+  const workerCompileStartedIds = [];
+  const compiledWorkerGraph = await compileWasmModuleGraphForThread("parser", "worker", {
+    baseUrl: "/assets/wasm",
+    compile(url, moduleId) {
+      workerCompileStartedIds.push(moduleId);
+      assert(wasmModuleIdsForThread("worker").includes(moduleId));
+      return Promise.resolve({ moduleId, url });
+    },
+  });
+  assert.deepEqual(new Set(workerCompileStartedIds), new Set(wasmModuleIdsForThread("worker")));
+  assert.deepEqual(new Set(compiledWorkerGraph.keys()), new Set(wasmModuleIdsForThread("worker")));
+
+  const mainCompileStartedIds = [];
+  const compiledMainGraph = await compileWasmModuleGraphForThread("app", "main", {
+    baseUrl: "/assets/wasm",
+    compile(url, moduleId) {
+      mainCompileStartedIds.push(moduleId);
+      assert(wasmModuleIdsForThread("main").includes(moduleId));
+      return Promise.resolve({ moduleId, url });
+    },
+  });
+  assert.deepEqual(new Set(mainCompileStartedIds), new Set(wasmModuleIdsForThread("main")));
+  assert.deepEqual(new Set(compiledMainGraph.keys()), new Set(wasmModuleIdsForThread("main")));
 
   const compileStartedIds = [];
   const instantiatedIds = [];
@@ -162,6 +228,62 @@ async function main() {
   assert.equal(imports.alloc.moduleId, "std/alloc");
   assert.equal(imports.hash.moduleId, "std/hash");
   assert.equal(imports.strtab.moduleId, "std/strtab");
+
+  const workerInstantiatedIds = [];
+  const workerLoaded = await instantiateWasmModuleForThread(
+    "parser",
+    "worker",
+    { env: { memory: "worker-memory" } },
+    {
+      baseUrl: "/assets/wasm",
+      compile(url, moduleId) {
+        assert(wasmModuleIdsForThread("worker").includes(moduleId));
+        return Promise.resolve({ moduleId, url });
+      },
+      instantiate(module, moduleImports, moduleId) {
+        assert.equal(moduleImports.env.memory, "worker-memory");
+        workerInstantiatedIds.push(moduleId);
+        return Promise.resolve({ moduleId, thread: "worker" });
+      },
+    },
+  );
+  assert.deepEqual(new Set(workerInstantiatedIds), new Set(parserGraphIds));
+  assert.equal(workerLoaded.exports.moduleId, "parser");
+  assert.equal(workerLoaded.imports.mem.thread, "worker");
+
+  const mainLoadedShared = await instantiateWasmModuleForThread(
+    "std/mem",
+    "main",
+    { env: { memory: "main-memory" } },
+    {
+      compile(url, moduleId) {
+        assert(wasmModuleIdsForThread("main").includes(moduleId));
+        return Promise.resolve({ moduleId, url });
+      },
+      instantiate(module, moduleImports, moduleId) {
+        assert.equal(moduleImports.env.memory, "main-memory");
+        return Promise.resolve({ moduleId, thread: "main" });
+      },
+    },
+  );
+  const workerLoadedShared = await instantiateWasmModuleForThread(
+    "std/mem",
+    "worker",
+    { env: { memory: "worker-memory" } },
+    {
+      compile(url, moduleId) {
+        assert(wasmModuleIdsForThread("worker").includes(moduleId));
+        return Promise.resolve({ moduleId, url });
+      },
+      instantiate(module, moduleImports, moduleId) {
+        assert.equal(moduleImports.env.memory, "worker-memory");
+        return Promise.resolve({ moduleId, thread: "worker" });
+      },
+    },
+  );
+  assert.notEqual(mainLoadedShared.exports, workerLoadedShared.exports);
+  assert.equal(mainLoadedShared.exports.thread, "main");
+  assert.equal(workerLoadedShared.exports.thread, "worker");
 
   for (const moduleId of registryModuleIds) {
     const loaded = await instantiateWasmModule(

--- a/tools/worker-bundle-check.js
+++ b/tools/worker-bundle-check.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+const assert = require("node:assert/strict");
+const childProcess = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ROOT_DIR = path.resolve(__dirname, "..");
+const FORBIDDEN_ISOLATION_PATTERNS = [
+  /\bSharedArrayBuffer\b/,
+  /\bCOOP\b/,
+  /\bCOEP\b/,
+  /Cross-Origin-Opener-Policy/,
+  /Cross-Origin-Embedder-Policy/,
+];
+
+function readRepoFile(relativePath) {
+  return fs.readFileSync(path.join(ROOT_DIR, relativePath), "utf8");
+}
+
+function assertNoIsolationRequirement(relativePath) {
+  const source = readRepoFile(relativePath);
+
+  for (const pattern of FORBIDDEN_ISOLATION_PATTERNS) {
+    assert(
+      !pattern.test(source),
+      `${relativePath} should not require ${pattern.source}`,
+    );
+  }
+}
+
+function assertTracked(relativePath) {
+  const output = childProcess.execFileSync(
+    "git",
+    ["ls-files", "--error-unmatch", relativePath],
+    {
+      cwd: ROOT_DIR,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  assert.equal(output.trim(), relativePath);
+}
+
+function main() {
+  const buildScript = readRepoFile("tools/build.sh");
+  const runtimeSource = readRepoFile("host/runtime.mjs");
+  const workerSource = readRepoFile("worker.js");
+  const packageJson = JSON.parse(readRepoFile("package.json"));
+
+  assert.match(
+    buildScript,
+    /esbuild "\$\{ROOT_DIR\}\/bootstrap\.js"[\s\S]+--outfile="\$\{DIST_DIR\}\/bootstrap\.bundle\.js"/,
+    "build should emit the main bootstrap bundle",
+  );
+  assert.match(
+    buildScript,
+    /esbuild "\$\{ROOT_DIR\}\/worker\.js"[\s\S]+--format=esm[\s\S]+--outfile="\$\{DIST_DIR\}\/worker\.bundle\.js"/,
+    "build should emit the module worker bundle",
+  );
+  assert.match(runtimeSource, /const WORKER_URL = "worker\.bundle\.js"/);
+  assert.match(
+    runtimeSource,
+    /new WorkerCtor\(options\.workerUrl \?\? WORKER_URL, \{ type: "module" \}\)/,
+  );
+  assert.match(
+    workerSource,
+    /createIngestWorkerMessageHandler/,
+    "worker entrypoint should install the ingest message handler",
+  );
+  assert.equal(
+    packageJson.scripts["test:worker-bundle"],
+    "node tools/worker-bundle-check.js",
+  );
+  assert.match(packageJson.scripts.test, /test:worker-bundle/);
+
+  for (const relativePath of [
+    "tools/ingest-worker-runtime-check.js",
+    "tools/runtime-worker-orchestration-check.js",
+  ]) {
+    assertTracked(relativePath);
+  }
+  assert(fs.existsSync(path.join(ROOT_DIR, "tools/worker-bundle-check.js")));
+
+  for (const relativePath of [
+    "bootstrap.js",
+    "host/ingest-worker-runtime.mjs",
+    "host/runtime.mjs",
+    "index.html",
+    "manifest.webmanifest",
+    "worker.js",
+  ]) {
+    assertNoIsolationRequirement(relativePath);
+  }
+
+  for (const relativePath of [
+    "dist/bootstrap.bundle.js",
+    "dist/worker.bundle.js",
+  ]) {
+    const bundlePath = path.join(ROOT_DIR, relativePath);
+
+    assert(fs.existsSync(bundlePath), `${relativePath} should be emitted by build`);
+    assertNoIsolationRequirement(relativePath);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error.stack || error.message || String(error));
+  process.exitCode = 1;
+}

--- a/wat/app.wat
+++ b/wat/app.wat
@@ -1,4 +1,5 @@
 (module
+  ;; @thread main
   ;; @generated host-imports app:start
   (import "host" "canvas_get_size" (func $canvas_get_size (result i64)))
   (import "host" "canvas_listen_resize" (func $canvas_listen_resize))

--- a/wat/index.wat
+++ b/wat/index.wat
@@ -1,4 +1,5 @@
 (module
+  ;; @thread worker
   ;; @include index/constants-and-helpers.wat.inc
   ;; @include index/codecs.wat.inc
   ;; @include index/page-layout-and-writer-pages.wat.inc

--- a/wat/parser.wat
+++ b/wat/parser.wat
@@ -1,4 +1,5 @@
 (module
+  ;; @thread worker
   (import "env" "memory" (memory $memory 1 32768))
   ;; @generated host-imports parser:start
   (import "host" "opfs_source_read" (func $opfs_source_read (param i32 i64 i32 i32) (result i32)))

--- a/wat/parser_state.wat
+++ b/wat/parser_state.wat
@@ -1,4 +1,5 @@
 (module
+  ;; @thread worker
   (import "env" "memory" (memory $memory 1 32768))
 
   ;; @generated parser-state-globals:start

--- a/wat/std/alloc.wat
+++ b/wat/std/alloc.wat
@@ -1,4 +1,5 @@
 (module
+  ;; @thread shared
   (import "env" "memory" (memory $memory 1 32768))
 
   (global $WASM_PAGE_SIZE i32 (i32.const 0x00010000))

--- a/wat/std/array.wat
+++ b/wat/std/array.wat
@@ -1,4 +1,5 @@
 (module
+  ;; @thread shared
   (import "env" "memory" (memory $memory 1 32768))
   (import "alloc" "alloc" (func $alloc (param i32) (result i32)))
 

--- a/wat/std/assert.wat
+++ b/wat/std/assert.wat
@@ -1,4 +1,5 @@
 (module
+  ;; @thread shared
   (import "env" "memory" (memory $memory 1))
   (import "watwat" "fail" (func $fail (param i32)))
 

--- a/wat/std/hash.wat
+++ b/wat/std/hash.wat
@@ -1,4 +1,5 @@
 (module
+  ;; @thread shared
   (import "env" "memory" (memory $memory 1 32768))
   (import "alloc" "alloc" (func $alloc (param i32) (result i32)))
 

--- a/wat/std/mem.wat
+++ b/wat/std/mem.wat
@@ -1,6 +1,7 @@
 ;; Generated from abi/layout.json by tools/generate-layout.js.
 ;; Do not edit wat/std/mem.wat by hand.
 (module
+  ;; @thread shared
   (global $WASM_PAGE_SIZE (export "WASM_PAGE_SIZE") i32 (i32.const 0x00010000))
   (global $OPFS_PAGE_SIZE (export "OPFS_PAGE_SIZE") i32 (i32.const 0x00010000))
   (global $MEM_SCRATCH_BASE (export "MEM_SCRATCH_BASE") i32 (i32.const 0x00000000))

--- a/wat/std/pool.wat
+++ b/wat/std/pool.wat
@@ -1,4 +1,5 @@
 (module
+  ;; @thread shared
   (import "env" "memory" (memory $memory 1 32768))
   (import "alloc" "alloc" (func $alloc (param i32) (result i32)))
 

--- a/wat/std/ring.wat
+++ b/wat/std/ring.wat
@@ -1,4 +1,5 @@
 (module
+  ;; @thread shared
   (import "env" "memory" (memory $memory 1 32768))
   (import "alloc" "alloc" (func $alloc (param i32) (result i32)))
 

--- a/wat/std/strtab.wat
+++ b/wat/std/strtab.wat
@@ -1,4 +1,5 @@
 (module
+  ;; @thread shared
   (import "env" "memory" (memory $memory 1 32768))
   (import "alloc" "alloc" (func $alloc (param i32) (result i32)))
   (import "hash" "hash_new" (func $hash_new (param i32) (result i32)))

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,7 @@
+import { createIngestWorkerMessageHandler } from "./host/ingest-worker-runtime.mjs";
+
+const handleMessage = createIngestWorkerMessageHandler();
+
+self.addEventListener("message", (event) => {
+  handleMessage(event);
+});


### PR DESCRIPTION
Moves cold ingest into a dedicated module worker using the thread-aware loader, split host shims, and table-driven OPFS host mappings. The remaining work bundles `worker.bundle.js`, verifies the browser boundary and worker failure cases, and keeps the OPFS host wrappers generated instead of hand-maintained.

Fixes #95.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (7)</summary>

- [x] Bundle and verify worker ingest <!-- type:spec -->
- [x] [Generate or table-drive the repeated OPFS host shim mapping in host/opfs-source.mjs, simplifying the file with loops so the import wrappers are not hand-maintained.](https://github.com/rhencke/tracy/pull/103#discussion_r3198331745) <!-- type:thread -->
- [x] Orchestrate the worker from the main runtime <!-- type:spec -->
- [x] Add the ingest worker runtime <!-- type:spec -->
- [x] Split host shims by thread <!-- type:spec -->
- [x] Generate thread-aware WASM loader helpers <!-- type:spec -->
- [x] Annotate WASM modules with thread ownership <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->