### PR TITLE
v0.1 #41a — Core shell load uses manifest dependency set (closes #111)

### DIFF
--- a/host/runtime.mjs
+++ b/host/runtime.mjs
@@ -1,11 +1,15 @@
 import { INGEST_WORKER_MESSAGE } from "./ingest-worker-runtime.mjs";
-import { instantiateWasmModuleForThread } from "./wasm-modules.mjs";
+import {
+  CORE_SHELL_MODULE_ID,
+  CORE_SHELL_THREAD,
+  instantiateWasmModuleForThread,
+} from "./wasm-modules.mjs";
 
-const MAIN_THREAD = "main";
 const WORKER_URL = "worker.js";
 const PERFORMANCE_MARKS = Object.freeze({
   appReady: "tracy.app.ready",
   bootstrapStart: "tracy.bootstrap.start",
+  coreReady: "tracy.core.ready",
   tracyMainEnd: "tracy.main.end",
   tracyMainStart: "tracy.main.start",
   wasmInstantiateEnd: "tracy.wasm.instantiate.end",
@@ -13,6 +17,7 @@ const PERFORMANCE_MARKS = Object.freeze({
 });
 const PERFORMANCE_MEASURES = Object.freeze({
   appLoad: "tracy.app.load",
+  coreLoad: "tracy.core.load",
   tracyMain: "tracy.main",
   wasmInstantiate: "tracy.wasm.instantiate",
 });
@@ -189,6 +194,14 @@ function errorMessage(error) {
   return error instanceof Error ? error.message : String(error);
 }
 
+function requestInteractiveFrame(options) {
+  const requestFrame = options.requestAnimationFrame ?? globalThis.requestAnimationFrame;
+
+  return new Promise((resolve) => {
+    requestFrame(resolve);
+  });
+}
+
 async function loadApp(memory, host, options = {}) {
   if (!supportsJSPI()) {
     showError(
@@ -200,7 +213,7 @@ async function loadApp(memory, host, options = {}) {
   const imports = { env: { memory }, host };
   const instantiate = options.instantiateWasmModuleForThread ?? instantiateWasmModuleForThread;
   markPerformance(PERFORMANCE_MARKS.wasmInstantiateStart, options);
-  const { exports } = await instantiate("app", MAIN_THREAD, imports, {
+  const { exports } = await instantiate(CORE_SHELL_MODULE_ID, CORE_SHELL_THREAD, imports, {
     baseUrl: options.baseUrl ?? "wasm/",
     compile: options.compile,
     instantiate: options.instantiate,
@@ -212,6 +225,15 @@ async function loadApp(memory, host, options = {}) {
     PERFORMANCE_MARKS.wasmInstantiateEnd,
     options,
   );
+  await requestInteractiveFrame(options);
+  markPerformance(PERFORMANCE_MARKS.coreReady, options);
+  measurePerformance(
+    PERFORMANCE_MEASURES.coreLoad,
+    PERFORMANCE_MARKS.bootstrapStart,
+    PERFORMANCE_MARKS.coreReady,
+    options,
+  );
+
   const { tracy_main, tracy_tick } = exports;
 
   markPerformance(PERFORMANCE_MARKS.tracyMainStart, options);
@@ -231,12 +253,13 @@ async function loadApp(memory, host, options = {}) {
     options,
   );
 
+  const requestFrame = options.requestAnimationFrame ?? globalThis.requestAnimationFrame;
   const loop = (ts) => {
     tracy_tick(ts);
-    requestAnimationFrame(loop);
+    requestFrame(loop);
   };
 
-  requestAnimationFrame(loop);
+  requestFrame(loop);
 
   if (options.ingest !== undefined) {
     options.ingestWorker?.start(

--- a/host/wasm-modules.mjs
+++ b/host/wasm-modules.mjs
@@ -81,6 +81,8 @@ function normalizePath(value) {
 }
 
 const WASM_MODULE_THREADS = Object.freeze(["main", "worker", "shared"]);
+export const CORE_SHELL_MODULE_ID = "app";
+export const CORE_SHELL_THREAD = "main";
 
 function assertWasmModuleThread(thread) {
   if (!WASM_MODULE_THREADS.includes(thread)) {
@@ -172,6 +174,10 @@ export function wasmModuleGraphIdsForThread(id, thread) {
   }
 
   return graphIds;
+}
+
+export function coreShellWasmModuleGraphIds() {
+  return wasmModuleGraphIdsForThread(CORE_SHELL_MODULE_ID, CORE_SHELL_THREAD);
 }
 
 async function defaultCompile(url) {

--- a/tools/app-load-bench.js
+++ b/tools/app-load-bench.js
@@ -61,6 +61,13 @@ const REQUIRED_DIST_FILES = Object.freeze([
   "wasm/parser_state.wasm",
   "worker.js",
 ]);
+const PERFORMANCE_MARKS = Object.freeze({
+  appReady: "tracy.app.ready",
+  bootstrapStart: "tracy.bootstrap.start",
+  coreReady: "tracy.core.ready",
+  wasmInstantiateEnd: "tracy.wasm.instantiate.end",
+});
+const FRAME_SAMPLER_GLOBAL = "__TRACY_APP_LOAD_FRAME_TIMES__";
 
 function parseArgs(argv) {
   const options = {
@@ -98,6 +105,37 @@ function assertMeasuredBudget(name, metrics, budget) {
     if (value > limit) {
       throw new Error(`${name} ${field} ${value.toFixed(1)} > ${limit}`);
     }
+  }
+}
+
+function requireFiniteMarker(timeline, field) {
+  const value = timeline[field];
+
+  if (!Number.isFinite(value)) {
+    throw new Error(`app-load bench missing performance marker ${field}`);
+  }
+
+  return value;
+}
+
+function assertCoreReadyOrdering(timeline) {
+  const bootstrapStartMs = requireFiniteMarker(timeline, "bootstrapStartMs");
+  const wasmInstantiateEndMs = requireFiniteMarker(timeline, "wasmInstantiateEndMs");
+  const firstShellFrameMs = requireFiniteMarker(timeline, "firstShellFrameMs");
+  const coreReadyMs = requireFiniteMarker(timeline, "coreReadyMs");
+  const appReadyMs = requireFiniteMarker(timeline, "appReadyMs");
+
+  if (coreReadyMs <= bootstrapStartMs) {
+    throw new Error("tracy.core.ready must be later than tracy.bootstrap.start");
+  }
+  if (coreReadyMs < wasmInstantiateEndMs) {
+    throw new Error("tracy.core.ready must wait for core wasm dependencies");
+  }
+  if (coreReadyMs < firstShellFrameMs) {
+    throw new Error("tracy.core.ready must wait for the first shell-capable frame");
+  }
+  if (appReadyMs < coreReadyMs) {
+    throw new Error("tracy.app.ready must not precede tracy.core.ready");
   }
 }
 
@@ -520,6 +558,22 @@ async function createPage(cdp) {
   await cdp.send("Network.enable", {}, sessionId);
   await cdp.send("Performance.enable", {}, sessionId);
   await cdp.send("Runtime.enable", {}, sessionId);
+  await cdp.send("Page.addScriptToEvaluateOnNewDocument", {
+    source: `(() => {
+      const frameTimes = [];
+      Object.defineProperty(globalThis, ${JSON.stringify(FRAME_SAMPLER_GLOBAL)}, {
+        configurable: false,
+        value: frameTimes,
+      });
+      function tick() {
+        if (frameTimes.length < 512) {
+          frameTimes.push(performance.now());
+        }
+        requestAnimationFrame(tick);
+      }
+      requestAnimationFrame(tick);
+    })();`,
+  }, sessionId);
 
   return { sessionId, targetId };
 }
@@ -577,10 +631,11 @@ async function navigateAndMeasure(cdp, page, url, options = {}) {
       expression: `(() => {
         const error = document.querySelector('[role="alert"]')?.textContent ?? "";
         const detail = globalThis.__TRACY_APP_LOAD_ERROR__ ?? "";
+        const mark = (name) => performance.getEntriesByName(name)[0]?.startTime;
         return {
           detail,
           error,
-          ready: performance.getEntriesByName("tracy.app.ready").length > 0,
+          ready: Number.isFinite(mark(${JSON.stringify(PERFORMANCE_MARKS.appReady)})),
         };
       })()`,
       returnByValue: true,
@@ -597,14 +652,35 @@ async function navigateAndMeasure(cdp, page, url, options = {}) {
 
   const result = await cdp.send("Runtime.evaluate", {
     expression: `(() => {
+      const mark = (name) => performance.getEntriesByName(name)[0]?.startTime;
       const fcp = performance.getEntriesByName("first-contentful-paint")[0]?.startTime ?? 0;
       const appLoad = performance.getEntriesByName("tracy.app.load")[0]?.duration;
       const wasm = performance.getEntriesByName("tracy.wasm.instantiate")[0]?.duration;
-      return { fcpMs: fcp, ttiMs: appLoad, wasmInstantiateMs: wasm };
+      const bootstrapStartMs = mark(${JSON.stringify(PERFORMANCE_MARKS.bootstrapStart)});
+      const wasmInstantiateEndMs = mark(${JSON.stringify(PERFORMANCE_MARKS.wasmInstantiateEnd)});
+      const coreReadyMs = mark(${JSON.stringify(PERFORMANCE_MARKS.coreReady)});
+      const appReadyMs = mark(${JSON.stringify(PERFORMANCE_MARKS.appReady)});
+      const frameTimes = globalThis[${JSON.stringify(FRAME_SAMPLER_GLOBAL)}] ?? [];
+      return {
+        appReadyMs,
+        bootstrapStartMs,
+        coreReadyMs,
+        fcpMs: fcp,
+        firstShellFrameMs: frameTimes.find((time) => time >= wasmInstantiateEndMs),
+        ttiMs: appLoad,
+        wasmInstantiateMs: wasm,
+        wasmInstantiateEndMs,
+      };
     })()`,
     returnByValue: true,
   }, page.sessionId);
   const metrics = result.result.value;
+
+  // `tracy.core.ready` is the app-load bench's interactivity marker: the
+  // core shell wasm closure is loaded, then the browser reaches a frame that
+  // can run shell input/rendering. The canvas prepaint may happen earlier and
+  // is intentionally not accepted as readiness.
+  assertCoreReadyOrdering(metrics);
 
   metrics.transferBytes = [...loadingBytes]
     .filter(([requestId]) => requestIds.has(requestId) && !cachedRequestIds.has(requestId))
@@ -701,6 +777,45 @@ function runSelfTest() {
     () => assertMeasuredBudget("fixture", { fcpMs: 2 }, { fcpMs: 1 }),
     /fixture fcpMs 2.0 > 1/,
   );
+  assert.doesNotThrow(() =>
+    assertCoreReadyOrdering({
+      appReadyMs: 4,
+      bootstrapStartMs: 0,
+      coreReadyMs: 3,
+      firstShellFrameMs: 3,
+      wasmInstantiateEndMs: 2,
+    }),
+  );
+  assert.throws(
+    () => assertCoreReadyOrdering({
+      appReadyMs: 4,
+      bootstrapStartMs: 0,
+      coreReadyMs: 1,
+      firstShellFrameMs: 3,
+      wasmInstantiateEndMs: 2,
+    }),
+    /core wasm dependencies/,
+  );
+  assert.throws(
+    () => assertCoreReadyOrdering({
+      appReadyMs: 4,
+      bootstrapStartMs: 0,
+      coreReadyMs: 2,
+      firstShellFrameMs: 3,
+      wasmInstantiateEndMs: 2,
+    }),
+    /first shell-capable frame/,
+  );
+  assert.throws(
+    () => assertCoreReadyOrdering({
+      appReadyMs: 2,
+      bootstrapStartMs: 0,
+      coreReadyMs: 3,
+      firstShellFrameMs: 3,
+      wasmInstantiateEndMs: 2,
+    }),
+    /app.ready must not precede/,
+  );
   const staticServerSource = createServer.toString();
   assert.match(staticServerSource, /fs\.promises\.stat/);
   assert.match(staticServerSource, /fs\.createReadStream/);
@@ -750,6 +865,14 @@ function runSelfTest() {
     /dist\/build-info\.js: \$\(filter-out dist\/build-info\.js \$\(SERVICE_WORKER_FILES\),\$\(DIST_FILES\)\)/,
   );
   assert.match(makefile, /node tools\/app-load-bench\.js --self-test/);
+
+  const createPageSource = createPage.toString();
+  const navigateAndMeasureSource = navigateAndMeasure.toString();
+  assert.equal(FRAME_SAMPLER_GLOBAL, "__TRACY_APP_LOAD_FRAME_TIMES__");
+  assert.match(createPageSource, /Page\.addScriptToEvaluateOnNewDocument/);
+  assert.match(createPageSource, /FRAME_SAMPLER_GLOBAL/);
+  assert.match(navigateAndMeasureSource, /assertCoreReadyOrdering\(metrics\)/);
+  assert.match(navigateAndMeasureSource, /canvas prepaint/);
 }
 
 async function main() {

--- a/tools/generate-wasm-modules-abi.js
+++ b/tools/generate-wasm-modules-abi.js
@@ -55,6 +55,8 @@ function renderWasmModulesModule() {
 }
 
 const WASM_MODULE_THREADS = Object.freeze(["main", "worker", "shared"]);
+export const CORE_SHELL_MODULE_ID = "app";
+export const CORE_SHELL_THREAD = "main";
 
 function assertWasmModuleThread(thread) {
   if (!WASM_MODULE_THREADS.includes(thread)) {
@@ -146,6 +148,10 @@ export function wasmModuleGraphIdsForThread(id, thread) {
   }
 
   return graphIds;
+}
+
+export function coreShellWasmModuleGraphIds() {
+  return wasmModuleGraphIdsForThread(CORE_SHELL_MODULE_ID, CORE_SHELL_THREAD);
 }
 
 async function defaultCompile(url) {

--- a/tools/runtime-worker-orchestration-check.js
+++ b/tools/runtime-worker-orchestration-check.js
@@ -69,6 +69,7 @@ class FakeWorker {
 }
 
 async function checkRuntimeOrchestratesWorker() {
+  FakeWorker.instances = [];
   const { frames } = installBrowserStubs();
   const runtime = await import(moduleUrl("host/runtime.mjs"));
   const workerMessages = [];
@@ -143,6 +144,30 @@ async function checkRuntimeOrchestratesWorker() {
       start: "tracy.wasm.instantiate.start",
       end: "tracy.wasm.instantiate.end",
     },
+  ]);
+  assert.equal(frames.length, 1, "core readiness should wait for a frame");
+  assert.deepEqual(worker.posted, []);
+
+  frames[0](100);
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.deepEqual(performanceEntries, [
+    { kind: "mark", name: "tracy.wasm.instantiate.start" },
+    { kind: "mark", name: "tracy.wasm.instantiate.end" },
+    {
+      kind: "measure",
+      name: "tracy.wasm.instantiate",
+      start: "tracy.wasm.instantiate.start",
+      end: "tracy.wasm.instantiate.end",
+    },
+    { kind: "mark", name: "tracy.core.ready" },
+    {
+      kind: "measure",
+      name: "tracy.core.load",
+      start: "tracy.bootstrap.start",
+      end: "tracy.core.ready",
+    },
     { kind: "mark", name: "tracy.main.start" },
     { kind: "mark", name: "tracy.main.end" },
     {
@@ -159,7 +184,7 @@ async function checkRuntimeOrchestratesWorker() {
       end: "tracy.app.ready",
     },
   ]);
-  assert.equal(frames.length, 1, "requestAnimationFrame should be scheduled");
+  assert.equal(frames.length, 2, "requestAnimationFrame should be scheduled");
   assert.deepEqual(worker.posted, [
     {
       indexName: "indexes/trace.idx",
@@ -184,7 +209,7 @@ async function checkRuntimeOrchestratesWorker() {
     committedEvents: 7,
   });
 
-  frames[0](123);
+  frames[1](123);
   assert.deepEqual(ticks, ["main", 123]);
   assert.equal(controller.status().state, "complete");
   assert.equal(controller.status().result.committedEvents, 7);
@@ -204,7 +229,52 @@ async function checkRuntimeOrchestratesWorker() {
   assert.equal(workerMessages.at(-1).status.state, "error");
 }
 
-checkRuntimeOrchestratesWorker().catch((error) => {
+async function checkCoreReadyRequiresSuccessfulLoad() {
+  FakeWorker.instances = [];
+  const { frames } = installBrowserStubs();
+  const runtime = await import(moduleUrl("host/runtime.mjs"));
+  const previousConsoleError = console.error;
+  const performanceEntries = [];
+  const memory = new WebAssembly.Memory({ initial: 1 });
+  const performance = {
+    mark(name) {
+      performanceEntries.push({ kind: "mark", name });
+    },
+    measure(name, start, end) {
+      performanceEntries.push({ kind: "measure", name, start, end });
+    },
+  };
+
+  try {
+    console.error = () => {};
+    runtime.runApp(memory, {}, {
+      instantiateWasmModuleForThread: async () => {
+        throw new Error("missing core dependency");
+      },
+      performance,
+      worker: {
+        Worker: FakeWorker,
+      },
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.deepEqual(performanceEntries, [
+      { kind: "mark", name: "tracy.wasm.instantiate.start" },
+    ]);
+    assert.equal(frames.length, 0, "failed core load should not schedule readiness frame");
+  } finally {
+    console.error = previousConsoleError;
+  }
+}
+
+async function main() {
+  await checkRuntimeOrchestratesWorker();
+  await checkCoreReadyRequiresSuccessfulLoad();
+}
+
+main().catch((error) => {
   console.error(error.stack || error.message || String(error));
   process.exitCode = 1;
 });

--- a/tools/wasm-modules-check.js
+++ b/tools/wasm-modules-check.js
@@ -94,8 +94,11 @@ function assertComesBefore(values, before, after) {
 async function main() {
   const manifestUrl = pathToFileURL(path.resolve(__dirname, "../host/wasm-modules.mjs")).href;
   const {
+    CORE_SHELL_MODULE_ID,
+    CORE_SHELL_THREAD,
     compileWasmModuleGraph,
     compileWasmModuleGraphForThread,
+    coreShellWasmModuleGraphIds,
     instantiateWasmModuleForThread,
     instantiateWasmModule,
     wasmModuleGraphIds,
@@ -110,6 +113,14 @@ async function main() {
   await testExtractorFixtures();
 
   const parserGraphIds = wasmModuleGraphIds("parser");
+  const coreShellGraphIds = coreShellWasmModuleGraphIds();
+
+  assert.equal(CORE_SHELL_MODULE_ID, "app");
+  assert.equal(CORE_SHELL_THREAD, "main");
+  assert(Object.isFrozen(coreShellGraphIds));
+  assert.deepEqual(coreShellGraphIds, wasmModuleGraphIdsForThread("app", "main"));
+  assert.deepEqual(coreShellGraphIds, [...coreShellGraphIds].sort());
+  assert.deepEqual(new Set(coreShellGraphIds), new Set(["app"]));
   assert.deepEqual(parserGraphIds, [...parserGraphIds].sort());
   assert.deepEqual(new Set(parserGraphIds), new Set([
     "std/mem",


### PR DESCRIPTION
Defines the core shell load set from the wasm module manifest and uses it to gate `tracy.core.ready` on loaded shell dependencies plus a real animation frame, not the prepaint optimization. Adds runtime and app-load bench coverage for missing core dependencies, marker ordering, pre-frame fake readiness, and avoiding duplicate instantiation when the full runtime continues.

Fixes #111.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Load core shell and mark frame-gated readiness <!-- type:spec -->
- [x] Teach app-load bench core readiness ordering <!-- type:spec -->
- [x] Add manifest-derived core shell graph helpers <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->