### PR TITLE
LOC #2a - Runtime app boot harness (closes #298)

### DIFF
--- a/abi/runtime.json
+++ b/abi/runtime.json
@@ -262,6 +262,18 @@
       "description": "Polling cadence for async production handoff checks in the interactive ingest verification gate."
     }
   },
+  "runtimeWorkerOrchestrationCheck": {
+    "bootSensitiveChecks": [
+      "checkRuntimeOrchestratesWorker",
+      "checkRuntimeStartsIngestFromFileSelection",
+      "checkRuntimePreloadsIndexReaderBeforeWorkerPreloadSignal",
+      "checkRuntimeSkipsLateWorkerPreloadAfterFileSelectionStart",
+      "checkRuntimePreloadsProgressiveTraceRendererImplementation",
+      "checkRuntimeDrawsProgressiveRendererWhenCreatedQueryable",
+      "checkAppReadyWaitsForFirstFrameAndDeferredRenderer",
+      "checkAppReadyFailsWhenDeferredRendererFails"
+    ]
+  },
   "runtimeBridge": {
     "threads": {
       "MAIN": "main"

--- a/host/startup-spec.mjs
+++ b/host/startup-spec.mjs
@@ -37,6 +37,19 @@ export const INTERACTIVE_INGEST_CHECK = Object.freeze({
   ASYNC_POLL_INTERVAL_MS: 1,
 });
 
+export const RUNTIME_WORKER_ORCHESTRATION_CHECK = Object.freeze({
+  "bootSensitiveChecks": [
+    "checkRuntimeOrchestratesWorker",
+    "checkRuntimeStartsIngestFromFileSelection",
+    "checkRuntimePreloadsIndexReaderBeforeWorkerPreloadSignal",
+    "checkRuntimeSkipsLateWorkerPreloadAfterFileSelectionStart",
+    "checkRuntimePreloadsProgressiveTraceRendererImplementation",
+    "checkRuntimeDrawsProgressiveRendererWhenCreatedQueryable",
+    "checkAppReadyWaitsForFirstFrameAndDeferredRenderer",
+    "checkAppReadyFailsWhenDeferredRendererFails"
+  ]
+});
+
 export const RUNTIME_BRIDGE = Object.freeze({
   "threads": {
     "MAIN": "main"

--- a/tools/browser-harness.js
+++ b/tools/browser-harness.js
@@ -177,6 +177,113 @@ async function flushAsyncWork(options = {}) {
   await flushMicrotasks(options.afterImmediateMicrotasks ?? 1);
 }
 
+const RUNTIME_APP_FIRST_FRAME_TIMESTAMP_MS = 0;
+const RUNTIME_APP_READY_FRAME_TIMESTAMP_MS = 16;
+
+function createRuntimeAppHarness(options = {}) {
+  const {
+    browserGlobals: defaultBrowserGlobals = {},
+    host: defaultHost = {},
+    memory: defaultMemory = null,
+    memoryOptions: defaultMemoryOptions = { initial: 1 },
+    runAppOptions: defaultRunAppOptions = {},
+    runtime: defaultRuntime = null,
+    runtimeModulePath: defaultRuntimeModulePath = "host/runtime.mjs",
+  } = options;
+  let browserGlobals = null;
+  let controller = null;
+  let memory = defaultMemory;
+  let runtime = defaultRuntime;
+
+  function requireBooted() {
+    if (browserGlobals === null || controller === null) {
+      throw new Error("runtime app harness must boot before running frames");
+    }
+  }
+
+  async function flushRuntimeWork(count) {
+    await flushRuntimeMicrotasks(count);
+  }
+
+  async function boot(bootOptions = {}) {
+    if (controller !== null) {
+      throw new Error("runtime app harness boot was already called");
+    }
+
+    browserGlobals = installRuntimeBrowserGlobals(
+      bootOptions.browserGlobals ?? defaultBrowserGlobals,
+    );
+    memory =
+      bootOptions.memory ??
+      memory ??
+      new WebAssembly.Memory(bootOptions.memoryOptions ?? defaultMemoryOptions);
+    runtime =
+      bootOptions.runtime ??
+      runtime ??
+      await importRepoModule(bootOptions.runtimeModulePath ?? defaultRuntimeModulePath);
+    controller = runtime.runApp(
+      memory,
+      bootOptions.host ?? defaultHost,
+      bootOptions.runAppOptions ?? defaultRunAppOptions,
+    );
+    await flushRuntimeWork(bootOptions.microtasks);
+
+    return controller;
+  }
+
+  async function runFrame(timestamp, frameOptions = {}) {
+    requireBooted();
+
+    await runAnimationFrame(browserGlobals.frames, timestamp, {
+      beforeFrame: frameOptions.beforeFrame,
+      frameDurations: frameOptions.frameDurations,
+      microtasks: 0,
+      performance: frameOptions.performance,
+    });
+    await flushRuntimeWork(frameOptions.microtasks);
+  }
+
+  async function bootToAppReady(appReadyOptions = {}) {
+    if (controller === null) {
+      await boot(appReadyOptions);
+    } else {
+      requireBooted();
+    }
+
+    await runFrame(
+      appReadyOptions.firstFrameTimestamp ?? RUNTIME_APP_FIRST_FRAME_TIMESTAMP_MS,
+      appReadyOptions,
+    );
+    const appReadyFrameCallbacks = browserGlobals.frames.splice(0);
+    for (const frame of appReadyFrameCallbacks) {
+      frame(
+        appReadyOptions.appReadyFrameTimestamp ??
+          RUNTIME_APP_READY_FRAME_TIMESTAMP_MS,
+      );
+    }
+    await flushRuntimeWork(appReadyOptions.microtasks);
+  }
+
+  return {
+    boot,
+    bootToAppReady,
+    flushRuntimeWork,
+    get browserGlobals() {
+      return browserGlobals;
+    },
+    get controller() {
+      return controller;
+    },
+    get frames() {
+      return browserGlobals?.frames ?? [];
+    },
+    get memory() {
+      return memory;
+    },
+    runFrame,
+  };
+}
+
 function createFakeWorkerClass() {
   return class FakeWorker {
     static instances = [];
@@ -222,6 +329,7 @@ function importRepoModule(relativePath) {
 module.exports = {
   createFakeWorkerClass,
   createRafHarness,
+  createRuntimeAppHarness,
   flushAsyncWork,
   flushMicrotasks,
   flushRuntimeMicrotasks,

--- a/tools/browser-harness.js
+++ b/tools/browser-harness.js
@@ -243,6 +243,19 @@ function createRuntimeAppHarness(options = {}) {
     await flushRuntimeWork(frameOptions.microtasks);
   }
 
+  async function advanceAppReadyFrame(appReadyOptions = {}) {
+    requireBooted();
+
+    const appReadyFrameCallbacks = browserGlobals.frames.splice(0);
+    for (const frame of appReadyFrameCallbacks) {
+      frame(
+        appReadyOptions.appReadyFrameTimestamp ??
+          RUNTIME_APP_READY_FRAME_TIMESTAMP_MS,
+      );
+    }
+    await flushRuntimeWork(appReadyOptions.microtasks);
+  }
+
   async function bootToAppReady(appReadyOptions = {}) {
     if (controller === null) {
       await boot(appReadyOptions);
@@ -254,17 +267,11 @@ function createRuntimeAppHarness(options = {}) {
       appReadyOptions.firstFrameTimestamp ?? RUNTIME_APP_FIRST_FRAME_TIMESTAMP_MS,
       appReadyOptions,
     );
-    const appReadyFrameCallbacks = browserGlobals.frames.splice(0);
-    for (const frame of appReadyFrameCallbacks) {
-      frame(
-        appReadyOptions.appReadyFrameTimestamp ??
-          RUNTIME_APP_READY_FRAME_TIMESTAMP_MS,
-      );
-    }
-    await flushRuntimeWork(appReadyOptions.microtasks);
+    await advanceAppReadyFrame(appReadyOptions);
   }
 
   return {
+    advanceAppReadyFrame,
     boot,
     bootToAppReady,
     flushRuntimeWork,

--- a/tools/direct-esm-check.js
+++ b/tools/direct-esm-check.js
@@ -20,9 +20,79 @@ const FORBIDDEN_BUNDLE_PATTERNS = [
 ];
 const LEGACY_BOOTSTRAP_ENTRYPOINT = "bootstrap" + ".js";
 const LEGACY_BOOTSTRAP_PATTERN = new RegExp(`${"bootstrap"}\\.js`);
+const RUNTIME_APP_BOOT_SENSITIVE_CHECKS = Object.freeze([
+  "checkRuntimeOrchestratesWorker",
+  "checkRuntimeStartsIngestFromFileSelection",
+  "checkRuntimePreloadsIndexReaderBeforeWorkerPreloadSignal",
+  "checkRuntimeSkipsLateWorkerPreloadAfterFileSelectionStart",
+  "checkRuntimePreloadsProgressiveTraceRendererImplementation",
+  "checkRuntimeDrawsProgressiveRendererWhenCreatedQueryable",
+  "checkAppReadyWaitsForFirstFrameAndDeferredRenderer",
+  "checkAppReadyFailsWhenDeferredRendererFails",
+]);
+const FORBIDDEN_RUNTIME_APP_BOOT_PATTERNS = Object.freeze([
+  {
+    pattern: /\bruntime\.runApp\s*\(/,
+    message: "direct runtime app startup",
+  },
+  {
+    pattern: /\binstallRuntimeBrowserGlobals\s*\(/,
+    message: "local runtime browser-global installation",
+  },
+  {
+    pattern: /new\s+WebAssembly\.Memory\s*\(/,
+    message: "local runtime Wasm memory setup",
+  },
+  {
+    pattern: /\bawait\s+Promise\.resolve\s*\(\s*\)/,
+    message: "local microtask flushing",
+  },
+  {
+    pattern: /\bflushRuntimeMicrotasks\s*\(/,
+    message: "direct runtime microtask flushing",
+  },
+  {
+    pattern: /\bframes\s*\[/,
+    message: "direct frame-array callback execution",
+  },
+  {
+    pattern: /\bframes\.splice\s*\(/,
+    message: "direct frame-array mutation",
+  },
+  {
+    pattern: /\bappReadyFrameCallbacks\b/,
+    message: "local app-ready frame orchestration",
+  },
+]);
 
 function readRepoFile(relativePath) {
   return fs.readFileSync(path.join(ROOT_DIR, relativePath), "utf8");
+}
+
+function extractFunctionSource(source, functionName) {
+  const functionPattern = new RegExp(`\\b(?:async\\s+)?function\\s+${functionName}\\s*\\(`);
+  const match = functionPattern.exec(source);
+
+  assert(match, `runtime worker orchestration check should define ${functionName}`);
+
+  const functionStart = match.index;
+  const bodyStart = source.indexOf("{", functionStart);
+
+  assert.notEqual(bodyStart, -1, `${functionName} should have a function body`);
+
+  let depth = 0;
+  for (let index = bodyStart; index < source.length; index += 1) {
+    if (source[index] === "{") {
+      depth += 1;
+    } else if (source[index] === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(functionStart, index + 1);
+      }
+    }
+  }
+
+  assert.fail(`${functionName} should have a balanced function body`);
 }
 
 function escapeRegExp(value) {
@@ -326,6 +396,44 @@ function assertRuntimeWorkerCheckUsesSharedHarness() {
       pattern,
       `runtime worker orchestration check should not own ${message}`,
     );
+  }
+}
+
+function assertRuntimeAppBootChecksUseHarnessOperations() {
+  const source = readRepoFile("tools/runtime-worker-orchestration-check.js");
+
+  assert.match(
+    source,
+    /createRuntimeAppHarness/,
+    "runtime worker orchestration check should import the runtime app boot harness",
+  );
+
+  for (const functionName of RUNTIME_APP_BOOT_SENSITIVE_CHECKS) {
+    const functionSource = extractFunctionSource(source, functionName);
+
+    assert.match(
+      functionSource,
+      /\bcreateRuntimeAppHarness\s*\(/,
+      `${functionName} should create the shared runtime app boot harness`,
+    );
+    assert.match(
+      functionSource,
+      /\bharness\.(?:boot|bootToAppReady)\s*\(/,
+      `${functionName} should boot the runtime app through the harness`,
+    );
+    assert.match(
+      functionSource,
+      /\bharness\.(?:runFrame|bootToAppReady)\s*\(/,
+      `${functionName} should advance runtime frames through the harness`,
+    );
+
+    for (const { pattern, message } of FORBIDDEN_RUNTIME_APP_BOOT_PATTERNS) {
+      assert.doesNotMatch(
+        functionSource,
+        pattern,
+        `${functionName} should not reintroduce ${message}; use createRuntimeAppHarness operations instead`,
+      );
+    }
   }
 }
 
@@ -1160,6 +1268,7 @@ function main() {
   assertIndexCatalogUsesGeneratedFormatSpec();
   assertRuntimeWorkerCheckUsesGeneratedIndexFormatSpec();
   assertRuntimeWorkerCheckUsesSharedHarness();
+  assertRuntimeAppBootChecksUseHarnessOperations();
   assertInteractiveIngestCheckUsesGeneratedVerificationSpec();
   assertInteractiveIngestCheckUsesSharedHarness();
   assertProductionTopologyFixtureUsesHostAbiSpec();

--- a/tools/direct-esm-check.js
+++ b/tools/direct-esm-check.js
@@ -20,16 +20,6 @@ const FORBIDDEN_BUNDLE_PATTERNS = [
 ];
 const LEGACY_BOOTSTRAP_ENTRYPOINT = "bootstrap" + ".js";
 const LEGACY_BOOTSTRAP_PATTERN = new RegExp(`${"bootstrap"}\\.js`);
-const RUNTIME_APP_BOOT_SENSITIVE_CHECKS = Object.freeze([
-  "checkRuntimeOrchestratesWorker",
-  "checkRuntimeStartsIngestFromFileSelection",
-  "checkRuntimePreloadsIndexReaderBeforeWorkerPreloadSignal",
-  "checkRuntimeSkipsLateWorkerPreloadAfterFileSelectionStart",
-  "checkRuntimePreloadsProgressiveTraceRendererImplementation",
-  "checkRuntimeDrawsProgressiveRendererWhenCreatedQueryable",
-  "checkAppReadyWaitsForFirstFrameAndDeferredRenderer",
-  "checkAppReadyFailsWhenDeferredRendererFails",
-]);
 const FORBIDDEN_RUNTIME_APP_BOOT_PATTERNS = Object.freeze([
   {
     pattern: /\bruntime\.runApp\s*\(/,
@@ -67,6 +57,10 @@ const FORBIDDEN_RUNTIME_APP_BOOT_PATTERNS = Object.freeze([
 
 function readRepoFile(relativePath) {
   return fs.readFileSync(path.join(ROOT_DIR, relativePath), "utf8");
+}
+
+function readJsonRepoFile(relativePath) {
+  return JSON.parse(readRepoFile(relativePath));
 }
 
 function extractFunctionSource(source, functionName) {
@@ -400,15 +394,33 @@ function assertRuntimeWorkerCheckUsesSharedHarness() {
 }
 
 function assertRuntimeAppBootChecksUseHarnessOperations() {
+  const runtimeSpec = readJsonRepoFile("abi/runtime.json");
+  const bootSensitiveChecks =
+    runtimeSpec.runtimeWorkerOrchestrationCheck?.bootSensitiveChecks;
   const source = readRepoFile("tools/runtime-worker-orchestration-check.js");
+  const startupSpecSource = readRepoFile("host/startup-spec.mjs");
 
   assert.match(
     source,
     /createRuntimeAppHarness/,
     "runtime worker orchestration check should import the runtime app boot harness",
   );
+  assertStringArray(
+    bootSensitiveChecks,
+    "runtime worker orchestration check boot-sensitive check names should live in abi/runtime.json",
+  );
+  assert.match(
+    startupSpecSource,
+    /export const RUNTIME_WORKER_ORCHESTRATION_CHECK = Object\.freeze/,
+    "generated startup spec should expose the runtime worker orchestration check contract",
+  );
+  assert.match(
+    startupSpecSource,
+    /bootSensitiveChecks/,
+    "generated startup spec should include boot-sensitive runtime worker check names",
+  );
 
-  for (const functionName of RUNTIME_APP_BOOT_SENSITIVE_CHECKS) {
+  for (const functionName of bootSensitiveChecks) {
     const functionSource = extractFunctionSource(source, functionName);
 
     assert.match(

--- a/tools/generate-runtime-spec.js
+++ b/tools/generate-runtime-spec.js
@@ -354,6 +354,8 @@ function renderStartupSpecModule() {
     "",
     renderNumberConstants("INTERACTIVE_INGEST_CHECK", spec.interactiveIngestCheck),
     "",
+    renderObjectConstant("RUNTIME_WORKER_ORCHESTRATION_CHECK", spec.runtimeWorkerOrchestrationCheck),
+    "",
     renderObjectConstant("RUNTIME_BRIDGE", spec.runtimeBridge),
     "",
     renderNamedStrings("PERFORMANCE_MARKS", spec.performanceMarks),

--- a/tools/runtime-worker-orchestration-check.js
+++ b/tools/runtime-worker-orchestration-check.js
@@ -773,7 +773,7 @@ async function checkRuntimeOrchestratesWorker() {
   await harness.runFrame(122);
   await harness.runFrame(123);
   await importRepoModule("host/trace-renderer-spec.mjs");
-  await flushRuntimeMicrotasks();
+  await harness.flushRuntimeWork();
   assert.deepEqual(performanceEntries.slice(-2), [
     { kind: "mark", name: "tracy.app.ready" },
     {
@@ -938,7 +938,7 @@ async function checkRuntimePreloadsIndexReaderBeforeWorkerPreloadSignal() {
   );
 
   resolveIndexPreload(true);
-  await flushRuntimeMicrotasks();
+  await harness.flushRuntimeWork();
 
   assert.deepEqual(
     preloadCalls,
@@ -1012,7 +1012,7 @@ async function checkRuntimeSkipsLateWorkerPreloadAfterFileSelectionStart() {
   assert.equal(callbacks.length, 1);
 
   callbacks[0]({ file: selectedFile, handle: selectedFileHandle });
-  await flushRuntimeMicrotasks();
+  await harness.flushRuntimeWork();
 
   const worker = controller.worker;
   assert.deepEqual(worker.posted, [
@@ -1028,7 +1028,7 @@ async function checkRuntimeSkipsLateWorkerPreloadAfterFileSelectionStart() {
   ]);
 
   resolveIndexPreload(true);
-  await flushRuntimeMicrotasks();
+  await harness.flushRuntimeWork();
 
   assert.deepEqual(
     worker.posted.map((message) => message.type),
@@ -3391,7 +3391,7 @@ async function checkAppReadyWaitsForFirstFrameAndDeferredRenderer() {
     },
   });
   await importRepoModule("host/trace-renderer-spec.mjs");
-  await flushRuntimeMicrotasks();
+  await harness.flushRuntimeWork();
   assert.deepEqual(performanceEntries.slice(-2), [
     { kind: "mark", name: "tracy.app.ready" },
     {

--- a/tools/runtime-worker-orchestration-check.js
+++ b/tools/runtime-worker-orchestration-check.js
@@ -5,6 +5,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const {
   createFakeWorkerClass,
+  createRuntimeAppHarness,
   flushRuntimeMicrotasks,
   importRepoModule,
   installRuntimeBrowserGlobals,
@@ -604,13 +605,10 @@ function makeAppExports(extra = {}) {
 }
 
 async function checkRuntimeOrchestratesWorker() {
-  const { frames } = installRuntimeBrowserGlobals();
-  const runtime = await importRepoModule("host/runtime.mjs");
   const workerMessages = [];
   const instantiateCalls = [];
   const performanceEntries = [];
   const ticks = [];
-  const memory = new WebAssembly.Memory({ initial: 512 });
   const indexReaderOpenCalls = [];
   const host = {
     opfs_index_create() {
@@ -626,70 +624,71 @@ async function checkRuntimeOrchestratesWorker() {
       performanceEntries.push({ kind: "measure", name, start, end });
     },
   };
-
-  const controller = runtime.runApp(memory, host, {
-    ingest: {
-      indexName: "indexes/trace.idx",
-      sourceName: "sources/trace.json",
-    },
-    indexReader: {
-      open(indexName) {
-        indexReaderOpenCalls.push(indexName);
-        return Promise.resolve(true);
+  const harness = createRuntimeAppHarness({
+    host,
+    memoryOptions: { initial: 512 },
+    runAppOptions: {
+      ingest: {
+        indexName: "indexes/trace.idx",
+        sourceName: "sources/trace.json",
       },
-    },
-    instantiateWasmModuleForThread: async (id, thread, imports) => {
-      instantiateCalls.push({
-        hostImport: imports.host.opfs_index_create,
-        id,
-        memory: imports.env.memory,
-        thread,
-      });
-      return {
-        exports: makeAppExports({
-          tracy_main() {
-            ticks.push("main");
-          },
-          tracy_tick(ts) {
-            ticks.push(ts);
-          },
-        }),
-      };
-    },
-    importProgressiveTraceRenderer: async () => ({
-      createProgressiveTraceRenderer() {
+      indexReader: {
+        open(indexName) {
+          indexReaderOpenCalls.push(indexName);
+          return Promise.resolve(true);
+        },
+      },
+      instantiateWasmModuleForThread: async (id, thread, imports) => {
+        instantiateCalls.push({
+          hostImport: imports.host.opfs_index_create,
+          id,
+          memory: imports.env.memory,
+          thread,
+        });
         return {
-          draw() {},
+          exports: makeAppExports({
+            tracy_main() {
+              ticks.push("main");
+            },
+            tracy_tick(ts) {
+              ticks.push(ts);
+            },
+          }),
         };
       },
-    }),
-    performance,
-    worker: {
-      Worker: FakeWorker,
-      onWorkerStatus(status, message) {
-        workerStatus.push({ status, message });
+      importProgressiveTraceRenderer: async () => ({
+        createProgressiveTraceRenderer() {
+          return {
+            draw() {},
+          };
+        },
+      }),
+      performance,
+      worker: {
+        Worker: FakeWorker,
+        onWorkerStatus(status, message) {
+          workerStatus.push({ status, message });
+        },
+        workerUrl: "worker.js",
       },
-      workerUrl: "worker.js",
     },
   });
 
-  await Promise.resolve();
-  await Promise.resolve();
+  const controller = await harness.boot();
+  const { memory } = harness;
 
   assert.equal(FakeWorker.instances.length, 0);
-  assert.ok(frames.length >= 1, "draw loop should be scheduled before ingest preload");
-  frames[0](0);
-  await flushRuntimeMicrotasks();
+  assert.ok(
+    harness.frames.length >= 1,
+    "draw loop should be scheduled before ingest preload",
+  );
+  await harness.runFrame(0);
   assert.equal(FakeWorker.instances.length, 0);
   assert.ok(
-    frames.length >= 2,
+    harness.frames.length >= 2,
     "app-ready follow-up frame should be scheduled before ingest preload",
   );
-  const appReadyFrameCallbacks = frames.splice(0);
-  for (const frame of appReadyFrameCallbacks) {
-    frame(16);
-  }
-  await flushRuntimeMicrotasks();
+  await harness.advanceAppReadyFrame();
 
   assert.equal(FakeWorker.instances.length, 1);
   const worker = FakeWorker.instances[0];
@@ -697,9 +696,7 @@ async function checkRuntimeOrchestratesWorker() {
   assert.deepEqual(worker.options, { type: "module" });
   assert.deepEqual(worker.posted, [{ type: "preload" }]);
   worker.emit("message", { type: "preloaded" });
-  await Promise.resolve();
-  await Promise.resolve();
-  await Promise.resolve();
+  await harness.flushRuntimeWork();
   assert.deepEqual(instantiateCalls, [
     { hostImport: host.opfs_index_create, id: "app", memory, thread: "main" },
   ]);
@@ -730,7 +727,11 @@ async function checkRuntimeOrchestratesWorker() {
       end: "tracy.app.ready",
     },
   ]);
-  assert.equal(frames.length, 1, "draw loop should continue after ingest preload");
+  assert.equal(
+    harness.frames.length,
+    1,
+    "draw loop should continue after ingest preload",
+  );
   assert.deepEqual(worker.posted, [
     {
       type: "preload",
@@ -769,8 +770,8 @@ async function checkRuntimeOrchestratesWorker() {
     committedEvents: 7,
   });
 
-  frames[0](122);
-  frames[1](123);
+  await harness.runFrame(122);
+  await harness.runFrame(123);
   await importRepoModule("host/trace-renderer-spec.mjs");
   await flushRuntimeMicrotasks();
   assert.deepEqual(performanceEntries.slice(-2), [
@@ -792,6 +793,7 @@ async function checkRuntimeOrchestratesWorker() {
   assert.equal(controller.status().result.committedEvents, 7);
   assert.equal(workerStatus.at(-1).status.state, "complete");
 
+  const runtime = await importRepoModule("host/runtime.mjs");
   const controllerWithError = runtime.createIngestWorkerController({
     Worker: FakeWorker,
     onWorkerStatus(status, message) {
@@ -809,11 +811,7 @@ async function checkRuntimeOrchestratesWorker() {
 }
 
 async function checkRuntimeStartsIngestFromFileSelection() {
-  const { frames } = installRuntimeBrowserGlobals();
-
-  const runtime = await importRepoModule("host/runtime.mjs");
   const abi = await importRepoModule("host/abi.mjs");
-  const memory = new WebAssembly.Memory({ initial: 512 });
   const sourceName = "sources/selected trace.json";
   const callbacks = [];
   const workerStatus = [];
@@ -831,52 +829,47 @@ async function checkRuntimeStartsIngestFromFileSelection() {
       callbacks.push(callback);
     },
   };
-
-  const controller = runtime.runApp(memory, host, {
-    indexReader: false,
-    importProgressiveTraceRenderer: async () => ({
-      createProgressiveTraceRenderer() {
-        return { draw() {} };
+  const harness = createRuntimeAppHarness({
+    host,
+    memoryOptions: { initial: 512 },
+    runAppOptions: {
+      indexReader: false,
+      importProgressiveTraceRenderer: async () => ({
+        createProgressiveTraceRenderer() {
+          return { draw() {} };
+        },
+      }),
+      instantiateWasmModuleForThread: async () => ({
+        exports: makeAppExports(),
+      }),
+      worker: {
+        Worker: FakeWorker,
+        onWorkerStatus(status, message) {
+          workerStatus.push({ status, message });
+        },
+        workerUrl: "worker.js",
       },
-    }),
-    instantiateWasmModuleForThread: async () => ({
-      exports: makeAppExports(),
-    }),
-    worker: {
-      Worker: FakeWorker,
-      onWorkerStatus(status, message) {
-        workerStatus.push({ status, message });
-      },
-      workerUrl: "worker.js",
     },
   });
 
-  await Promise.resolve();
-  await Promise.resolve();
+  const controller = await harness.boot();
 
   assert.equal(controller.worker, null);
-  frames[0](0);
-  await flushRuntimeMicrotasks();
+  await harness.runFrame(0);
   assert.equal(controller.worker, null);
-  assert.ok(frames.length >= 2);
-  const appReadyFrameCallbacks = frames.splice(0);
-  for (const frame of appReadyFrameCallbacks) {
-    frame(16);
-  }
-  await flushRuntimeMicrotasks();
+  assert.ok(harness.frames.length >= 2);
+  await harness.advanceAppReadyFrame();
 
   const preloadWorker = controller.worker;
   assert.deepEqual(preloadWorker.posted, [{ type: "preload" }]);
   preloadWorker.emit("message", { type: "preloaded" });
-  await Promise.resolve();
-  await Promise.resolve();
+  await harness.flushRuntimeWork();
 
   assert.equal(callbacks.length, 1);
   assert.equal(controller.worker, preloadWorker);
 
   callbacks[0]({ file: selectedFile, handle: 9 });
-  await Promise.resolve();
-  await Promise.resolve();
+  await harness.flushRuntimeWork();
 
   const worker = controller.worker;
   assert.equal(
@@ -902,14 +895,11 @@ async function checkRuntimeStartsIngestFromFileSelection() {
   assert.equal(workerStatus.at(-1).status.state, "running");
 
   callbacks[0]({ handle: -1 });
-  await Promise.resolve();
+  await harness.flushRuntimeWork();
   assert.equal(worker.posted.length, 2, "cancelled picker should not start ingest");
 }
 
 async function checkRuntimePreloadsIndexReaderBeforeWorkerPreloadSignal() {
-  const { frames } = installRuntimeBrowserGlobals();
-  const runtime = await importRepoModule("host/runtime.mjs");
-  const memory = new WebAssembly.Memory({ initial: 1 });
   const preloadCalls = [];
   let resolveIndexPreload;
   const indexPreload = new Promise((resolve) => {
@@ -927,23 +917,19 @@ async function checkRuntimePreloadsIndexReaderBeforeWorkerPreloadSignal() {
       return Promise.resolve(true);
     },
   };
-
-  runtime.runApp(memory, {}, {
-    ingestWorker,
-    instantiateWasmModuleForThread: async () => ({
-      exports: makeAppExports(),
-    }),
-    progressiveTraceRenderer: false,
+  const harness = createRuntimeAppHarness({
+    runAppOptions: {
+      ingestWorker,
+      instantiateWasmModuleForThread: async () => ({
+        exports: makeAppExports(),
+      }),
+      progressiveTraceRenderer: false,
+    },
   });
 
-  await flushRuntimeMicrotasks();
-  frames[0](0);
-  await flushRuntimeMicrotasks();
-  const appReadyFrameCallbacks = frames.splice(0);
-  for (const frame of appReadyFrameCallbacks) {
-    frame(16);
-  }
-  await flushRuntimeMicrotasks();
+  await harness.boot();
+  await harness.runFrame(0);
+  await harness.advanceAppReadyFrame();
 
   assert.deepEqual(
     preloadCalls,
@@ -962,13 +948,10 @@ async function checkRuntimePreloadsIndexReaderBeforeWorkerPreloadSignal() {
 }
 
 async function checkRuntimeSkipsLateWorkerPreloadAfterFileSelectionStart() {
-  const { frames } = installRuntimeBrowserGlobals();
   FakeWorker.reset();
 
-  const runtime = await importRepoModule("host/runtime.mjs");
   const abi = await importRepoModule("host/abi.mjs");
   const runtimeMemoryPages = 1;
-  const memory = new WebAssembly.Memory({ initial: runtimeMemoryPages });
   const selectedFileSizeBytes = 1234;
   const selectedFile = Object.freeze({
     name: "pending preload trace.json",
@@ -978,8 +961,6 @@ async function checkRuntimeSkipsLateWorkerPreloadAfterFileSelectionStart() {
   const expectedSourceName = `sources/${selectedFile.name}`;
   const expectedIndexName = "indexes/pending_preload_trace.json.idx";
   const workerUrl = "worker.js";
-  const firstFrameTimestampMs = 0;
-  const appReadyFrameTimestampMs = 16;
   const preloadCalls = [];
   const callbacks = [];
   let resolveIndexPreload;
@@ -997,32 +978,30 @@ async function checkRuntimeSkipsLateWorkerPreloadAfterFileSelectionStart() {
       callbacks.push(callback);
     },
   };
-
-  const controller = runtime.runApp(memory, host, {
-    indexReader: {
-      preload() {
-        preloadCalls.push("index-reader");
-        return indexPreload;
+  const harness = createRuntimeAppHarness({
+    host,
+    memoryOptions: { initial: runtimeMemoryPages },
+    runAppOptions: {
+      indexReader: {
+        preload() {
+          preloadCalls.push("index-reader");
+          return indexPreload;
+        },
       },
-    },
-    instantiateWasmModuleForThread: async () => ({
-      exports: makeAppExports(),
-    }),
-    progressiveTraceRenderer: false,
-    worker: {
-      Worker: FakeWorker,
-      workerUrl,
+      instantiateWasmModuleForThread: async () => ({
+        exports: makeAppExports(),
+      }),
+      progressiveTraceRenderer: false,
+      worker: {
+        Worker: FakeWorker,
+        workerUrl,
+      },
     },
   });
 
-  await flushRuntimeMicrotasks();
-  frames[0](firstFrameTimestampMs);
-  await flushRuntimeMicrotasks();
-  const appReadyFrameCallbacks = frames.splice(0);
-  for (const frame of appReadyFrameCallbacks) {
-    frame(appReadyFrameTimestampMs);
-  }
-  await flushRuntimeMicrotasks();
+  const controller = await harness.boot();
+  await harness.runFrame(0);
+  await harness.advanceAppReadyFrame();
 
   assert.deepEqual(
     preloadCalls,
@@ -3201,9 +3180,6 @@ async function checkProgressiveTraceRendererClampsPanZoomAndDrawsUnknownRange() 
 }
 
 async function checkRuntimePreloadsProgressiveTraceRendererImplementation() {
-  const { frames } = installRuntimeBrowserGlobals();
-  const runtime = await importRepoModule("host/runtime.mjs");
-  const memory = new WebAssembly.Memory({ initial: 1 });
   let coveredRange = null;
   let readerCoveredRange = null;
   let readerState = "idle";
@@ -3223,58 +3199,56 @@ async function checkRuntimePreloadsProgressiveTraceRendererImplementation() {
       return { coveredRange, state: "running" };
     },
   };
-
-  runtime.runApp(memory, {}, {
-    importProgressiveTraceRenderer: async () => {
-      importCalls += 1;
-      return {
-        createProgressiveTraceRenderer(nextMemory, nextIngestWorker, options) {
-          assert.equal(nextMemory, memory);
-          assert.equal(nextIngestWorker, ingestWorker);
-          rendererOptions = options;
-          return {
-            draw() {
-              drawCalls += 1;
-            },
-          };
-        },
-      };
-    },
-    ingestWorker,
-    preloadIngestDependencies: false,
-    instantiateWasmModuleForThread: async () => ({
-      exports: makeAppExports(),
-    }),
-    worker: {
-      Worker: FakeWorker,
+  const harness = createRuntimeAppHarness({
+    runAppOptions: {
+      importProgressiveTraceRenderer: async () => {
+        importCalls += 1;
+        return {
+          createProgressiveTraceRenderer(nextMemory, nextIngestWorker, options) {
+            assert.equal(nextMemory, harness.memory);
+            assert.equal(nextIngestWorker, ingestWorker);
+            rendererOptions = options;
+            return {
+              draw() {
+                drawCalls += 1;
+              },
+            };
+          },
+        };
+      },
+      ingestWorker,
+      preloadIngestDependencies: false,
+      instantiateWasmModuleForThread: async () => ({
+        exports: makeAppExports(),
+      }),
+      worker: {
+        Worker: FakeWorker,
+      },
     },
   });
 
-  await flushRuntimeMicrotasks();
+  await harness.boot();
 
   assert.equal(
     importCalls,
     1,
     "renderer implementation module import should start before the first animation frame",
   );
-  frames[0](1);
-  await flushRuntimeMicrotasks();
+  await harness.runFrame(1);
   assert.equal(importCalls, 1, "renderer implementation module should be imported once");
   assert.equal(drawCalls, 0, "renderer should not draw before covered pages are queryable");
 
   coveredRange = { end: 0, start: 0, type: "covered_range", valid: false };
   readerState = "ready";
-  frames[1](2);
-  await flushRuntimeMicrotasks();
+  await harness.runFrame(2);
   assert.equal(
     drawCalls,
     0,
     "renderer should wait a frame for creation after the reader becomes queryable",
   );
 
-  frames[2](3);
-  await flushRuntimeMicrotasks();
-  frames[3](4);
+  await harness.runFrame(3);
+  await harness.runFrame(4);
   assert.equal(
     drawCalls,
     1,
@@ -3293,23 +3267,19 @@ async function checkRuntimePreloadsProgressiveTraceRendererImplementation() {
 
   readerCoveredRange = { end: 120, start: 100, valid: true };
   coveredRange = { end: 120, start: 100, type: "covered_range", valid: true };
-  frames[4](5);
+  await harness.runFrame(5);
   assert.equal(
     importCalls,
     1,
     "first queryable ingest frame should reuse the preloaded renderer implementation module",
   );
 
-  await flushRuntimeMicrotasks();
-  frames[5](6);
+  await harness.runFrame(6);
   assert.equal(importCalls, 1);
   assert.equal(drawCalls, 3);
 }
 
 async function checkRuntimeDrawsProgressiveRendererWhenCreatedQueryable() {
-  const { frames } = installRuntimeBrowserGlobals();
-  const runtime = await importRepoModule("host/runtime.mjs");
-  const memory = new WebAssembly.Memory({ initial: 1 });
   let drawCalls = 0;
   const coveredRange = { end: 120, start: 100, type: "covered_range", valid: true };
   const ingestWorker = {
@@ -3325,30 +3295,30 @@ async function checkRuntimeDrawsProgressiveRendererWhenCreatedQueryable() {
       return { coveredRange, state: "running" };
     },
   };
-
-  runtime.runApp(memory, {}, {
-    importProgressiveTraceRenderer: async () => ({
-      createProgressiveTraceRenderer() {
-        return {
-          draw() {
-            drawCalls += 1;
-          },
-        };
+  const harness = createRuntimeAppHarness({
+    runAppOptions: {
+      importProgressiveTraceRenderer: async () => ({
+        createProgressiveTraceRenderer() {
+          return {
+            draw() {
+              drawCalls += 1;
+            },
+          };
+        },
+      }),
+      ingestWorker,
+      instantiateWasmModuleForThread: async () => ({
+        exports: makeAppExports(),
+      }),
+      worker: {
+        Worker: FakeWorker,
       },
-    }),
-    ingestWorker,
-    instantiateWasmModuleForThread: async () => ({
-      exports: makeAppExports(),
-    }),
-    worker: {
-      Worker: FakeWorker,
     },
   });
 
-  await flushRuntimeMicrotasks();
-  frames[0](1);
-  frames[1](2);
-  await flushRuntimeMicrotasks();
+  await harness.boot();
+  await harness.runFrame(1);
+  await harness.runFrame(2);
 
   assert.equal(
     drawCalls,
@@ -3358,9 +3328,6 @@ async function checkRuntimeDrawsProgressiveRendererWhenCreatedQueryable() {
 }
 
 async function checkAppReadyWaitsForFirstFrameAndDeferredRenderer() {
-  const { frames } = installRuntimeBrowserGlobals();
-  const runtime = await importRepoModule("host/runtime.mjs");
-  const memory = new WebAssembly.Memory({ initial: 1 });
   const performanceEntries = [];
   const performance = {
     mark(name) {
@@ -3375,24 +3342,25 @@ async function checkAppReadyWaitsForFirstFrameAndDeferredRenderer() {
   const rendererImport = new Promise((resolve) => {
     resolveRendererImport = resolve;
   });
-
-  runtime.runApp(memory, {}, {
-    indexReader: false,
-    preloadIngestDependencies: false,
-    importProgressiveTraceRenderer: () => {
-      rendererImportStarted = true;
-      return rendererImport;
-    },
-    instantiateWasmModuleForThread: async () => ({
-      exports: makeAppExports(),
-    }),
-    performance,
-    worker: {
-      Worker: FakeWorker,
+  const harness = createRuntimeAppHarness({
+    runAppOptions: {
+      indexReader: false,
+      preloadIngestDependencies: false,
+      importProgressiveTraceRenderer: () => {
+        rendererImportStarted = true;
+        return rendererImport;
+      },
+      instantiateWasmModuleForThread: async () => ({
+        exports: makeAppExports(),
+      }),
+      performance,
+      worker: {
+        Worker: FakeWorker,
+      },
     },
   });
 
-  await flushRuntimeMicrotasks();
+  await harness.boot();
 
   assert.equal(
     performanceEntries.some((entry) => entry.name === "tracy.core.ready"),
@@ -3410,8 +3378,7 @@ async function checkAppReadyWaitsForFirstFrameAndDeferredRenderer() {
     "deferred renderer import should start before the first frame",
   );
 
-  frames[0](1);
-  await flushRuntimeMicrotasks();
+  await harness.runFrame(1);
   assert.equal(
     performanceEntries.some((entry) => entry.name === "tracy.app.ready"),
     false,
@@ -3437,9 +3404,6 @@ async function checkAppReadyWaitsForFirstFrameAndDeferredRenderer() {
 }
 
 async function checkAppReadyFailsWhenDeferredRendererFails() {
-  const { frames } = installRuntimeBrowserGlobals();
-  const runtime = await importRepoModule("host/runtime.mjs");
-  const memory = new WebAssembly.Memory({ initial: 1 });
   const performanceEntries = [];
   const previousError = globalThis.__TRACY_APP_LOAD_ERROR__;
   const previousConsoleError = console.error;
@@ -3454,24 +3418,25 @@ async function checkAppReadyFailsWhenDeferredRendererFails() {
 
   globalThis.__TRACY_APP_LOAD_ERROR__ = "";
   console.error = () => {};
-  runtime.runApp(memory, {}, {
-    indexReader: false,
-    preloadIngestDependencies: false,
-    importProgressiveTraceRenderer: async () => {
-      throw new Error("deferred renderer unavailable");
-    },
-    instantiateWasmModuleForThread: async () => ({
-      exports: makeAppExports(),
-    }),
-    performance,
-    worker: {
-      Worker: FakeWorker,
+  const harness = createRuntimeAppHarness({
+    runAppOptions: {
+      indexReader: false,
+      preloadIngestDependencies: false,
+      importProgressiveTraceRenderer: async () => {
+        throw new Error("deferred renderer unavailable");
+      },
+      instantiateWasmModuleForThread: async () => ({
+        exports: makeAppExports(),
+      }),
+      performance,
+      worker: {
+        Worker: FakeWorker,
+      },
     },
   });
 
-  await flushRuntimeMicrotasks();
-  frames[0](1);
-  await flushRuntimeMicrotasks();
+  await harness.boot();
+  await harness.runFrame(1);
 
   assert.equal(
     performanceEntries.some((entry) => entry.name === "tracy.app.ready"),


### PR DESCRIPTION
Fixes #298.

Extracts runtime app boot orchestration into a named test harness, migrates the boot-sensitive runtime checks onto `boot`, `runFrame`, and `bootToAppReady` style operations, and preserves the existing app-ready, preload ordering, first-frame, and renderer readiness behavior. Adds a guardrail against reintroducing open-coded boot setup, with the boot-sensitive check contract moving into generated/spec data instead of hard-coded checker literals.

Fixes #298.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] [Move the runtime app boot-sensitive check list/guard contract out of direct-esm-check.js hard-coded literals into spec JSON or generated contract data, then have the guard consume that source of truth.](https://github.com/rhencke/tracy/pull/322#discussion_r3222636974) <!-- type:thread -->
- [x] Migrate runtime orchestration checks to the boot harness <!-- type:spec -->
- [x] Guard runtime checks against open-coded app boot <!-- type:spec -->
- [x] Add runtime app boot harness <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->