### PR TITLE
LOC #1a - Shared generated-file write support (closes #294)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,6 +262,7 @@ test: dist check-generated
 	node tools/interactive-ingest-browser-check.js
 	node tools/direct-esm-check.js
 	node tools/service-worker-check.js
+	node tools/generated-file-writer-check.js
 	node tools/dist-budget-check.js --self-test
 	node tools/app-load-bench.js --self-test
 	node tools/lighthouse-ci-check.js

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,8 @@ ifneq ($(MODULE_DOC_GENERATOR),)
 CLEAN_GENERATED_FILES += docs/MODULES.md
 endif
 
+GENERATED_SUPPORT_INPUTS := $(filter-out %-check.js,$(wildcard tools/generated-*.js))
+
 GENERATED_INPUTS := \
 	abi/host.json \
 	abi/layout.json \
@@ -101,6 +103,7 @@ GENERATED_INPUTS := \
 	tools/generate-parser-state-abi.js \
 	tools/generate-runtime-spec.js \
 	tools/generate-wasm-modules-abi.js \
+	$(GENERATED_SUPPORT_INPUTS) \
 	tools/layout-spec.js \
 	tools/wat-parser.js \
 	$(MODULE_DOC_GENERATOR) \

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:production-topology-fixture": "node tools/production-topology-fixture-check.js",
     "test:interactive-ingest-browser": "node tools/interactive-ingest-browser-check.js",
     "test:direct-esm": "node tools/direct-esm-check.js",
+    "test:generated-file-writer": "node tools/generated-file-writer-check.js",
     "test:service-worker": "node tools/service-worker-check.js",
     "test:dist-budget": "node tools/dist-budget-check.js --self-test",
     "test:app-load-bench": "node tools/app-load-bench.js --self-test",

--- a/tools/extract-wasm-modules.js
+++ b/tools/extract-wasm-modules.js
@@ -4,10 +4,16 @@ const fs = require("node:fs/promises");
 const os = require("node:os");
 const path = require("node:path");
 const { assembleWatFile, collectWatInputs } = require("./assemble-wat.js");
+const { createGeneratedFileWriter } = require("./generated-file-writer.js");
 const { TokenReader, WatParseError, skipWatList } = require("./wat-parser.js");
 
 const root = path.dirname(__dirname);
 const checkOnly = process.argv.includes("--check");
+const { writeIfChangedAsync } = createGeneratedFileWriter({
+  root,
+  checkOnly,
+  staleMessage: (relativePath) => `${relativePath} is out of date`,
+});
 const watRoot = path.join(root, "wat");
 const outputPath = path.join(root, "abi/wasm-modules.json");
 const validThreads = new Set(["main", "worker", "shared"]);
@@ -213,32 +219,13 @@ function renderJson(value) {
   return `${JSON.stringify(value, null, 2)}\n`;
 }
 
