### PR TITLE
LOC #1c - Shared Wasm boundary utility module (closes #296)

### DIFF
--- a/abi/runtime.json
+++ b/abi/runtime.json
@@ -324,6 +324,26 @@
       "SLICE_CATALOG_FULL_PREFIX": "main-thread slice catalog full while rebuilding index ",
       "SLICE_CATALOG_FULL_PAGE_SEPARATOR": " at page ",
       "WORKER_INGEST_FAILED": "worker ingest failed"
+    },
+    "wasmBoundaryHelpers": {
+      "ownerModule": "host/memory.mjs",
+      "startupImporter": "host/shim.mjs",
+      "helpers": [
+        "errorMessage",
+        "globalValue",
+        "normalizedPositiveInteger",
+        "normalizedRowCap",
+        "numericSize",
+        "promisingWasmExport",
+        "wasmNumber"
+      ],
+      "consumers": [
+        "host/index-reader-catalog.mjs",
+        "host/ingest-worker-runtime.mjs",
+        "host/opfs-source.mjs",
+        "host/progressive-trace-renderer.mjs",
+        "host/runtime.mjs"
+      ]
     }
   },
   "traceRenderer": {

--- a/host/index-reader-catalog.mjs
+++ b/host/index-reader-catalog.mjs
@@ -1,11 +1,8 @@
 import { HOST_IMPORT_NAME } from "./abi.mjs";
 import { INDEX_FORMAT } from "./index-format-spec.mjs";
+import { globalValue, promisingWasmExport } from "./memory.mjs";
 export const OPFS_INDEX_SIZE_MAY_BE_STALE =
   "tracy.opfsIndexSizeMayBeStale";
-
-function globalValue(value) {
-  return value instanceof WebAssembly.Global ? value.value : value;
-}
 
 function indexPageCountFromSize(size) {
   return typeof size === "bigint"
@@ -20,12 +17,6 @@ function hasCatalogRebuildExports(index) {
     typeof index.read_page === "function" &&
     "INDEX_WRITER_STATUS_CATALOG_FULL" in index
   );
-}
-
-function promisingWasmExport(fn, receiver = undefined) {
-  return typeof WebAssembly.promising === "function"
-    ? WebAssembly.promising(fn)
-    : fn.bind(receiver);
 }
 
 export async function rebuildMainThreadSliceCatalog(

--- a/host/ingest-worker-runtime.mjs
+++ b/host/ingest-worker-runtime.mjs
@@ -5,6 +5,12 @@ import {
   compileWasmModuleGraphForThread,
   instantiateWasmModuleForThread,
 } from "./wasm-modules.mjs";
+import {
+  errorMessage,
+  globalValue,
+  numericSize,
+  promisingWasmExport,
+} from "./memory.mjs";
 
 export const INGEST_WORKER_MESSAGE = Object.freeze({
   COMPLETE: "complete",
@@ -33,14 +39,6 @@ const {
 const TOKEN_OUTPUT_BASE = 5 * 1024 * 1024;
 let preloadedWorkerWasmModules = null;
 
-function globalValue(value) {
-  return value instanceof WebAssembly.Global ? value.value : value;
-}
-
-function errorMessage(error) {
-  return error instanceof Error ? error.message : String(error);
-}
-
 function supportsWasmJspi() {
   return (
     typeof WebAssembly.Suspending === "function" &&
@@ -60,12 +58,6 @@ function wasmHostImports(host) {
     }
   }
   return wrapped;
-}
-
-function promisingWasmExport(fn, receiver = undefined) {
-  return typeof WebAssembly.promising === "function"
-    ? WebAssembly.promising(fn)
-    : fn.bind(receiver);
 }
 
 function makeDefaultMemory() {
@@ -146,15 +138,6 @@ function parserDefaultOutputRecordCap(parserState) {
   }
 
   return recordCap;
-}
-
-function numericSize(size) {
-  if (size === undefined || size === null) {
-    return null;
-  }
-
-  const value = Number(size);
-  return Number.isFinite(value) && value >= 0 ? value : null;
 }
 
 function sourceSize(host, sourceId) {

--- a/host/memory.mjs
+++ b/host/memory.mjs
@@ -1,3 +1,48 @@
+export function globalValue(value) {
+  return value instanceof WebAssembly.Global ? value.value : value;
+}
+
+export function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function promisingWasmExport(fn, receiver = undefined) {
+  return typeof WebAssembly.promising === "function"
+    ? WebAssembly.promising(fn)
+    : fn.bind(receiver);
+}
+
+export function normalizedRowCap(value, fallback) {
+  const numeric = Number(value);
+
+  return Number.isFinite(numeric) && numeric >= 0
+    ? Math.floor(numeric)
+    : fallback;
+}
+
+export function normalizedPositiveInteger(value, fallback) {
+  const numeric = Number(value);
+
+  return Number.isFinite(numeric) && numeric > 0
+    ? Math.floor(numeric)
+    : fallback;
+}
+
+export function numericSize(value) {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : null;
+}
+
+export function wasmNumber(value, fallback) {
+  const numeric = Number(globalValue(value));
+
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
 export function u64ToNumber(value) {
   const number = typeof value === "bigint" ? Number(value) : value;
 

--- a/host/opfs-source.mjs
+++ b/host/opfs-source.mjs
@@ -1,5 +1,5 @@
 import { HOST_IMPORT_NAME, OPFS_BRIDGE_CONTRACT } from "./abi.mjs";
-import { u64ToNumber } from "./memory.mjs";
+import { errorMessage, u64ToNumber } from "./memory.mjs";
 
 function makeUnsupportedHostImport(name, reason) {
   return () => {
@@ -26,10 +26,6 @@ export function makeOpfsSourceHost(memoryView, files = new Map(), options = {}) 
   const persistFileSources =
     options.persistFileSources ??
     OPFS_BRIDGE_CONTRACT.defaultPersistsFileSources;
-
-  function errorMessage(error) {
-    return error instanceof Error ? error.message : String(error);
-  }
 
   function requireSource(operation, sourceId) {
     const entry = sources.get(sourceId);

--- a/host/progressive-trace-renderer.mjs
+++ b/host/progressive-trace-renderer.mjs
@@ -112,6 +112,14 @@ const INDEX_QUERY_RESULT_LAYOUT = Object.freeze({
   PARTIAL: 24,
 });
 // @generated trace-renderer-contract:end
+import {
+  errorMessage,
+  globalValue,
+  normalizedPositiveInteger,
+  normalizedRowCap,
+  wasmNumber,
+} from "./memory.mjs";
+
 const {
   DEFAULT_TRACE_RENDER_COMMAND_CAP,
   DEFAULT_TRACE_RENDER_COMMAND_PTR,
@@ -207,20 +215,6 @@ const TRACE_RENDERER_COLORS = Object.freeze({
   INCOMPLETE_QUERY_FILL: "rgba(180, 83, 9, 0.16)",
   INCOMPLETE_QUERY_STRIPE: "rgba(146, 64, 14, 0.42)",
 });
-
-function globalValue(value) {
-  return value instanceof WebAssembly.Global ? value.value : value;
-}
-
-function wasmNumber(value, fallback) {
-  const numeric = Number(globalValue(value));
-
-  return Number.isFinite(numeric) ? numeric : fallback;
-}
-
-function errorMessage(error) {
-  return error instanceof Error ? error.message : String(error);
-}
 
 function canvasDimension(canvas, property, fallback) {
   const suffix = `${property[0].toUpperCase()}${property.slice(1)}`;
@@ -499,22 +493,6 @@ function isPromiseLike(value) {
     value !== null &&
     typeof value.then === "function"
   );
-}
-
-function normalizedRowCap(value, fallback) {
-  const numeric = Number(value);
-
-  return Number.isFinite(numeric) && numeric >= 0
-    ? Math.floor(numeric)
-    : fallback;
-}
-
-function normalizedPositiveInteger(value, fallback) {
-  const numeric = Number(value);
-
-  return Number.isFinite(numeric) && numeric > 0
-    ? Math.floor(numeric)
-    : fallback;
 }
 
 function requireTraceRenderExports(plannerExports) {

--- a/host/runtime.mjs
+++ b/host/runtime.mjs
@@ -1,6 +1,12 @@
 import { HOST_ASYNC_IMPORTS, HOST_IMPORT_NAME } from "./abi.mjs";
 import { INDEX_FORMAT } from "./index-format-spec.mjs";
 import {
+  errorMessage,
+  globalValue,
+  normalizedRowCap,
+  promisingWasmExport,
+} from "./memory.mjs";
+import {
   APP_SHELL_COLORS,
   PERFORMANCE_MARKS,
   PERFORMANCE_MEASURES,
@@ -68,12 +74,6 @@ function wasmHostImports(host) {
   return wrapped;
 }
 
-function promisingWasmExport(fn, receiver = undefined) {
-  return typeof WebAssembly.promising === "function"
-    ? WebAssembly.promising(fn)
-    : fn.bind(receiver);
-}
-
 function reportAppLoadError(error) {
   console.error(error);
   globalThis.__TRACY_APP_LOAD_ERROR__ = errorMessage(error);
@@ -96,18 +96,6 @@ function notifyWorkerStatus(status, options, message) {
 
   options.onWorkerStatus?.(snapshot, message);
   return snapshot;
-}
-
-function globalValue(value) {
-  return value instanceof WebAssembly.Global ? value.value : value;
-}
-
-function normalizedRowCap(value, fallback) {
-  const numeric = Number(value);
-
-  return Number.isFinite(numeric) && numeric >= 0
-    ? Math.floor(numeric)
-    : fallback;
 }
 
 function growMemoryToFit(memory, byteLength) {
@@ -781,10 +769,6 @@ function showError(message) {
   }
 
   document.body.appendChild(error);
-}
-
-function errorMessage(error) {
-  return error instanceof Error ? error.message : String(error);
 }
 
 function readHostString(memory, ptr, len) {

--- a/host/startup-spec.mjs
+++ b/host/startup-spec.mjs
@@ -99,6 +99,26 @@ export const RUNTIME_BRIDGE = Object.freeze({
     "SLICE_CATALOG_FULL_PREFIX": "main-thread slice catalog full while rebuilding index ",
     "SLICE_CATALOG_FULL_PAGE_SEPARATOR": " at page ",
     "WORKER_INGEST_FAILED": "worker ingest failed"
+  },
+  "wasmBoundaryHelpers": {
+    "ownerModule": "host/memory.mjs",
+    "startupImporter": "host/shim.mjs",
+    "helpers": [
+      "errorMessage",
+      "globalValue",
+      "normalizedPositiveInteger",
+      "normalizedRowCap",
+      "numericSize",
+      "promisingWasmExport",
+      "wasmNumber"
+    ],
+    "consumers": [
+      "host/index-reader-catalog.mjs",
+      "host/ingest-worker-runtime.mjs",
+      "host/opfs-source.mjs",
+      "host/progressive-trace-renderer.mjs",
+      "host/runtime.mjs"
+    ]
   }
 });
 

--- a/tools/direct-esm-check.js
+++ b/tools/direct-esm-check.js
@@ -20,22 +20,6 @@ const FORBIDDEN_BUNDLE_PATTERNS = [
 ];
 const LEGACY_BOOTSTRAP_ENTRYPOINT = "bootstrap" + ".js";
 const LEGACY_BOOTSTRAP_PATTERN = new RegExp(`${"bootstrap"}\\.js`);
-const WASM_BOUNDARY_HELPER_NAMES = Object.freeze([
-  "errorMessage",
-  "globalValue",
-  "normalizedPositiveInteger",
-  "normalizedRowCap",
-  "numericSize",
-  "promisingWasmExport",
-  "wasmNumber",
-]);
-const WASM_BOUNDARY_HELPER_CONSUMERS = Object.freeze([
-  "host/index-reader-catalog.mjs",
-  "host/ingest-worker-runtime.mjs",
-  "host/opfs-source.mjs",
-  "host/progressive-trace-renderer.mjs",
-  "host/runtime.mjs",
-]);
 
 function readRepoFile(relativePath) {
   return fs.readFileSync(path.join(ROOT_DIR, relativePath), "utf8");
@@ -183,37 +167,87 @@ function assertIndexCatalogUsesGeneratedFormatSpec() {
   );
 }
 
-function assertSharedWasmBoundaryHelpersStayOnStartupPath(bootstrapSource, shimSource) {
-  const memorySource = readRepoFile("host/memory.mjs");
+function importSpecifier(fromPath, toPath) {
+  const fromDir = path.dirname(fromPath);
+  const relativePath = path.relative(fromDir, toPath).replaceAll(path.sep, "/");
+
+  return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
+}
+
+function assertStringArray(value, message) {
+  assert(
+    Array.isArray(value) &&
+      value.length > 0 &&
+      value.every((entry) => typeof entry === "string" && entry.length > 0),
+    message,
+  );
+}
+
+function assertSharedWasmBoundaryHelpersStayOnStartupPath(bootstrapSource, bridge) {
+  const helperContract = bridge.wasmBoundaryHelpers;
+
+  assert(
+    helperContract !== null && typeof helperContract === "object",
+    "runtime bridge should define shared Wasm boundary helper topology",
+  );
+  assert.equal(
+    typeof helperContract.ownerModule,
+    "string",
+    "shared Wasm boundary helper contract should name its owner module",
+  );
+  assert.equal(
+    typeof helperContract.startupImporter,
+    "string",
+    "shared Wasm boundary helper contract should name its startup importer",
+  );
+  assertStringArray(
+    helperContract.helpers,
+    "shared Wasm boundary helper contract should list helper exports",
+  );
+  assertStringArray(
+    helperContract.consumers,
+    "shared Wasm boundary helper contract should list helper consumers",
+  );
+
+  const ownerSource = readRepoFile(helperContract.ownerModule);
+  const startupImporterSource = readRepoFile(helperContract.startupImporter);
+  const startupImportSpecifier = importSpecifier(
+    helperContract.startupImporter,
+    helperContract.ownerModule,
+  );
 
   assert.match(
-    shimSource,
-    /from "\.\/memory\.mjs"/,
-    "shared Wasm boundary helpers must stay in host/memory.mjs, which shim.mjs already fetches during startup",
+    startupImporterSource,
+    new RegExp(`from "${escapeRegExp(startupImportSpecifier)}"`),
+    `shared Wasm boundary helpers must stay in ${helperContract.ownerModule}, which ${helperContract.startupImporter} already fetches during startup`,
   );
   assert.match(
     bootstrapSource,
-    /const shimModulePromise = import\("\.\/host\/shim\.mjs"\)/,
-    "bootstrap should keep shim.mjs on the startup path before runtime imports shared Wasm boundary helpers",
+    new RegExp(`import\\("${escapeRegExp(`./${helperContract.startupImporter}`)}"\\)`),
+    `bootstrap should keep ${helperContract.startupImporter} on the startup path before runtime imports shared Wasm boundary helpers`,
   );
 
-  for (const name of WASM_BOUNDARY_HELPER_NAMES) {
+  for (const name of helperContract.helpers) {
     assert.match(
-      memorySource,
+      ownerSource,
       new RegExp(`export function ${name}\\(`),
-      `host/memory.mjs should own shared Wasm boundary helper ${name}`,
+      `${helperContract.ownerModule} should own shared Wasm boundary helper ${name}`,
     );
   }
 
-  for (const relativePath of WASM_BOUNDARY_HELPER_CONSUMERS) {
+  for (const relativePath of helperContract.consumers) {
     const source = readRepoFile(relativePath);
+    const ownerImportSpecifier = importSpecifier(
+      relativePath,
+      helperContract.ownerModule,
+    );
 
     assert.match(
       source,
-      /from "\.\/memory\.mjs"/,
-      `${relativePath} should reuse shared Wasm boundary helpers from startup-fetched host/memory.mjs`,
+      new RegExp(`from "${escapeRegExp(ownerImportSpecifier)}"`),
+      `${relativePath} should reuse shared Wasm boundary helpers from startup-fetched ${helperContract.ownerModule}`,
     );
-    for (const name of WASM_BOUNDARY_HELPER_NAMES) {
+    for (const name of helperContract.helpers) {
       assert.doesNotMatch(
         source,
         new RegExp(`function ${name}\\(`),
@@ -849,7 +883,6 @@ function main() {
   const rendererLoaderSource = readRepoFile("host/progressive-trace-renderer-loader.mjs");
   const rendererSource = readRepoFile("host/progressive-trace-renderer.mjs");
   const runtimeSource = readRepoFile("host/runtime.mjs");
-  const shimSource = readRepoFile("host/shim.mjs");
   const indexFormatSpecSource = readRepoFile("host/index-format-spec.mjs");
   const hostAbiSource = readRepoFile("host/abi.mjs");
   const opfsSourceSource = readRepoFile("host/opfs-source.mjs");
@@ -857,6 +890,7 @@ function main() {
   const traceRendererSpecSource = readRepoFile("host/trace-renderer-spec.mjs");
   const workerSource = readRepoFile("worker.js");
   const packageJson = JSON.parse(readRepoFile("package.json"));
+  const runtimeSpec = JSON.parse(readRepoFile("abi/runtime.json"));
   const paletteSpec = JSON.parse(readRepoFile("abi/palette.json"));
   const readmeSource = readRepoFile("README.md");
   const appLoadBenchSource = readRepoFile("tools/app-load-bench.js");
@@ -869,7 +903,10 @@ function main() {
   assertRendererLoaderUsesGeneratedBridgeContract(rendererLoaderSource, traceRendererSpecSource);
   assertRuntimeUsesGeneratedBridgeContract(runtimeSource, startupSpecSource);
   assertPaletteScopesProtectStartup(paletteSpec, startupSpecSource, traceRendererSpecSource);
-  assertSharedWasmBoundaryHelpersStayOnStartupPath(bootstrapSource, shimSource);
+  assertSharedWasmBoundaryHelpersStayOnStartupPath(
+    bootstrapSource,
+    runtimeSpec.runtimeBridge,
+  );
 
   assert.match(
     buildScript,

--- a/tools/direct-esm-check.js
+++ b/tools/direct-esm-check.js
@@ -20,6 +20,22 @@ const FORBIDDEN_BUNDLE_PATTERNS = [
 ];
 const LEGACY_BOOTSTRAP_ENTRYPOINT = "bootstrap" + ".js";
 const LEGACY_BOOTSTRAP_PATTERN = new RegExp(`${"bootstrap"}\\.js`);
+const WASM_BOUNDARY_HELPER_NAMES = Object.freeze([
+  "errorMessage",
+  "globalValue",
+  "normalizedPositiveInteger",
+  "normalizedRowCap",
+  "numericSize",
+  "promisingWasmExport",
+  "wasmNumber",
+]);
+const WASM_BOUNDARY_HELPER_CONSUMERS = Object.freeze([
+  "host/index-reader-catalog.mjs",
+  "host/ingest-worker-runtime.mjs",
+  "host/opfs-source.mjs",
+  "host/progressive-trace-renderer.mjs",
+  "host/runtime.mjs",
+]);
 
 function readRepoFile(relativePath) {
   return fs.readFileSync(path.join(ROOT_DIR, relativePath), "utf8");
@@ -165,6 +181,46 @@ function assertIndexCatalogUsesGeneratedFormatSpec() {
     /call \$index_validate_page[\s\S]+call \$index_page_catalog_add_slice_page/,
     "Wasm catalog contract should validate pages before adding slice pages",
   );
+}
+
+function assertSharedWasmBoundaryHelpersStayOnStartupPath(bootstrapSource, shimSource) {
+  const memorySource = readRepoFile("host/memory.mjs");
+
+  assert.match(
+    shimSource,
+    /from "\.\/memory\.mjs"/,
+    "shared Wasm boundary helpers must stay in host/memory.mjs, which shim.mjs already fetches during startup",
+  );
+  assert.match(
+    bootstrapSource,
+    /const shimModulePromise = import\("\.\/host\/shim\.mjs"\)/,
+    "bootstrap should keep shim.mjs on the startup path before runtime imports shared Wasm boundary helpers",
+  );
+
+  for (const name of WASM_BOUNDARY_HELPER_NAMES) {
+    assert.match(
+      memorySource,
+      new RegExp(`export function ${name}\\(`),
+      `host/memory.mjs should own shared Wasm boundary helper ${name}`,
+    );
+  }
+
+  for (const relativePath of WASM_BOUNDARY_HELPER_CONSUMERS) {
+    const source = readRepoFile(relativePath);
+
+    assert.match(
+      source,
+      /from "\.\/memory\.mjs"/,
+      `${relativePath} should reuse shared Wasm boundary helpers from startup-fetched host/memory.mjs`,
+    );
+    for (const name of WASM_BOUNDARY_HELPER_NAMES) {
+      assert.doesNotMatch(
+        source,
+        new RegExp(`function ${name}\\(`),
+        `${relativePath} should not duplicate shared Wasm boundary helper ${name}`,
+      );
+    }
+  }
 }
 
 function assertRuntimeWorkerCheckUsesGeneratedIndexFormatSpec() {
@@ -793,6 +849,7 @@ function main() {
   const rendererLoaderSource = readRepoFile("host/progressive-trace-renderer-loader.mjs");
   const rendererSource = readRepoFile("host/progressive-trace-renderer.mjs");
   const runtimeSource = readRepoFile("host/runtime.mjs");
+  const shimSource = readRepoFile("host/shim.mjs");
   const indexFormatSpecSource = readRepoFile("host/index-format-spec.mjs");
   const hostAbiSource = readRepoFile("host/abi.mjs");
   const opfsSourceSource = readRepoFile("host/opfs-source.mjs");
@@ -812,6 +869,7 @@ function main() {
   assertRendererLoaderUsesGeneratedBridgeContract(rendererLoaderSource, traceRendererSpecSource);
   assertRuntimeUsesGeneratedBridgeContract(runtimeSource, startupSpecSource);
   assertPaletteScopesProtectStartup(paletteSpec, startupSpecSource, traceRendererSpecSource);
+  assertSharedWasmBoundaryHelpersStayOnStartupPath(bootstrapSource, shimSource);
 
   assert.match(
     buildScript,
@@ -1015,6 +1073,7 @@ function main() {
     "Makefile",
     "README.md",
     "host/runtime.mjs",
+    "host/memory.mjs",
     "host/index-format-spec.mjs",
     "host/progressive-trace-renderer-loader.mjs",
     "host/startup-spec.mjs",
@@ -1030,6 +1089,7 @@ function main() {
     "host/ingest-worker-runtime.mjs",
     "host/progressive-trace-renderer-loader.mjs",
     "host/runtime.mjs",
+    "host/memory.mjs",
     "host/index-format-spec.mjs",
     "host/startup-spec.mjs",
     "host/trace-renderer-spec.mjs",
@@ -1044,6 +1104,7 @@ function main() {
     "bootstrap.mjs",
     "worker.js",
     "host/runtime.mjs",
+    "host/memory.mjs",
     "host/index-format-spec.mjs",
     "host/progressive-trace-renderer-loader.mjs",
     "host/startup-spec.mjs",


### PR DESCRIPTION
Fixes #296.

Centralizes host-side Wasm boundary helpers under the existing startup-loaded memory utility, preserving runtime, worker runtime, and index-reader behavior. Adds startup topology guardrails whose helper and consumer lists come from spec or generated contract data, so helper sharing keeps one owner without adding a protected startup fetch.

Fixes #296.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] [Move the shared Wasm boundary helper and consumer lists out of hardcoded direct-esm-check literals and source them from spec JSON or generated contract data.](https://github.com/rhencke/tracy/pull/320#discussion_r3219846981) <!-- type:thread -->
- [x] [Move the shared Wasm boundary helper and consumer lists out of hardcoded direct-esm-check literals and source them from spec JSON or generated contract data.](https://github.com/rhencke/tracy/pull/320#discussion_r3219849490) <!-- type:thread -->
- [x] Centralize host Wasm boundary helpers <!-- type:spec -->
- [x] Guard shared helper startup topology <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->