### PR TITLE
v0.1 R1c — Migrate ingest/runtime checks onto the shared harness (closes #157)

### DIFF
--- a/tools/browser-harness.js
+++ b/tools/browser-harness.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { moduleUrl } = require("./acceptance-wasm-helpers.js");
+
 function makeFakeElement(overrides = {}) {
   return {
     addEventListener() {},
@@ -97,6 +99,22 @@ function createRafHarness() {
   return { frames };
 }
 
+async function runAnimationFrame(frames, timestamp, options = {}) {
+  const frame = frames.shift();
+
+  if (typeof frame !== "function") {
+    throw new Error(`expected a frame callback at ${timestamp} ms`);
+  }
+
+  options.beforeFrame?.(timestamp);
+  const startedAt = options.performance?.now?.();
+  frame(timestamp);
+  if (startedAt !== undefined) {
+    options.frameDurations?.push(options.performance.now() - startedAt);
+  }
+  await flushMicrotasks(options.microtasks ?? 1);
+}
+
 function installJspiStubs() {
   globalThis.WebAssembly.Suspending = class Suspending {
     constructor(fn) {
@@ -118,21 +136,96 @@ function installBrowserGlobals(options = {}) {
   return { ...installed, ...raf, window };
 }
 
+function installRuntimeBrowserGlobals(options = {}) {
+  const {
+    canvas = {},
+    createElement = () => makeFakeElement(),
+    ...browserOptions
+  } = options;
+
+  return installBrowserGlobals({
+    canvas: { hidden: false, id: "tracy", ...canvas },
+    createElement,
+    ...browserOptions,
+  });
+}
+
 async function flushMicrotasks(count = 1) {
   for (let index = 0; index < count; index += 1) {
     await Promise.resolve();
   }
 }
 
+async function flushRuntimeMicrotasks(count = 8) {
+  await flushMicrotasks(count);
+}
+
+async function flushAsyncWork(options = {}) {
+  await flushMicrotasks(options.beforeImmediateMicrotasks ?? 1);
+  if (options.immediate !== false) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  await flushMicrotasks(options.afterImmediateMicrotasks ?? 1);
+}
+
+function createFakeWorkerClass() {
+  return class FakeWorker {
+    static instances = [];
+
+    static reset() {
+      this.instances.length = 0;
+    }
+
+    constructor(url, options) {
+      this.events = new Map();
+      this.options = options;
+      this.posted = [];
+      this.url = url;
+      this.constructor.instances.push(this);
+    }
+
+    addEventListener(type, callback) {
+      this.events.set(type, callback);
+    }
+
+    emit(type, data) {
+      this.events.get(type)?.({ data });
+    }
+
+    postMessage(message) {
+      this.posted.push(message);
+    }
+
+    terminate() {
+      this.terminated = true;
+    }
+  };
+}
+
+function repoModuleUrl(relativePath) {
+  return moduleUrl(relativePath);
+}
+
+function importRepoModule(relativePath) {
+  return import(repoModuleUrl(relativePath));
+}
+
 module.exports = {
+  createFakeWorkerClass,
   createRafHarness,
+  flushAsyncWork,
   flushMicrotasks,
+  flushRuntimeMicrotasks,
+  importRepoModule,
   installBrowserGlobals,
   installFakeDocument,
   installFakeWindow,
   installJspiStubs,
+  installRuntimeBrowserGlobals,
   makeFakeCanvas,
   makeFakeCanvasContext,
   makeFakeDocument,
   makeFakeElement,
+  repoModuleUrl,
+  runAnimationFrame,
 };

--- a/tools/browser-harness.js
+++ b/tools/browser-harness.js
@@ -138,13 +138,22 @@ function installBrowserGlobals(options = {}) {
 
 function installRuntimeBrowserGlobals(options = {}) {
   const {
-    canvas = {},
+    canvas,
     createElement = () => makeFakeElement(),
     ...browserOptions
   } = options;
+  const canvasOverrides = { hidden: false, id: "tracy", ...canvas };
+  const runtimeCanvas =
+    typeof canvas?.getContext === "function"
+      ? canvas
+      : makeFakeCanvas({
+          elementOverrides: canvasOverrides,
+          height: canvas?.height,
+          width: canvas?.width,
+        });
 
   return installBrowserGlobals({
-    canvas: { hidden: false, id: "tracy", ...canvas },
+    canvas: runtimeCanvas,
     createElement,
     ...browserOptions,
   });

--- a/tools/direct-esm-check.js
+++ b/tools/direct-esm-check.js
@@ -206,6 +206,39 @@ function assertRuntimeWorkerCheckUsesGeneratedIndexFormatSpec() {
   }
 }
 
+function assertRuntimeWorkerCheckUsesSharedHarness() {
+  const source = readRepoFile("tools/runtime-worker-orchestration-check.js");
+
+  for (const [pattern, message] of [
+    [/createFakeWorkerClass/, "fake Worker"],
+    [/installRuntimeBrowserGlobals/, "browser globals"],
+    [/flushRuntimeMicrotasks/, "runtime microtask flushing"],
+    [/importRepoModule/, "repo module imports"],
+  ]) {
+    assert.match(
+      source,
+      pattern,
+      `runtime worker orchestration check should get ${message} from the shared browser harness`,
+    );
+  }
+
+  for (const [pattern, message] of [
+    [/class\s+FakeWorker\b/, "a local fake Worker class"],
+    [/function\s+installBrowserStubs\b/, "a local browser stub installer"],
+    [/function\s+flushRuntimeMicrotasks\b/, "a local runtime microtask flusher"],
+    [/moduleUrl\(/, "direct moduleUrl imports"],
+    [/installBrowserGlobals/, "low-level browser global installation"],
+    [/makeFakeElement/, "local fake element wiring"],
+    [/globalThis\.requestAnimationFrame\s*=/, "local RAF installation"],
+  ]) {
+    assert.doesNotMatch(
+      source,
+      pattern,
+      `runtime worker orchestration check should not own ${message}`,
+    );
+  }
+}
+
 function assertInteractiveIngestCheckUsesGeneratedVerificationSpec() {
   const source = readRepoFile("tools/interactive-ingest-check.js");
   const startupSpecSource = readRepoFile("host/startup-spec.mjs");
@@ -349,6 +382,41 @@ function assertInteractiveIngestCheckUsesGeneratedVerificationSpec() {
     /interactive_ingest_expect_independent_memories/,
     "interactive ingest gate should fail closed when main and worker Wasm memories are shared",
   );
+}
+
+function assertInteractiveIngestCheckUsesSharedHarness() {
+  const source = readRepoFile("tools/interactive-ingest-check.js");
+
+  for (const [pattern, message] of [
+    [/createFakeWorkerClass/, "fake Worker"],
+    [/installRuntimeBrowserGlobals/, "browser globals"],
+    [/flushAsyncWork/, "async flushing"],
+    [/runAnimationFrame/, "frame execution"],
+    [/importRepoModule/, "repo module imports"],
+  ]) {
+    assert.match(
+      source,
+      pattern,
+      `interactive ingest check should get ${message} from the shared browser harness`,
+    );
+  }
+
+  for (const [pattern, message] of [
+    [/class\s+FakeWorker\b/, "a local fake Worker class"],
+    [/function\s+installBrowserHarness\b/, "a local browser harness installer"],
+    [/function\s+flushAsyncWork\b/, "a local async flusher"],
+    [/function\s+runFrame\b/, "a local frame runner"],
+    [/moduleUrl\(/, "direct moduleUrl imports"],
+    [/installBrowserGlobals/, "low-level browser global installation"],
+    [/makeFakeElement/, "local fake element wiring"],
+    [/globalThis\.requestAnimationFrame\s*=/, "local RAF installation"],
+  ]) {
+    assert.doesNotMatch(
+      source,
+      pattern,
+      `interactive ingest check should not own ${message}`,
+    );
+  }
 }
 
 function assertIngestWorkerProgressPolicyUsesGeneratedSpec() {
@@ -894,7 +962,9 @@ function main() {
   assertNoInlinePaletteColor("host/runtime.mjs");
   assertIndexCatalogUsesGeneratedFormatSpec();
   assertRuntimeWorkerCheckUsesGeneratedIndexFormatSpec();
+  assertRuntimeWorkerCheckUsesSharedHarness();
   assertInteractiveIngestCheckUsesGeneratedVerificationSpec();
+  assertInteractiveIngestCheckUsesSharedHarness();
 }
 
 try {

--- a/tools/host-shim-check.js
+++ b/tools/host-shim-check.js
@@ -3,13 +3,37 @@
 const assert = require("node:assert/strict");
 const { pathToFileURL } = require("node:url");
 const path = require("node:path");
-const { installBrowserGlobals } = require("./browser-harness.js");
+const {
+  installBrowserGlobals,
+  installRuntimeBrowserGlobals,
+} = require("./browser-harness.js");
 
 function hostKeys(host) {
   return new Set(Object.keys(host));
 }
 
 async function main() {
+  const runtimeGlobals = installRuntimeBrowserGlobals({ raf: false, jspi: false });
+
+  assert.equal(runtimeGlobals.canvas.id, "tracy");
+  assert.equal(runtimeGlobals.canvas.hidden, false);
+  assert.equal(typeof runtimeGlobals.canvas.getContext, "function");
+  assert.equal(typeof runtimeGlobals.canvas.getBoundingClientRect, "function");
+  assert.equal(typeof runtimeGlobals.canvas.addEventListener, "function");
+  assert.equal(runtimeGlobals.canvas.clientWidth, 320);
+  assert.equal(runtimeGlobals.canvas.clientHeight, 240);
+
+  const partialRuntimeGlobals = installRuntimeBrowserGlobals({
+    canvas: { height: 180, width: 360 },
+    raf: false,
+    jspi: false,
+  });
+
+  assert.equal(partialRuntimeGlobals.canvas.id, "tracy");
+  assert.equal(typeof partialRuntimeGlobals.canvas.getContext, "function");
+  assert.equal(partialRuntimeGlobals.canvas.clientWidth, 360);
+  assert.equal(partialRuntimeGlobals.canvas.clientHeight, 180);
+
   installBrowserGlobals({ raf: false, jspi: false });
 
   const shimUrl = pathToFileURL(path.resolve(__dirname, "../host/shim.mjs")).href;

--- a/tools/interactive-ingest-check.js
+++ b/tools/interactive-ingest-check.js
@@ -6,14 +6,16 @@ const {
   compileDistWasmModule,
   distWasmModuleOptions,
   instantiateDistWasmModule,
-  moduleUrl,
 } = require("./acceptance-wasm-helpers.js");
 const {
+  createFakeWorkerClass,
+  flushAsyncWork,
   flushMicrotasks,
-  installBrowserGlobals,
+  importRepoModule,
+  installRuntimeBrowserGlobals,
   makeFakeCanvas,
   makeFakeCanvasContext,
-  makeFakeElement,
+  runAnimationFrame,
 } = require("./browser-harness.js");
 
 let FIXTURE_SIZE_BYTES;
@@ -24,10 +26,9 @@ let REQUIRED_TRACE_RENDER_PLANNER_EXPORTS;
 const FIRST_EVENTS_BUDGET_MS = 100;
 
 async function loadGeneratedInteractiveIngestCheckSpec() {
-  const { INTERACTIVE_INGEST_CHECK } = await import(moduleUrl("host/startup-spec.mjs"));
-  const { TRACE_RENDERER_REQUIRED_EXPORTS } = await import(
-    moduleUrl("host/trace-renderer-spec.mjs")
-  );
+  const { INTERACTIVE_INGEST_CHECK } = await importRepoModule("host/startup-spec.mjs");
+  const { TRACE_RENDERER_REQUIRED_EXPORTS } =
+    await importRepoModule("host/trace-renderer-spec.mjs");
 
   FIXTURE_SIZE_BYTES = INTERACTIVE_INGEST_CHECK.FIXTURE_SIZE_BYTES;
   INGEST_WINDOW_BYTES = INTERACTIVE_INGEST_CHECK.INGEST_WINDOW_BYTES;
@@ -68,37 +69,7 @@ function makeInteractiveIngestMemory() {
   return new WebAssembly.Memory({ initial: 8272, maximum: 32768 });
 }
 
-function installBrowserHarness(canvas) {
-  return installBrowserGlobals({
-    canvas,
-    createElement: () => makeFakeElement(),
-  });
-}
-
-class FakeWorker {
-  constructor(url, options) {
-    this.events = new Map();
-    this.options = options;
-    this.posted = [];
-    this.url = url;
-  }
-
-  addEventListener(type, callback) {
-    this.events.set(type, callback);
-  }
-
-  emit(type, data) {
-    this.events.get(type)?.({ data });
-  }
-
-  postMessage(message) {
-    this.posted.push(message);
-  }
-
-  terminate() {
-    this.terminated = true;
-  }
-}
+const FakeWorker = createFakeWorkerClass();
 
 function decodeString(memory, ptr, len) {
   return new TextDecoder().decode(new Uint8Array(memory.buffer, ptr, len));
@@ -624,12 +595,6 @@ function makeCanvasHarness() {
   };
 }
 
-async function flushAsyncWork() {
-  await flushMicrotasks();
-  await new Promise((resolve) => setImmediate(resolve));
-  await flushMicrotasks();
-}
-
 function assertProductionTraceRenderPlannerExports(exports) {
   for (const name of REQUIRED_TRACE_RENDER_PLANNER_EXPORTS) {
     assert.equal(
@@ -656,14 +621,14 @@ async function waitForAsyncCondition(callback, label, timeoutMs = 2000) {
 
 async function checkInteractiveIngestGate() {
   await loadGeneratedInteractiveIngestCheckSpec();
-  const runtime = await import(moduleUrl("host/runtime.mjs"));
-  const ingestRuntime = await import(moduleUrl("host/ingest-worker-runtime.mjs"));
-  const wasmModules = await import(moduleUrl("host/wasm-modules.mjs"));
-  const abi = await import(moduleUrl("host/abi.mjs"));
-  const rendererModule = await import(moduleUrl("host/progressive-trace-renderer.mjs"));
+  const runtime = await importRepoModule("host/runtime.mjs");
+  const ingestRuntime = await importRepoModule("host/ingest-worker-runtime.mjs");
+  const wasmModules = await importRepoModule("host/wasm-modules.mjs");
+  const abi = await importRepoModule("host/abi.mjs");
+  const rendererModule = await importRepoModule("host/progressive-trace-renderer.mjs");
   const memory = makeInteractiveIngestMemory();
   const canvasHarness = makeCanvasHarness();
-  const { frames } = installBrowserHarness(canvasHarness.canvas);
+  const { frames } = installRuntimeBrowserGlobals({ canvas: canvasHarness.canvas });
   const sourceName = "sources/throttled-100mb.json";
   const workerStatuses = [];
   const importCalls = [];
@@ -867,16 +832,15 @@ async function checkInteractiveIngestGate() {
     () => frames.length >= 1,
     "interactive ingest gate should schedule frames before production preload",
   );
-  await runFrame(frames, canvasHarness, 0);
+  await runInteractiveFrame(frames, canvasHarness, 0);
   await flushAsyncWork();
   await waitForAsyncCondition(
     () => frames.length >= 1,
     "interactive ingest gate should schedule an app-ready follow-up frame before ingest preload",
   );
   const appReadyFrameCallbacks = frames.splice(0);
-  for (const frame of appReadyFrameCallbacks) {
-    canvasHarness.setFrameAt(16);
-    frame(16);
+  while (appReadyFrameCallbacks.length > 0) {
+    await runInteractiveFrame(appReadyFrameCallbacks, canvasHarness, 16);
   }
   await flushAsyncWork();
   await waitForAsyncCondition(
@@ -914,7 +878,7 @@ async function checkInteractiveIngestGate() {
     "interactive ingest gate should schedule frames after production preload",
   );
   if (frames.length > 0) {
-    await runFrame(frames, canvasHarness, 0);
+    await runInteractiveFrame(frames, canvasHarness, 0);
   }
   assertInteractiveContractOk(
     interactiveContract,
@@ -965,7 +929,7 @@ async function checkInteractiveIngestGate() {
       continue;
     }
 
-    await runFrame(frames, canvasHarness, nextFrameAt, frameDurations);
+    await runInteractiveFrame(frames, canvasHarness, nextFrameAt, frameDurations);
     await flushAsyncWork();
     nextFrameAt += 16;
   }
@@ -1101,7 +1065,7 @@ async function checkInteractiveIngestGate() {
     "interactive ingest gate should instantiate the real production app renderer planner module",
   );
 
-  await runFrame(frames, canvasHarness, nextFrameAt, frameDurations);
+  await runInteractiveFrame(frames, canvasHarness, nextFrameAt, frameDurations);
   nextFrameAt += 16;
 
   const queryableCoveredRange = controller.indexReader.coveredRange();
@@ -1134,7 +1098,7 @@ async function checkInteractiveIngestGate() {
     deltaY: -500,
     preventDefault() {},
   });
-  await runFrame(frames, canvasHarness, nextFrameAt, frameDurations);
+  await runInteractiveFrame(frames, canvasHarness, nextFrameAt, frameDurations);
   nextFrameAt += 16;
   const zoomedViewport = rendererInstance.status().viewport;
   assertInteractiveContractOk(
@@ -1161,7 +1125,7 @@ async function checkInteractiveIngestGate() {
     preventDefault() {},
   });
   canvasHarness.listeners.get("pointerup")({ pointerId: 1 });
-  await runFrame(frames, canvasHarness, nextFrameAt, frameDurations);
+  await runInteractiveFrame(frames, canvasHarness, nextFrameAt, frameDurations);
   nextFrameAt += 16;
   assertInteractiveContractOk(
     interactiveContract,
@@ -1173,7 +1137,7 @@ async function checkInteractiveIngestGate() {
     ],
   );
 
-  await runFrame(frames, canvasHarness, nextFrameAt, frameDurations);
+  await runInteractiveFrame(frames, canvasHarness, nextFrameAt, frameDurations);
   const progressStatuses = workerStatuses.filter(
     (entry) => entry.message?.type === "progress",
   );
@@ -1239,16 +1203,12 @@ function nextWorkerTime() {
 
 nextWorkerTime.times = [0, 10, 20, 34, 3034, 3035];
 
-async function runFrame(frames, canvasHarness, ts, frameDurations = null) {
-  const frame = frames.shift();
-
-  assert.equal(typeof frame, "function", `expected a frame callback at ${ts} ms`);
-  canvasHarness.setFrameAt(ts);
-  const startedAt = performance.now();
-  frame(ts);
-  const duration = performance.now() - startedAt;
-  frameDurations?.push(duration);
-  await flushMicrotasks();
+async function runInteractiveFrame(frames, canvasHarness, ts, frameDurations = null) {
+  await runAnimationFrame(frames, ts, {
+    beforeFrame: (timestamp) => canvasHarness.setFrameAt(timestamp),
+    frameDurations,
+    performance,
+  });
 }
 
 checkInteractiveIngestGate().catch((error) => {

--- a/tools/runtime-worker-orchestration-check.js
+++ b/tools/runtime-worker-orchestration-check.js
@@ -3,11 +3,11 @@
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
-const { moduleUrl } = require("./acceptance-wasm-helpers.js");
 const {
-  flushMicrotasks,
-  installBrowserGlobals,
-  makeFakeElement,
+  createFakeWorkerClass,
+  flushRuntimeMicrotasks,
+  importRepoModule,
+  installRuntimeBrowserGlobals,
 } = require("./browser-harness.js");
 
 let OPFS_PAGE_SIZE;
@@ -25,9 +25,8 @@ let TEST_TRACE_RENDER_ROW_BYTES;
 let TEST_TRACE_RENDER_RANGE_BYTES;
 
 async function loadGeneratedIndexFormatSpec() {
-  const { INDEX_DECODE_HINTS, INDEX_FORMAT, INDEX_PAGE_HEADER_OFFSETS } = await import(
-    moduleUrl("host/index-format-spec.mjs")
-  );
+  const { INDEX_DECODE_HINTS, INDEX_FORMAT, INDEX_PAGE_HEADER_OFFSETS } =
+    await importRepoModule("host/index-format-spec.mjs");
 
   OPFS_PAGE_SIZE = INDEX_FORMAT.OPFS_PAGE_SIZE;
   INDEX_DECODE_HINT_COMPACT_SLICES = INDEX_DECODE_HINTS.COMPACT_SLICES;
@@ -43,7 +42,7 @@ async function loadGeneratedTraceRendererSpec() {
     INDEX_QUERY_RESULT_LAYOUT,
     TRACE_RENDERER_CANVAS_OPS,
     TRACE_RENDERER_INCOMPLETE_RANGE_LAYOUT,
-  } = await import(moduleUrl("host/trace-renderer-spec.mjs")));
+  } = await importRepoModule("host/trace-renderer-spec.mjs"));
   TEST_TRACE_RENDER_COMMAND = Object.freeze({
     BYTES: TRACE_RENDERER_CANVAS_OPS.DRAW_COMMAND_BYTES,
     CLEAR_RECT: TRACE_RENDERER_CANVAS_OPS.DRAW_CLEAR_RECT_TAG,
@@ -67,44 +66,7 @@ async function loadGeneratedTraceRendererSpec() {
   TEST_TRACE_RENDER_RANGE_BYTES = TRACE_RENDERER_INCOMPLETE_RANGE_LAYOUT.BYTES;
 }
 
-class FakeWorker {
-  static instances = [];
-
-  constructor(url, options) {
-    this.events = new Map();
-    this.options = options;
-    this.posted = [];
-    this.url = url;
-    FakeWorker.instances.push(this);
-  }
-
-  addEventListener(type, callback) {
-    this.events.set(type, callback);
-  }
-
-  emit(type, data) {
-    this.events.get(type)?.({ data });
-  }
-
-  postMessage(message) {
-    this.posted.push(message);
-  }
-
-  terminate() {
-    this.terminated = true;
-  }
-}
-
-function installBrowserStubs() {
-  return installBrowserGlobals({
-    canvas: { hidden: false, id: "tracy" },
-    createElement: () => makeFakeElement(),
-  });
-}
-
-async function flushRuntimeMicrotasks(count = 8) {
-  await flushMicrotasks(count);
-}
+const FakeWorker = createFakeWorkerClass();
 
 function readTraceRenderRow(memory, ptr, index) {
   const view = new DataView(memory.buffer);
@@ -642,8 +604,8 @@ function makeAppExports(extra = {}) {
 }
 
 async function checkRuntimeOrchestratesWorker() {
-  const { frames } = installBrowserStubs();
-  const runtime = await import(moduleUrl("host/runtime.mjs"));
+  const { frames } = installRuntimeBrowserGlobals();
+  const runtime = await importRepoModule("host/runtime.mjs");
   const workerMessages = [];
   const instantiateCalls = [];
   const performanceEntries = [];
@@ -809,7 +771,7 @@ async function checkRuntimeOrchestratesWorker() {
 
   frames[0](122);
   frames[1](123);
-  await import(moduleUrl("host/trace-renderer-spec.mjs"));
+  await importRepoModule("host/trace-renderer-spec.mjs");
   await flushRuntimeMicrotasks();
   assert.deepEqual(performanceEntries.slice(-2), [
     { kind: "mark", name: "tracy.app.ready" },
@@ -847,10 +809,10 @@ async function checkRuntimeOrchestratesWorker() {
 }
 
 async function checkRuntimeStartsIngestFromFileSelection() {
-  const { frames } = installBrowserStubs();
+  const { frames } = installRuntimeBrowserGlobals();
 
-  const runtime = await import(moduleUrl("host/runtime.mjs"));
-  const abi = await import(moduleUrl("host/abi.mjs"));
+  const runtime = await importRepoModule("host/runtime.mjs");
+  const abi = await importRepoModule("host/abi.mjs");
   const memory = new WebAssembly.Memory({ initial: 512 });
   const sourceName = "sources/selected trace.json";
   const callbacks = [];
@@ -945,9 +907,9 @@ async function checkRuntimeStartsIngestFromFileSelection() {
 }
 
 async function checkRuntimeIgnoresStaleIngestWorkerMessages() {
-  installBrowserStubs();
+  installRuntimeBrowserGlobals();
 
-  const runtime = await import(moduleUrl("host/runtime.mjs"));
+  const runtime = await importRepoModule("host/runtime.mjs");
   const indexReaderOpenCalls = [];
   const workerStatus = [];
   const controller = runtime.createIngestWorkerController({
@@ -1059,10 +1021,10 @@ async function checkRuntimeIgnoresStaleIngestWorkerMessages() {
 }
 
 async function checkFileSelectionSetupErrorsReportStatus() {
-  installBrowserStubs();
+  installRuntimeBrowserGlobals();
 
-  const runtime = await import(moduleUrl("host/runtime.mjs"));
-  const abi = await import(moduleUrl("host/abi.mjs"));
+  const runtime = await importRepoModule("host/runtime.mjs");
+  const abi = await importRepoModule("host/abi.mjs");
   const memory = new WebAssembly.Memory({ initial: 512 });
   let callback;
   const workerStatus = [];
@@ -1105,8 +1067,8 @@ async function checkFileSelectionSetupErrorsReportStatus() {
 }
 
 async function checkMainThreadIndexReaderQueriesCommittedPages() {
-  const runtime = await import(moduleUrl("host/runtime.mjs"));
-  const abi = await import(moduleUrl("host/abi.mjs"));
+  const runtime = await importRepoModule("host/runtime.mjs");
+  const abi = await importRepoModule("host/abi.mjs");
   const memory = new WebAssembly.Memory({ initial: 512 });
   const view = new DataView(memory.buffer);
   const pagePtr = 32768;
@@ -1359,8 +1321,8 @@ async function checkMainThreadIndexReaderQueriesCommittedPages() {
 }
 
 async function checkMainThreadIndexReaderRequiresCappedQueryMetadataExports() {
-  const runtime = await import(moduleUrl("host/runtime.mjs"));
-  const abi = await import(moduleUrl("host/abi.mjs"));
+  const runtime = await importRepoModule("host/runtime.mjs");
+  const abi = await importRepoModule("host/abi.mjs");
   const memory = new WebAssembly.Memory({ initial: 512 });
   let opened = false;
   const host = {
@@ -1400,8 +1362,8 @@ async function checkMainThreadIndexReaderRequiresCappedQueryMetadataExports() {
 }
 
 async function checkMainThreadIndexReaderProbesStaleCatalogSize() {
-  const runtime = await import(moduleUrl("host/runtime.mjs"));
-  const abi = await import(moduleUrl("host/abi.mjs"));
+  const runtime = await importRepoModule("host/runtime.mjs");
+  const abi = await importRepoModule("host/abi.mjs");
   const memory = new WebAssembly.Memory({ initial: 512 });
   const view = new DataView(memory.buffer);
   const pagePtr = 32768;
@@ -1598,8 +1560,8 @@ async function checkMainThreadIndexReaderProbesStaleCatalogSize() {
 }
 
 async function checkMainThreadCoveredRangeRereadsUnqueryablePartialPage() {
-  const runtime = await import(moduleUrl("host/runtime.mjs"));
-  const abi = await import(moduleUrl("host/abi.mjs"));
+  const runtime = await importRepoModule("host/runtime.mjs");
+  const abi = await importRepoModule("host/abi.mjs");
   const memory = new WebAssembly.Memory({ initial: 512 });
   const view = new DataView(memory.buffer);
   const pagePtr = 32768;
@@ -1724,8 +1686,8 @@ async function checkMainThreadCoveredRangeRereadsUnqueryablePartialPage() {
 }
 
 async function checkMainThreadSliceCatalogReportsCapacityOverflow() {
-  const catalog = await import(moduleUrl("host/index-reader-catalog.mjs"));
-  const abi = await import(moduleUrl("host/abi.mjs"));
+  const catalog = await importRepoModule("host/index-reader-catalog.mjs");
+  const abi = await importRepoModule("host/abi.mjs");
   const memory = new WebAssembly.Memory({ initial: 512 });
   const view = new DataView(memory.buffer);
   const pagePtr = 32768;
@@ -1786,8 +1748,8 @@ async function checkMainThreadSliceCatalogReportsCapacityOverflow() {
 }
 
 async function checkMainThreadIndexReaderFailsOnCatalogOverflow() {
-  const runtime = await import(moduleUrl("host/runtime.mjs"));
-  const abi = await import(moduleUrl("host/abi.mjs"));
+  const runtime = await importRepoModule("host/runtime.mjs");
+  const abi = await importRepoModule("host/abi.mjs");
   const memory = new WebAssembly.Memory({ initial: 512 });
   const view = new DataView(memory.buffer);
   const pagePtr = 32768;
@@ -1866,7 +1828,7 @@ async function checkMainThreadIndexReaderFailsOnCatalogOverflow() {
 }
 
 async function checkWorkerStatusReportsReaderCatalogOverflow() {
-  const runtime = await import(moduleUrl("host/runtime.mjs"));
+  const runtime = await importRepoModule("host/runtime.mjs");
   const workerStatus = [];
   const indexReader = {
     open() {
@@ -1900,7 +1862,7 @@ async function checkWorkerStatusReportsReaderCatalogOverflow() {
 }
 
 async function checkWorkerCoveredRangeOpensReaderBeforeRangeIsValid() {
-  const runtime = await import(moduleUrl("host/runtime.mjs"));
+  const runtime = await importRepoModule("host/runtime.mjs");
   const indexReaderOpenCalls = [];
   const controller = runtime.createIngestWorkerController({
     Worker: FakeWorker,
@@ -1959,7 +1921,7 @@ function checkWatWriterPropagatesCatalogOverflow() {
 }
 
 async function checkProgressiveTraceRendererDrawsCoveredPartialRows() {
-  const rendererModule = await import(moduleUrl("host/progressive-trace-renderer.mjs"));
+  const rendererModule = await importRepoModule("host/progressive-trace-renderer.mjs");
   const memory = new WebAssembly.Memory({ initial: 1 });
   const operations = [];
   const canvas = {
@@ -2123,7 +2085,7 @@ async function checkProgressiveTraceRendererDrawsCoveredPartialRows() {
 }
 
 async function checkProgressiveTraceRendererClipsLeftEdgeSlices() {
-  const rendererModule = await import(moduleUrl("host/progressive-trace-renderer.mjs"));
+  const rendererModule = await importRepoModule("host/progressive-trace-renderer.mjs");
   const memory = new WebAssembly.Memory({ initial: 1 });
   const operations = [];
   const canvas = {
@@ -2217,7 +2179,7 @@ async function checkProgressiveTraceRendererClipsLeftEdgeSlices() {
 }
 
 async function checkProgressiveTraceRendererClampsToSliceCatalogCoverage() {
-  const rendererModule = await import(moduleUrl("host/progressive-trace-renderer.mjs"));
+  const rendererModule = await importRepoModule("host/progressive-trace-renderer.mjs");
   const memory = new WebAssembly.Memory({ initial: 1 });
   const canvas = {
     height: 120,
@@ -2300,7 +2262,7 @@ async function checkProgressiveTraceRendererClampsToSliceCatalogCoverage() {
 }
 
 async function checkProgressiveTraceRendererSurfacesCappedQueries() {
-  const rendererModule = await import(moduleUrl("host/progressive-trace-renderer.mjs"));
+  const rendererModule = await importRepoModule("host/progressive-trace-renderer.mjs");
   const memory = new WebAssembly.Memory({ initial: 1 });
   const queryCalls = [];
   const operations = [];
@@ -2423,7 +2385,7 @@ async function checkProgressiveTraceRendererSurfacesCappedQueries() {
 }
 
 async function checkProgressiveTraceRendererTilesFullVisibleViewport() {
-  const rendererModule = await import(moduleUrl("host/progressive-trace-renderer.mjs"));
+  const rendererModule = await importRepoModule("host/progressive-trace-renderer.mjs");
   const memory = new WebAssembly.Memory({ initial: 1 });
   const queryCalls = [];
   const canvas = {
@@ -2488,7 +2450,7 @@ async function checkProgressiveTraceRendererTilesFullVisibleViewport() {
 }
 
 async function checkProgressiveTraceRendererBoundsLargeViewportQueries() {
-  const rendererModule = await import(moduleUrl("host/progressive-trace-renderer.mjs"));
+  const rendererModule = await importRepoModule("host/progressive-trace-renderer.mjs");
   const memory = new WebAssembly.Memory({ initial: 1 });
   const queryCalls = [];
   const canvas = {
@@ -2566,7 +2528,7 @@ async function checkProgressiveTraceRendererBoundsLargeViewportQueries() {
 }
 
 async function checkProgressiveTraceRendererMarksSkippedTracksWhenBudgetExhausted() {
-  const rendererModule = await import(moduleUrl("host/progressive-trace-renderer.mjs"));
+  const rendererModule = await importRepoModule("host/progressive-trace-renderer.mjs");
   const memory = new WebAssembly.Memory({ initial: 1 });
   const queryCalls = [];
   const operations = [];
@@ -2684,7 +2646,7 @@ async function checkProgressiveTraceRendererMarksSkippedTracksWhenBudgetExhauste
 }
 
 async function checkProgressiveTraceRendererUsesWasmCanvasOpPlanner() {
-  const rendererModule = await import(moduleUrl("host/progressive-trace-renderer.mjs"));
+  const rendererModule = await importRepoModule("host/progressive-trace-renderer.mjs");
   assert.throws(
     () => rendererModule.createProgressiveTraceRenderer(
       new WebAssembly.Memory({ initial: 1 }),
@@ -2762,7 +2724,7 @@ async function checkProgressiveTraceRendererUsesWasmCanvasOpPlanner() {
 }
 
 async function checkProgressiveTraceRendererClampsPanZoomAndDrawsUnknownRange() {
-  const rendererModule = await import(moduleUrl("host/progressive-trace-renderer.mjs"));
+  const rendererModule = await importRepoModule("host/progressive-trace-renderer.mjs");
   const memory = new WebAssembly.Memory({ initial: 1 });
   const listeners = new Map();
   const operations = [];
@@ -2921,8 +2883,8 @@ async function checkProgressiveTraceRendererClampsPanZoomAndDrawsUnknownRange() 
 }
 
 async function checkRuntimePreloadsProgressiveTraceRendererImplementation() {
-  const { frames } = installBrowserStubs();
-  const runtime = await import(moduleUrl("host/runtime.mjs"));
+  const { frames } = installRuntimeBrowserGlobals();
+  const runtime = await importRepoModule("host/runtime.mjs");
   const memory = new WebAssembly.Memory({ initial: 1 });
   let coveredRange = null;
   let readerCoveredRange = null;
@@ -3027,8 +2989,8 @@ async function checkRuntimePreloadsProgressiveTraceRendererImplementation() {
 }
 
 async function checkRuntimeDrawsProgressiveRendererWhenCreatedQueryable() {
-  const { frames } = installBrowserStubs();
-  const runtime = await import(moduleUrl("host/runtime.mjs"));
+  const { frames } = installRuntimeBrowserGlobals();
+  const runtime = await importRepoModule("host/runtime.mjs");
   const memory = new WebAssembly.Memory({ initial: 1 });
   let drawCalls = 0;
   const coveredRange = { end: 120, start: 100, type: "covered_range", valid: true };
@@ -3078,8 +3040,8 @@ async function checkRuntimeDrawsProgressiveRendererWhenCreatedQueryable() {
 }
 
 async function checkAppReadyWaitsForFirstFrameAndDeferredRenderer() {
-  const { frames } = installBrowserStubs();
-  const runtime = await import(moduleUrl("host/runtime.mjs"));
+  const { frames } = installRuntimeBrowserGlobals();
+  const runtime = await importRepoModule("host/runtime.mjs");
   const memory = new WebAssembly.Memory({ initial: 1 });
   const performanceEntries = [];
   const performance = {
@@ -3143,7 +3105,7 @@ async function checkAppReadyWaitsForFirstFrameAndDeferredRenderer() {
       throw new Error("not expected before queryable pages");
     },
   });
-  await import(moduleUrl("host/trace-renderer-spec.mjs"));
+  await importRepoModule("host/trace-renderer-spec.mjs");
   await flushRuntimeMicrotasks();
   assert.deepEqual(performanceEntries.slice(-2), [
     { kind: "mark", name: "tracy.app.ready" },
@@ -3157,8 +3119,8 @@ async function checkAppReadyWaitsForFirstFrameAndDeferredRenderer() {
 }
 
 async function checkAppReadyFailsWhenDeferredRendererFails() {
-  const { frames } = installBrowserStubs();
-  const runtime = await import(moduleUrl("host/runtime.mjs"));
+  const { frames } = installRuntimeBrowserGlobals();
+  const runtime = await importRepoModule("host/runtime.mjs");
   const memory = new WebAssembly.Memory({ initial: 1 });
   const performanceEntries = [];
   const previousError = globalThis.__TRACY_APP_LOAD_ERROR__;


### PR DESCRIPTION
The shared browser/runtime harness is in place, and both migrated checks now use it for Worker, browser globals, async/frame helpers, and module imports.

The remaining work is to fix the default `installRuntimeBrowserGlobals()` canvas so it preserves the full `makeFakeCanvas()` browser-like surface, with a smoke assertion to prevent plain-object regressions.

Fixes #157.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (5)</summary>

- [x] [Update installRuntimeBrowserGlobals so its default canvas preserves makeFakeCanvas browser-like methods and dimensions while applying the Tracy hidden/id overrides.](https://github.com/rhencke/tracy/pull/273#discussion_r3214100752) <!-- type:thread -->
- [x] Migrate interactive ingest scenarios <!-- type:spec -->
- [x] Add harness ownership guardrails <!-- type:spec -->
- [x] Migrate runtime-worker orchestration scenarios <!-- type:spec -->
- [x] Add shared runtime test harness utilities <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->