### PR TITLE
v0.1 R1a — Browser-like test harness primitives (closes #155)

### DIFF
--- a/tools/browser-harness.js
+++ b/tools/browser-harness.js
@@ -1,0 +1,138 @@
+"use strict";
+
+function makeFakeElement(overrides = {}) {
+  return {
+    addEventListener() {},
+    removeAttribute() {},
+    removeEventListener() {},
+    setAttribute() {},
+    style: {},
+    set hidden(value) {
+      this.isHidden = value;
+    },
+    ...overrides,
+  };
+}
+
+function makeFakeCanvasContext(overrides = {}) {
+  return {
+    set fillStyle(value) {
+      this.lastFillStyle = value;
+    },
+    fillRect() {},
+    setTransform() {},
+    ...overrides,
+  };
+}
+
+function makeFakeCanvas({
+  context = makeFakeCanvasContext(),
+  elementOverrides = {},
+  height = 240,
+  id = "tracy",
+  width = 320,
+} = {}) {
+  return {
+    clientHeight: height,
+    clientWidth: width,
+    height: 0,
+    hidden: false,
+    id,
+    width: 0,
+    addEventListener() {},
+    getBoundingClientRect() {
+      return { left: 0, top: 0 };
+    },
+    getContext() {
+      return context;
+    },
+    ...elementOverrides,
+  };
+}
+
+function makeFakeDocument({
+  body = { appendChild() {} },
+  canvas = makeFakeCanvas(),
+  createElement = () => makeFakeElement(),
+} = {}) {
+  return {
+    body,
+    createElement,
+    getElementById(id) {
+      return id === canvas?.id ? canvas : null;
+    },
+  };
+}
+
+function installFakeDocument(options = {}) {
+  const canvas = options.canvas ?? makeFakeCanvas(options.canvasOptions);
+  const document = makeFakeDocument({ ...options, canvas });
+
+  globalThis.document = document;
+
+  return { canvas, document };
+}
+
+function installFakeWindow(options = {}) {
+  const window = {
+    devicePixelRatio: 1,
+    addEventListener() {},
+    removeEventListener() {},
+    ...options,
+  };
+
+  globalThis.window = window;
+
+  return window;
+}
+
+function createRafHarness() {
+  const frames = [];
+
+  globalThis.requestAnimationFrame = (callback) => {
+    frames.push(callback);
+    return frames.length;
+  };
+
+  return { frames };
+}
+
+function installJspiStubs() {
+  globalThis.WebAssembly.Suspending = class Suspending {
+    constructor(fn) {
+      return fn;
+    }
+  };
+  globalThis.WebAssembly.promising = (fn) => fn;
+}
+
+function installBrowserGlobals(options = {}) {
+  const installed = installFakeDocument(options);
+  const window = installFakeWindow(options.window);
+  const raf = options.raf === false ? { frames: [] } : createRafHarness();
+
+  if (options.jspi !== false) {
+    installJspiStubs();
+  }
+
+  return { ...installed, ...raf, window };
+}
+
+async function flushMicrotasks(count = 1) {
+  for (let index = 0; index < count; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+module.exports = {
+  createRafHarness,
+  flushMicrotasks,
+  installBrowserGlobals,
+  installFakeDocument,
+  installFakeWindow,
+  installJspiStubs,
+  makeFakeCanvas,
+  makeFakeCanvasContext,
+  makeFakeDocument,
+  makeFakeElement,
+};

--- a/tools/host-shim-check.js
+++ b/tools/host-shim-check.js
@@ -3,61 +3,14 @@
 const assert = require("node:assert/strict");
 const { pathToFileURL } = require("node:url");
 const path = require("node:path");
-
-function installBrowserStubs() {
-  const canvasContext = {
-    set fillStyle(value) {
-      this.lastFillStyle = value;
-    },
-    fillRect() {},
-    setTransform() {},
-  };
-  const canvas = {
-    clientWidth: 320,
-    clientHeight: 240,
-    hidden: false,
-    width: 0,
-    height: 0,
-    getBoundingClientRect() {
-      return { left: 0, top: 0 };
-    },
-    getContext() {
-      return canvasContext;
-    },
-    addEventListener() {},
-  };
-
-  globalThis.document = {
-    body: {
-      appendChild() {},
-    },
-    createElement() {
-      return {
-        addEventListener() {},
-        removeAttribute() {},
-        removeEventListener() {},
-        set hidden(value) {
-          this.isHidden = value;
-        },
-      };
-    },
-    getElementById(id) {
-      return id === "tracy" ? canvas : null;
-    },
-  };
-  globalThis.window = {
-    devicePixelRatio: 1,
-    addEventListener() {},
-    removeEventListener() {},
-  };
-}
+const { installBrowserGlobals } = require("./browser-harness.js");
 
 function hostKeys(host) {
   return new Set(Object.keys(host));
 }
 
 async function main() {
-  installBrowserStubs();
+  installBrowserGlobals({ raf: false, jspi: false });
 
   const shimUrl = pathToFileURL(path.resolve(__dirname, "../host/shim.mjs")).href;
   const abiUrl = pathToFileURL(path.resolve(__dirname, "../host/abi.mjs")).href;

--- a/tools/interactive-ingest-check.js
+++ b/tools/interactive-ingest-check.js
@@ -5,6 +5,13 @@ const fs = require("node:fs/promises");
 const path = require("node:path");
 const { performance } = require("node:perf_hooks");
 const { pathToFileURL } = require("node:url");
+const {
+  flushMicrotasks,
+  installBrowserGlobals,
+  makeFakeCanvas,
+  makeFakeCanvasContext,
+  makeFakeElement,
+} = require("./browser-harness.js");
 
 let FIXTURE_SIZE_BYTES;
 let INGEST_WINDOW_BYTES;
@@ -82,34 +89,10 @@ function makeInteractiveIngestMemory() {
 }
 
 function installBrowserHarness(canvas) {
-  const frames = [];
-
-  globalThis.document = {
-    body: {
-      appendChild() {},
-    },
-    createElement() {
-      return {
-        setAttribute() {},
-        style: {},
-      };
-    },
-    getElementById(id) {
-      return id === "tracy" ? canvas : null;
-    },
-  };
-  globalThis.requestAnimationFrame = (callback) => {
-    frames.push(callback);
-    return frames.length;
-  };
-  globalThis.WebAssembly.Suspending = class Suspending {
-    constructor(fn) {
-      return fn;
-    }
-  };
-  globalThis.WebAssembly.promising = (fn) => fn;
-
-  return { frames };
+  return installBrowserGlobals({
+    canvas,
+    createElement: () => makeFakeElement(),
+  });
 }
 
 class FakeWorker {
@@ -574,7 +557,7 @@ function makeCanvasHarness() {
   let currentFrameAt = 0;
   let firstTraceDrawAt = null;
   let firstTraceDrawWallAt = null;
-  const context = {
+  const context = makeFakeCanvasContext({
     beginPath() {
       operations.push({ at: currentFrameAt, op: "beginPath" });
     },
@@ -587,7 +570,7 @@ function makeCanvasHarness() {
     fillRect(x, y, width, height) {
       operations.push({
         at: currentFrameAt,
-        fillStyle: this.fillStyle,
+        fillStyle: this.fillStyle ?? this.lastFillStyle,
         height,
         op: "fillRect",
         width,
@@ -625,23 +608,25 @@ function makeCanvasHarness() {
         strokeStyle: this.strokeStyle,
       });
     },
-  };
-  const canvas = {
+  });
+  const canvas = makeFakeCanvas({
+    context,
     height: 180,
     width: 360,
-    addEventListener(type, callback) {
-      listeners.set(type, callback);
+    elementOverrides: {
+      height: 180,
+      width: 360,
+      addEventListener(type, callback) {
+        listeners.set(type, callback);
+      },
+      getContext(type) {
+        assert.equal(type, "2d");
+        return context;
+      },
+      releasePointerCapture() {},
+      setPointerCapture() {},
     },
-    getBoundingClientRect() {
-      return { left: 0, top: 0 };
-    },
-    getContext(type) {
-      assert.equal(type, "2d");
-      return context;
-    },
-    releasePointerCapture() {},
-    setPointerCapture() {},
-  };
+  });
 
   return {
     canvas,
@@ -657,12 +642,6 @@ function makeCanvasHarness() {
       currentFrameAt = value;
     },
   };
-}
-
-async function flushMicrotasks(count = 1) {
-  for (let i = 0; i < count; i += 1) {
-    await Promise.resolve();
-  }
 }
 
 async function flushAsyncWork() {

--- a/tools/runtime-worker-orchestration-check.js
+++ b/tools/runtime-worker-orchestration-check.js
@@ -4,6 +4,11 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
 const { pathToFileURL } = require("node:url");
+const {
+  flushMicrotasks,
+  installBrowserGlobals,
+  makeFakeElement,
+} = require("./browser-harness.js");
 
 let OPFS_PAGE_SIZE;
 let INDEX_DECODE_HINT_COMPACT_SLICES;
@@ -66,39 +71,6 @@ async function loadGeneratedTraceRendererSpec() {
   TEST_TRACE_RENDER_RANGE_BYTES = TRACE_RENDERER_INCOMPLETE_RANGE_LAYOUT.BYTES;
 }
 
-function installBrowserStubs() {
-  const frames = [];
-
-  globalThis.document = {
-    body: {
-      appendChild() {},
-    },
-    createElement() {
-      return {
-        setAttribute() {},
-        style: {},
-      };
-    },
-    getElementById() {
-      return {
-        hidden: false,
-      };
-    },
-  };
-  globalThis.requestAnimationFrame = (callback) => {
-    frames.push(callback);
-    return frames.length;
-  };
-  globalThis.WebAssembly.Suspending = class Suspending {
-    constructor(fn) {
-      return fn;
-    }
-  };
-  globalThis.WebAssembly.promising = (fn) => fn;
-
-  return { frames };
-}
-
 class FakeWorker {
   static instances = [];
 
@@ -127,10 +99,15 @@ class FakeWorker {
   }
 }
 
-async function flushMicrotasks(count = 8) {
-  for (let index = 0; index < count; index += 1) {
-    await Promise.resolve();
-  }
+function installBrowserStubs() {
+  return installBrowserGlobals({
+    canvas: { hidden: false, id: "tracy" },
+    createElement: () => makeFakeElement(),
+  });
+}
+
+async function flushRuntimeMicrotasks(count = 8) {
+  await flushMicrotasks(count);
 }
 
 function readTraceRenderRow(memory, ptr, index) {
@@ -744,7 +721,7 @@ async function checkRuntimeOrchestratesWorker() {
   assert.equal(FakeWorker.instances.length, 0);
   assert.ok(frames.length >= 1, "draw loop should be scheduled before ingest preload");
   frames[0](0);
-  await flushMicrotasks();
+  await flushRuntimeMicrotasks();
   assert.equal(FakeWorker.instances.length, 0);
   assert.ok(
     frames.length >= 2,
@@ -754,7 +731,7 @@ async function checkRuntimeOrchestratesWorker() {
   for (const frame of appReadyFrameCallbacks) {
     frame(16);
   }
-  await flushMicrotasks();
+  await flushRuntimeMicrotasks();
 
   assert.equal(FakeWorker.instances.length, 1);
   const worker = FakeWorker.instances[0];
@@ -837,7 +814,7 @@ async function checkRuntimeOrchestratesWorker() {
   frames[0](122);
   frames[1](123);
   await import(moduleUrl("host/trace-renderer-spec.mjs"));
-  await flushMicrotasks();
+  await flushRuntimeMicrotasks();
   assert.deepEqual(performanceEntries.slice(-2), [
     { kind: "mark", name: "tracy.app.ready" },
     {
@@ -921,14 +898,14 @@ async function checkRuntimeStartsIngestFromFileSelection() {
 
   assert.equal(controller.worker, null);
   frames[0](0);
-  await flushMicrotasks();
+  await flushRuntimeMicrotasks();
   assert.equal(controller.worker, null);
   assert.ok(frames.length >= 2);
   const appReadyFrameCallbacks = frames.splice(0);
   for (const frame of appReadyFrameCallbacks) {
     frame(16);
   }
-  await flushMicrotasks();
+  await flushRuntimeMicrotasks();
 
   const preloadWorker = controller.worker;
   assert.deepEqual(preloadWorker.posted, [{ type: "preload" }]);
@@ -2997,7 +2974,7 @@ async function checkRuntimePreloadsProgressiveTraceRendererImplementation() {
     },
   });
 
-  await flushMicrotasks();
+  await flushRuntimeMicrotasks();
 
   assert.equal(
     importCalls,
@@ -3005,14 +2982,14 @@ async function checkRuntimePreloadsProgressiveTraceRendererImplementation() {
     "renderer implementation module import should start before the first animation frame",
   );
   frames[0](1);
-  await flushMicrotasks();
+  await flushRuntimeMicrotasks();
   assert.equal(importCalls, 1, "renderer implementation module should be imported once");
   assert.equal(drawCalls, 0, "renderer should not draw before covered pages are queryable");
 
   coveredRange = { end: 0, start: 0, type: "covered_range", valid: false };
   readerState = "ready";
   frames[1](2);
-  await flushMicrotasks();
+  await flushRuntimeMicrotasks();
   assert.equal(
     drawCalls,
     0,
@@ -3020,7 +2997,7 @@ async function checkRuntimePreloadsProgressiveTraceRendererImplementation() {
   );
 
   frames[2](3);
-  await flushMicrotasks();
+  await flushRuntimeMicrotasks();
   frames[3](4);
   assert.equal(
     drawCalls,
@@ -3047,7 +3024,7 @@ async function checkRuntimePreloadsProgressiveTraceRendererImplementation() {
     "first queryable ingest frame should reuse the preloaded renderer implementation module",
   );
 
-  await flushMicrotasks();
+  await flushRuntimeMicrotasks();
   frames[5](6);
   assert.equal(importCalls, 1);
   assert.equal(drawCalls, 3);
@@ -3092,10 +3069,10 @@ async function checkRuntimeDrawsProgressiveRendererWhenCreatedQueryable() {
     },
   });
 
-  await flushMicrotasks();
+  await flushRuntimeMicrotasks();
   frames[0](1);
   frames[1](2);
-  await flushMicrotasks();
+  await flushRuntimeMicrotasks();
 
   assert.equal(
     drawCalls,
@@ -3139,7 +3116,7 @@ async function checkAppReadyWaitsForFirstFrameAndDeferredRenderer() {
     },
   });
 
-  await flushMicrotasks();
+  await flushRuntimeMicrotasks();
 
   assert.equal(
     performanceEntries.some((entry) => entry.name === "tracy.core.ready"),
@@ -3158,7 +3135,7 @@ async function checkAppReadyWaitsForFirstFrameAndDeferredRenderer() {
   );
 
   frames[0](1);
-  await flushMicrotasks();
+  await flushRuntimeMicrotasks();
   assert.equal(
     performanceEntries.some((entry) => entry.name === "tracy.app.ready"),
     false,
@@ -3171,7 +3148,7 @@ async function checkAppReadyWaitsForFirstFrameAndDeferredRenderer() {
     },
   });
   await import(moduleUrl("host/trace-renderer-spec.mjs"));
-  await flushMicrotasks();
+  await flushRuntimeMicrotasks();
   assert.deepEqual(performanceEntries.slice(-2), [
     { kind: "mark", name: "tracy.app.ready" },
     {
@@ -3216,9 +3193,9 @@ async function checkAppReadyFailsWhenDeferredRendererFails() {
     },
   });
 
-  await flushMicrotasks();
+  await flushRuntimeMicrotasks();
   frames[0](1);
-  await flushMicrotasks();
+  await flushRuntimeMicrotasks();
 
   assert.equal(
     performanceEntries.some((entry) => entry.name === "tracy.app.ready"),


### PR DESCRIPTION
Extracts shared fake browser primitives for Node-based browser-boundary checks, then moves the runtime orchestration and interactive ingest checks onto that harness. The scenario-specific workers, fixtures, OPFS topology, timing budgets, and assertions stay in the checks, so this remains a test-harness refactor with no production behavior changes.

Fixes #155.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Migrate runtime orchestration checks to the harness <!-- type:spec -->
- [x] Migrate interactive ingest checks to the harness <!-- type:spec -->
- [x] Extract shared fake DOM/canvas/RAF primitives <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->