-async function writeIfChanged(filePath, content) {
-  let previous = null;
-
-  try {
-    previous = await fs.readFile(filePath, "utf8");
-  } catch (error) {
-    if (error.code !== "ENOENT") {
-      throw error;
-    }
-  }
-
-  if (previous === content) {
-    return false;
-  }
-
-  if (checkOnly) {
-    throw new Error(`${path.relative(root, filePath)} is out of date`);
-  }
-
-  await fs.writeFile(filePath, content);
-  return true;
-}
-
 async function main() {
   const manifest = await extractWasmModules();
-  await writeIfChanged(outputPath, renderJson(manifest));
+  const ok = await writeIfChangedAsync(outputPath, renderJson(manifest));
+
+  if (!ok) {
+    process.exitCode = 1;
+  }
 }
 
 if (require.main === module) {

--- a/tools/generate-host-abi.js
+++ b/tools/generate-host-abi.js
@@ -1,10 +1,16 @@
 #!/usr/bin/env node
 
-const { readFileSync, writeFileSync } = require("node:fs");
+const { readFileSync } = require("node:fs");
 const { dirname, join } = require("node:path");
+const { createGeneratedFileWriter } = require("./generated-file-writer.js");
 
 const root = dirname(__dirname);
 const checkOnly = process.argv.includes("--check");
+const { updateMarkedFile, writeIfChanged } = createGeneratedFileWriter({
+  root,
+  checkOnly,
+  command: "node tools/generate-host-abi.js",
+});
 const sourcePath = join(root, "abi/host.json");
 const source = JSON.parse(readFileSync(sourcePath, "utf8"));
 const constants = source.constants;
@@ -110,18 +116,6 @@ function renderHostAbiModule() {
 function renderWatBlock(setName) {
   const names = source.watImportSets[setName];
   return names.map((name) => watImport(importsByName.get(name))).join("\n");
-}
-
-function replaceGeneratedBlock(text, start, end, body) {
-  const startIndex = text.indexOf(start);
-  const endIndex = text.indexOf(end);
-
-  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
-    throw new Error(`missing generated block ${start} ${end}`);
-  }
-
-  const bodyStart = startIndex + start.length;
-  return `${text.slice(0, bodyStart)}\n${body}\n${text.slice(endIndex)}`;
 }
 
 function renderDocs() {
@@ -256,42 +250,6 @@ function renderMemorySection() {
   );
 
   return lines.join("\n");
-}
-
-function writeIfChanged(path, content) {
-  const absolute = join(root, path);
-  let previous = null;
-
-  try {
-    previous = readFileSync(absolute, "utf8");
-  } catch (error) {
-    if (error.code !== "ENOENT") {
-      throw error;
-    }
-  }
-
-  if (previous === content) {
-    return true;
-  }
-
-  if (checkOnly) {
-    console.error(`${path} is out of date; run node tools/generate-host-abi.js`);
-    return false;
-  }
-
-  writeFileSync(absolute, content);
-  return true;
-}
-
-function updateMarkedFile(path, replacements) {
-  const absolute = join(root, path);
-  let text = readFileSync(absolute, "utf8");
-
-  for (const replacement of replacements) {
-    text = replaceGeneratedBlock(text, replacement.start, replacement.end, replacement.body);
-  }
-
-  return writeIfChanged(path, text);
 }
 
 const ok = [

--- a/tools/generate-layout.js
+++ b/tools/generate-layout.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
-const { readFileSync, writeFileSync } = require("node:fs");
+const { readFileSync } = require("node:fs");
 const { join } = require("node:path");
+const { createGeneratedFileWriter } = require("./generated-file-writer.js");
 const {
   OPFS_PAGE_SIZE,
   assertLayoutSpec,
@@ -11,6 +12,11 @@ const {
 
 const root = join(__dirname, "..");
 const checkOnly = process.argv.includes("--check");
+const { updateMarkedFile, writeIfChanged } = createGeneratedFileWriter({
+  root,
+  checkOnly,
+  command: "node tools/generate-layout.js",
+});
 
 assertLayoutSpec();
 
@@ -268,54 +274,6 @@ function renderMemoryLayoutSection() {
   );
 
   return lines.join("\n");
-}
-
-function replaceGeneratedBlock(text, start, end, body) {
-  const startIndex = text.indexOf(start);
-  const endIndex = text.indexOf(end);
-
-  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
-    throw new Error(`missing generated block ${start} ${end}`);
-  }
-
-  const bodyStart = startIndex + start.length;
-  return `${text.slice(0, bodyStart)}\n${body}\n${text.slice(endIndex)}`;
-}
-
-function writeIfChanged(path, content) {
-  const absolute = join(root, path);
-  let previous = null;
-
-  try {
-    previous = readFileSync(absolute, "utf8");
-  } catch (error) {
-    if (error.code !== "ENOENT") {
-      throw error;
-    }
-  }
-
-  if (previous === content) {
-    return true;
-  }
-
-  if (checkOnly) {
-    console.error(`${path} is out of date; run node tools/generate-layout.js`);
-    return false;
-  }
-
-  writeFileSync(absolute, content);
-  return true;
-}
-
-function updateMarkedFile(path, replacements) {
-  const absolute = join(root, path);
-  let text = readFileSync(absolute, "utf8");
-
-  for (const replacement of replacements) {
-    text = replaceGeneratedBlock(text, replacement.start, replacement.end, replacement.body);
-  }
-
-  return writeIfChanged(path, text);
 }
 
 const ok = [

--- a/tools/generate-parser-state-abi.js
+++ b/tools/generate-parser-state-abi.js
@@ -1,10 +1,16 @@
 #!/usr/bin/env node
 
-const { readFileSync, writeFileSync } = require("node:fs");
+const { readFileSync } = require("node:fs");
 const { dirname, join } = require("node:path");
+const { createGeneratedFileWriter } = require("./generated-file-writer.js");
 
 const root = dirname(__dirname);
 const checkOnly = process.argv.includes("--check");
+const { updateMarkedFile } = createGeneratedFileWriter({
+  root,
+  checkOnly,
+  command: "node tools/generate-parser-state-abi.js",
+});
 const sourcePath = join(root, "abi/parser-state.json");
 const source = JSON.parse(readFileSync(sourcePath, "utf8"));
 const constants = source.constants;
@@ -33,18 +39,6 @@ function globalLine(entry) {
 
 function importLine(name) {
   return `  (import "parser_state" "${name}" (global $${name} i32))`;
-}
-
-function replaceGeneratedBlock(text, start, end, body) {
-  const startIndex = text.indexOf(start);
-  const endIndex = text.indexOf(end);
-
-  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
-    throw new Error(`missing generated block ${start} ${end}`);
-  }
-
-  const bodyStart = startIndex + start.length;
-  return `${text.slice(0, bodyStart)}\n${body}\n${text.slice(endIndex)}`;
 }
 
 function renderGlobalBlock() {
@@ -208,42 +202,6 @@ function renderMemorySection() {
   );
 
   return lines.join("\n");
-}
-
-function writeIfChanged(path, content) {
-  const absolute = join(root, path);
-  let previous = null;
-
-  try {
-    previous = readFileSync(absolute, "utf8");
-  } catch (error) {
-    if (error.code !== "ENOENT") {
-      throw error;
-    }
-  }
-
-  if (previous === content) {
-    return true;
-  }
-
-  if (checkOnly) {
-    console.error(`${path} is out of date; run node tools/generate-parser-state-abi.js`);
-    return false;
-  }
-
-  writeFileSync(absolute, content);
-  return true;
-}
-
-function updateMarkedFile(path, replacements) {
-  const absolute = join(root, path);
-  let text = readFileSync(absolute, "utf8");
-
-  for (const replacement of replacements) {
-    text = replaceGeneratedBlock(text, replacement.start, replacement.end, replacement.body);
-  }
-
-  return writeIfChanged(path, text);
 }
 
 const ok = [

--- a/tools/generate-runtime-spec.js
+++ b/tools/generate-runtime-spec.js
@@ -1,10 +1,16 @@
 #!/usr/bin/env node
 
-const { readFileSync, writeFileSync } = require("node:fs");
+const { readFileSync } = require("node:fs");
 const { dirname, join } = require("node:path");
+const { createGeneratedFileWriter } = require("./generated-file-writer.js");
 
 const root = dirname(__dirname);
 const checkOnly = process.argv.includes("--check");
+const { writeIfChanged } = createGeneratedFileWriter({
+  root,
+  checkOnly,
+  command: "node tools/generate-runtime-spec.js",
+});
 const sourcePath = join(root, "abi/runtime.json");
 const spec = JSON.parse(readFileSync(sourcePath, "utf8"));
 const paletteSpec = JSON.parse(readFileSync(join(root, "abi/palette.json"), "utf8"));
@@ -400,31 +406,6 @@ function assertTraceRendererInlineContract() {
       "host/progressive-trace-renderer.mjs inline renderer contract is out of date with abi/runtime.json and abi/layout.json",
     );
   }
-}
-
-function writeIfChanged(path, content) {
-  const absolute = join(root, path);
-  let previous = null;
-
-  try {
-    previous = readFileSync(absolute, "utf8");
-  } catch (error) {
-    if (error.code !== "ENOENT") {
-      throw error;
-    }
-  }
-
-  if (previous === content) {
-    return true;
-  }
-
-  if (checkOnly) {
-    console.error(`${path} is out of date; run node tools/generate-runtime-spec.js`);
-    return false;
-  }
-
-  writeFileSync(absolute, content);
-  return true;
 }
 
 assertDuplicateNumericValuesAudited();

--- a/tools/generate-wasm-modules-abi.js
+++ b/tools/generate-wasm-modules-abi.js
@@ -1,10 +1,16 @@
 #!/usr/bin/env node
 
-const { readFileSync, writeFileSync } = require("node:fs");
+const { readFileSync } = require("node:fs");
 const { dirname, join } = require("node:path");
+const { createGeneratedFileWriter } = require("./generated-file-writer.js");
 
 const root = dirname(__dirname);
 const checkOnly = process.argv.includes("--check");
+const { writeIfChanged } = createGeneratedFileWriter({
+  root,
+  checkOnly,
+  command: "node tools/generate-wasm-modules-abi.js",
+});
 const sourcePath = join(root, "abi/wasm-modules.json");
 const source = JSON.parse(readFileSync(sourcePath, "utf8"));
 const modules = source.modules;
@@ -360,31 +366,6 @@ export function wasmModuleIdForPath(value) {
   return null;
 }`,
   ].join("\n")}\n`;
-}
-
-function writeIfChanged(path, content) {
-  const absolute = join(root, path);
-  let previous = null;
-
-  try {
-    previous = readFileSync(absolute, "utf8");
-  } catch (error) {
-    if (error.code !== "ENOENT") {
-      throw error;
-    }
-  }
-
-  if (previous === content) {
-    return true;
-  }
-
-  if (checkOnly) {
-    console.error(`${path} is out of date; run node tools/generate-wasm-modules-abi.js`);
-    return false;
-  }
-
-  writeFileSync(absolute, content);
-  return true;
 }
 
 const ok = writeIfChanged("host/wasm-modules.mjs", renderWasmModulesModule());

--- a/tools/generated-file-writer-check.js
+++ b/tools/generated-file-writer-check.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  createGeneratedFileWriter,
+  replaceGeneratedBlock,
+} = require("./generated-file-writer.js");
+
+function readFile(relativePath, root) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+async function main() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "tracy-generated-writer-"));
+
+  try {
+    const writer = createGeneratedFileWriter({
+      root,
+      checkOnly: false,
+      command: "node tools/example-generator.js",
+    });
+
+    assert.equal(writer.writeIfChanged("generated.txt", "fresh\n"), true);
+    assert.equal(readFile("generated.txt", root), "fresh\n");
+    assert.equal(writer.writeIfChanged("generated.txt", "fresh\n"), true);
+
+    fs.writeFileSync(
+      path.join(root, "marked.txt"),
+      ["header", "<!-- start -->", "old body", "<!-- end -->", "footer"].join("\n"),
+    );
+    assert.equal(
+      writer.updateMarkedFile("marked.txt", [
+        {
+          start: "<!-- start -->",
+          end: "<!-- end -->",
+          body: "new body",
+        },
+      ]),
+      true,
+    );
+    assert.equal(
+      readFile("marked.txt", root),
+      ["header", "<!-- start -->", "new body", "<!-- end -->", "footer"].join("\n"),
+    );
+
+    assert.equal(
+      replaceGeneratedBlock("a\n// start\nold\n// end\nz", "// start", "// end", "new"),
+      "a\n// start\nnew\n// end\nz",
+    );
+    assert.throws(
+      () => replaceGeneratedBlock("a\n// start\nold", "// start", "// end", "new"),
+      /missing generated block \/\/ start \/\/ end/,
+    );
+
+    const staleMessages = [];
+    const checkWriter = createGeneratedFileWriter({
+      root,
+      checkOnly: true,
+      command: "node tools/example-generator.js",
+      reportStale: (message) => staleMessages.push(message),
+    });
+
+    assert.equal(checkWriter.writeIfChanged("generated.txt", "stale\n"), false);
+    assert.equal(readFile("generated.txt", root), "fresh\n");
+    assert.deepEqual(staleMessages, [
+      "generated.txt is out of date; run node tools/example-generator.js",
+    ]);
+
+    assert.equal(await checkWriter.writeIfChangedAsync("missing.txt", "created\n"), false);
+    assert.equal(fs.existsSync(path.join(root, "missing.txt")), false);
+    assert.equal(staleMessages.at(-1), "missing.txt is out of date; run node tools/example-generator.js");
+
+    fs.writeFileSync(
+      path.join(root, "marked.txt"),
+      ["header", "<!-- start -->", "old body", "<!-- end -->", "footer"].join("\n"),
+    );
+    assert.equal(
+      checkWriter.updateMarkedFile("marked.txt", [
+        {
+          start: "<!-- start -->",
+          end: "<!-- end -->",
+          body: "new body",
+        },
+      ]),
+      false,
+    );
+    assert.equal(
+      readFile("marked.txt", root),
+      ["header", "<!-- start -->", "old body", "<!-- end -->", "footer"].join("\n"),
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message || String(error));
+  process.exitCode = 1;
+});

--- a/tools/generated-file-writer.js
+++ b/tools/generated-file-writer.js
@@ -1,0 +1,126 @@
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const path = require("node:path");
+
+function resolveOutputPath(root, outputPath) {
+  return path.isAbsolute(outputPath) ? outputPath : path.join(root, outputPath);
+}
+
+function relativeOutputPath(root, outputPath) {
+  return path.relative(root, resolveOutputPath(root, outputPath)) || ".";
+}
+
+function defaultStaleMessage(relativePath, command) {
+  return command === undefined
+    ? `${relativePath} is out of date`
+    : `${relativePath} is out of date; run ${command}`;
+}
+
+function replaceGeneratedBlock(text, start, end, body) {
+  const startIndex = text.indexOf(start);
+  const endIndex = text.indexOf(end);
+
+  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+    throw new Error(`missing generated block ${start} ${end}`);
+  }
+
+  const bodyStart = startIndex + start.length;
+  return `${text.slice(0, bodyStart)}\n${body}\n${text.slice(endIndex)}`;
+}
+
+function readUtf8IfExists(absolutePath) {
+  try {
+    return fs.readFileSync(absolutePath, "utf8");
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      throw error;
+    }
+    return null;
+  }
+}
+
+async function readUtf8IfExistsAsync(absolutePath) {
+  try {
+    return await fsp.readFile(absolutePath, "utf8");
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      throw error;
+    }
+    return null;
+  }
+}
+
+function createGeneratedFileWriter(options) {
+  const {
+    root,
+    checkOnly,
+    command,
+    staleMessage = defaultStaleMessage,
+    reportStale = (message) => console.error(message),
+  } = options;
+
+  if (typeof root !== "string") {
+    throw new TypeError("generated file writer requires a root path");
+  }
+
+  function reportStaleOutput(outputPath) {
+    const relativePath = relativeOutputPath(root, outputPath);
+    reportStale(staleMessage(relativePath, command));
+  }
+
+  function writeIfChanged(outputPath, content) {
+    const absolutePath = resolveOutputPath(root, outputPath);
+    const previous = readUtf8IfExists(absolutePath);
+
+    if (previous === content) {
+      return true;
+    }
+
+    if (checkOnly) {
+      reportStaleOutput(outputPath);
+      return false;
+    }
+
+    fs.writeFileSync(absolutePath, content);
+    return true;
+  }
+
+  async function writeIfChangedAsync(outputPath, content) {
+    const absolutePath = resolveOutputPath(root, outputPath);
+    const previous = await readUtf8IfExistsAsync(absolutePath);
+
+    if (previous === content) {
+      return true;
+    }
+
+    if (checkOnly) {
+      reportStaleOutput(outputPath);
+      return false;
+    }
+
+    await fsp.writeFile(absolutePath, content);
+    return true;
+  }
+
+  function updateMarkedFile(outputPath, replacements) {
+    const absolutePath = resolveOutputPath(root, outputPath);
+    let text = fs.readFileSync(absolutePath, "utf8");
+
+    for (const replacement of replacements) {
+      text = replaceGeneratedBlock(text, replacement.start, replacement.end, replacement.body);
+    }
+
+    return writeIfChanged(outputPath, text);
+  }
+
+  return {
+    updateMarkedFile,
+    writeIfChanged,
+    writeIfChangedAsync,
+  };
+}
+
+module.exports = {
+  createGeneratedFileWriter,
+  replaceGeneratedBlock,
+};


### PR DESCRIPTION
Fixes #294.

Extracts generated-file write behavior into a shared helper, migrates generator scripts to use it, and updates GENERATED_INPUTS to use a narrow generator-support pattern so the shared writer and future helpers are tracked without broadening the dependency graph.

Fixes #294.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] [Add tools/generated-file-writer.js to Makefile GENERATED_INPUTS next to the other generator support files.](https://github.com/rhencke/tracy/pull/318#discussion_r3219003151) <!-- type:thread -->
- [x] Add shared generated-file write helper <!-- type:spec -->
- [x] Migrate generators to the shared writer <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->