### PR TITLE
LOC #2b - Ingest worker fake lifecycle harness (closes #299)

### DIFF
--- a/tools/direct-esm-check.js
+++ b/tools/direct-esm-check.js
@@ -89,6 +89,10 @@ function extractFunctionSource(source, functionName) {
   assert.fail(`${functionName} should have a balanced function body`);
 }
 
+function removeFunctionSource(source, functionName) {
+  return source.replace(extractFunctionSource(source, functionName), "");
+}
+
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -362,9 +366,14 @@ function assertRuntimeWorkerCheckUsesGeneratedIndexFormatSpec() {
 
 function assertRuntimeWorkerCheckUsesSharedHarness() {
   const source = readRepoFile("tools/runtime-worker-orchestration-check.js");
+  const sourceOutsideWorkerLifecycleHarness = removeFunctionSource(
+    source,
+    "createIngestWorkerLifecycleHarness",
+  );
 
   for (const [pattern, message] of [
     [/createFakeWorkerClass/, "fake Worker"],
+    [/createIngestWorkerLifecycleHarness/, "fake ingest worker lifecycle harness"],
     [/installRuntimeBrowserGlobals/, "browser globals"],
     [/flushRuntimeMicrotasks/, "runtime microtask flushing"],
     [/importRepoModule/, "repo module imports"],
@@ -389,6 +398,20 @@ function assertRuntimeWorkerCheckUsesSharedHarness() {
       source,
       pattern,
       `runtime worker orchestration check should not own ${message}`,
+    );
+  }
+
+  for (const [pattern, message] of [
+    [/FakeWorker\.instances/, "direct fake Worker instance lookup"],
+    [/FakeWorker\.reset\s*\(/, "direct fake Worker reset"],
+    [/\b\w+\.posted\b/, "raw posted-message access"],
+    [/\b\w+\.emit\s*\(\s*"message"/, "ad hoc worker message emits"],
+    [/\b\w+\.events\.get\s*\(\s*"error"\s*\)/, "ad hoc worker error emits"],
+  ]) {
+    assert.doesNotMatch(
+      sourceOutsideWorkerLifecycleHarness,
+      pattern,
+      `runtime worker orchestration check should keep ${message} behind createIngestWorkerLifecycleHarness`,
     );
   }
 }

--- a/tools/runtime-worker-orchestration-check.js
+++ b/tools/runtime-worker-orchestration-check.js
@@ -69,6 +69,69 @@ async function loadGeneratedTraceRendererSpec() {
 
 const FakeWorker = createFakeWorkerClass();
 
+function createIngestWorkerLifecycleHarness(Worker = FakeWorker) {
+  return {
+    Worker,
+    reset() {
+      Worker.reset();
+    },
+    expectWorkerCount(expected, message) {
+      assert.equal(Worker.instances.length, expected, message);
+    },
+    workerAt(index, message) {
+      const worker = Worker.instances.at(index);
+
+      assert.notEqual(worker, undefined, message ?? `expected worker at index ${index}`);
+      return worker;
+    },
+    latestWorker(message) {
+      return this.workerAt(-1, message ?? "expected a latest ingest worker");
+    },
+    postedMessages(worker, type) {
+      if (type === undefined) {
+        return worker.posted;
+      }
+
+      return worker.posted.filter((message) => message.type === type);
+    },
+    latestPostedMessage(worker, type) {
+      const messages = this.postedMessages(worker, type);
+
+      return messages.at(-1);
+    },
+    latestIngestId(worker) {
+      const message = this.latestPostedMessage(worker, "start");
+
+      assert.notEqual(message, undefined, "expected worker to have a start message");
+      return message.ingestId;
+    },
+    assertPosted(worker, expected, message) {
+      assert.deepEqual(worker.posted, expected, message);
+    },
+    assertPostedTypes(worker, expected, message) {
+      assert.deepEqual(
+        worker.posted.map((postedMessage) => postedMessage.type),
+        expected,
+        message,
+      );
+    },
+    emitMessage(worker, message) {
+      worker.emit("message", message);
+    },
+    emitError(worker, message) {
+      worker.events.get("error")({ message });
+    },
+    assertWorkerIgnored(worker, readObservedState, exerciseWorker, message) {
+      const before = readObservedState();
+
+      exerciseWorker(worker);
+      assert.deepEqual(readObservedState(), before, message);
+    },
+  };
+}
+
+const ingestWorkers = createIngestWorkerLifecycleHarness();
+
 function readTraceRenderRow(memory, ptr, index) {
   const view = new DataView(memory.buffer);
   const base = ptr + index * TEST_TRACE_RENDER_ROW_BYTES;

--- a/tools/runtime-worker-orchestration-check.js
+++ b/tools/runtime-worker-orchestration-check.js
@@ -728,7 +728,7 @@ async function checkRuntimeOrchestratesWorker() {
       }),
       performance,
       worker: {
-        Worker: FakeWorker,
+        Worker: ingestWorkers.Worker,
         onWorkerStatus(status, message) {
           workerStatus.push({ status, message });
         },
@@ -740,25 +740,25 @@ async function checkRuntimeOrchestratesWorker() {
   const controller = await harness.boot();
   const { memory } = harness;
 
-  assert.equal(FakeWorker.instances.length, 0);
+  ingestWorkers.expectWorkerCount(0);
   assert.ok(
     harness.frames.length >= 1,
     "draw loop should be scheduled before ingest preload",
   );
   await harness.runFrame(0);
-  assert.equal(FakeWorker.instances.length, 0);
+  ingestWorkers.expectWorkerCount(0);
   assert.ok(
     harness.frames.length >= 2,
     "app-ready follow-up frame should be scheduled before ingest preload",
   );
   await harness.advanceAppReadyFrame();
 
-  assert.equal(FakeWorker.instances.length, 1);
-  const worker = FakeWorker.instances[0];
+  ingestWorkers.expectWorkerCount(1);
+  const worker = ingestWorkers.workerAt(0);
   assert.equal(worker.url, "worker.js");
   assert.deepEqual(worker.options, { type: "module" });
-  assert.deepEqual(worker.posted, [{ type: "preload" }]);
-  worker.emit("message", { type: "preloaded" });
+  ingestWorkers.assertPosted(worker, [{ type: "preload" }]);
+  ingestWorkers.emitMessage(worker, { type: "preloaded" });
   await harness.flushRuntimeWork();
   assert.deepEqual(instantiateCalls, [
     { hostImport: host.opfs_index_create, id: "app", memory, thread: "main" },
@@ -795,7 +795,7 @@ async function checkRuntimeOrchestratesWorker() {
     1,
     "draw loop should continue after ingest preload",
   );
-  assert.deepEqual(worker.posted, [
+  ingestWorkers.assertPosted(worker, [
     {
       type: "preload",
     },
@@ -808,7 +808,7 @@ async function checkRuntimeOrchestratesWorker() {
   ]);
   assert.equal(controller.status().state, "running");
 
-  worker.emit("message", {
+  ingestWorkers.emitMessage(worker, {
     ingestId: 1,
     type: "progress",
     committedPages: 2,
@@ -820,14 +820,14 @@ async function checkRuntimeOrchestratesWorker() {
     throughputBytesPerSecond: 8000,
     totalBytes: 64,
   });
-  worker.emit("message", {
+  ingestWorkers.emitMessage(worker, {
     ingestId: 1,
     type: "covered_range",
     valid: true,
     start: 100,
     end: 132,
   });
-  worker.emit("message", {
+  ingestWorkers.emitMessage(worker, {
     ingestId: 1,
     type: "complete",
     committedEvents: 7,
@@ -858,16 +858,16 @@ async function checkRuntimeOrchestratesWorker() {
 
   const runtime = await importRepoModule("host/runtime.mjs");
   const controllerWithError = runtime.createIngestWorkerController({
-    Worker: FakeWorker,
+    Worker: ingestWorkers.Worker,
     onWorkerStatus(status, message) {
       workerMessages.push({ status, message });
     },
   });
   assert.equal(controllerWithError.worker, null);
   controllerWithError.start();
-  const errorWorker = FakeWorker.instances.at(-1);
+  const errorWorker = ingestWorkers.latestWorker();
 
-  errorWorker.events.get("error")({ message: "worker crashed" });
+  ingestWorkers.emitError(errorWorker, "worker crashed");
   assert.equal(controllerWithError.status().state, "error");
   assert.equal(controllerWithError.status().error, "worker crashed");
   assert.equal(workerMessages.at(-1).status.state, "error");
@@ -906,7 +906,7 @@ async function checkRuntimeStartsIngestFromFileSelection() {
         exports: makeAppExports(),
       }),
       worker: {
-        Worker: FakeWorker,
+        Worker: ingestWorkers.Worker,
         onWorkerStatus(status, message) {
           workerStatus.push({ status, message });
         },
@@ -924,8 +924,8 @@ async function checkRuntimeStartsIngestFromFileSelection() {
   await harness.advanceAppReadyFrame();
 
   const preloadWorker = controller.worker;
-  assert.deepEqual(preloadWorker.posted, [{ type: "preload" }]);
-  preloadWorker.emit("message", { type: "preloaded" });
+  ingestWorkers.assertPosted(preloadWorker, [{ type: "preload" }]);
+  ingestWorkers.emitMessage(preloadWorker, { type: "preloaded" });
   await harness.flushRuntimeWork();
 
   assert.equal(callbacks.length, 1);
@@ -940,7 +940,7 @@ async function checkRuntimeStartsIngestFromFileSelection() {
     false,
     "file selection should post worker ingest before any full OPFS copy",
   );
-  assert.deepEqual(worker.posted, [
+  ingestWorkers.assertPosted(worker, [
     {
       type: "preload",
     },
@@ -959,7 +959,11 @@ async function checkRuntimeStartsIngestFromFileSelection() {
 
   callbacks[0]({ handle: -1 });
   await harness.flushRuntimeWork();
-  assert.equal(worker.posted.length, 2, "cancelled picker should not start ingest");
+  assert.equal(
+    ingestWorkers.postedMessages(worker).length,
+    2,
+    "cancelled picker should not start ingest",
+  );
 }
 
 async function checkRuntimePreloadsIndexReaderBeforeWorkerPreloadSignal() {
@@ -1011,7 +1015,7 @@ async function checkRuntimePreloadsIndexReaderBeforeWorkerPreloadSignal() {
 }
 
 async function checkRuntimeSkipsLateWorkerPreloadAfterFileSelectionStart() {
-  FakeWorker.reset();
+  ingestWorkers.reset();
 
   const abi = await importRepoModule("host/abi.mjs");
   const runtimeMemoryPages = 1;
@@ -1056,7 +1060,7 @@ async function checkRuntimeSkipsLateWorkerPreloadAfterFileSelectionStart() {
       }),
       progressiveTraceRenderer: false,
       worker: {
-        Worker: FakeWorker,
+        Worker: ingestWorkers.Worker,
         workerUrl,
       },
     },
@@ -1078,7 +1082,7 @@ async function checkRuntimeSkipsLateWorkerPreloadAfterFileSelectionStart() {
   await harness.flushRuntimeWork();
 
   const worker = controller.worker;
-  assert.deepEqual(worker.posted, [
+  ingestWorkers.assertPosted(worker, [
     {
       ingestId: 1,
       indexName: expectedIndexName,
@@ -1093,8 +1097,8 @@ async function checkRuntimeSkipsLateWorkerPreloadAfterFileSelectionStart() {
   resolveIndexPreload(true);
   await harness.flushRuntimeWork();
 
-  assert.deepEqual(
-    worker.posted.map((message) => message.type),
+  ingestWorkers.assertPostedTypes(
+    worker,
     ["start"],
     "late worker preload should not post after selected-file ingest has started",
   );
@@ -1107,7 +1111,7 @@ async function checkRuntimeIgnoresStaleIngestWorkerMessages() {
   const indexReaderOpenCalls = [];
   const workerStatus = [];
   const controller = runtime.createIngestWorkerController({
-    Worker: FakeWorker,
+    Worker: ingestWorkers.Worker,
     indexReader: {
       open(indexName) {
         indexReaderOpenCalls.push(indexName);
@@ -1129,7 +1133,7 @@ async function checkRuntimeIgnoresStaleIngestWorkerMessages() {
   );
   const firstWorker = controller.worker;
 
-  assert.deepEqual(firstWorker.posted, [
+  ingestWorkers.assertPosted(firstWorker, [
     {
       ingestId: 1,
       indexName: "indexes/first.idx",
@@ -1149,7 +1153,7 @@ async function checkRuntimeIgnoresStaleIngestWorkerMessages() {
 
   assert.notEqual(secondWorker, firstWorker);
   assert.equal(firstWorker.terminated, true);
-  assert.deepEqual(secondWorker.posted, [
+  ingestWorkers.assertPosted(secondWorker, [
     {
       ingestId: 2,
       indexName: "indexes/second.idx",
@@ -1158,49 +1162,54 @@ async function checkRuntimeIgnoresStaleIngestWorkerMessages() {
     },
   ]);
 
-  firstWorker.emit("message", {
-    committedPages: 99,
-    fileOffset: 999,
-    ingestId: 1,
-    type: "progress",
-  });
-  firstWorker.emit("message", {
-    end: 999,
-    ingestId: 1,
-    start: 900,
-    type: "covered_range",
-    valid: true,
-  });
-  firstWorker.emit("message", {
-    committedEvents: 999,
-    ingestId: 1,
-    type: "complete",
-  });
+  ingestWorkers.assertWorkerIgnored(
+    firstWorker,
+    () => ({
+      coveredRange: controller.status().coveredRange,
+      error: controller.status().error,
+      indexReaderOpenCalls: [...indexReaderOpenCalls],
+      progress: controller.status().progress,
+      result: controller.status().result,
+      state: controller.status().state,
+    }),
+    (staleWorker) => {
+      ingestWorkers.emitMessage(staleWorker, {
+        committedPages: 99,
+        fileOffset: 999,
+        ingestId: 1,
+        type: "progress",
+      });
+      ingestWorkers.emitMessage(staleWorker, {
+        end: 999,
+        ingestId: 1,
+        start: 900,
+        type: "covered_range",
+        valid: true,
+      });
+      ingestWorkers.emitMessage(staleWorker, {
+        committedEvents: 999,
+        ingestId: 1,
+        type: "complete",
+      });
+      ingestWorkers.emitError(staleWorker, "old worker crashed");
+    },
+    "stale worker messages and errors should not update the active ingest",
+  );
 
-  assert.equal(controller.status().state, "running");
-  assert.equal(controller.status().progress, null);
-  assert.equal(controller.status().coveredRange, null);
-  assert.equal(controller.status().result, null);
-  assert.deepEqual(indexReaderOpenCalls, []);
-
-  firstWorker.events.get("error")({ message: "old worker crashed" });
-  assert.equal(controller.status().state, "running");
-  assert.equal(controller.status().error, null);
-
-  secondWorker.emit("message", {
+  ingestWorkers.emitMessage(secondWorker, {
     committedPages: 2,
     fileOffset: 64,
     ingestId: 2,
     type: "progress",
   });
-  secondWorker.emit("message", {
+  ingestWorkers.emitMessage(secondWorker, {
     end: 132,
     ingestId: 2,
     start: 100,
     type: "covered_range",
     valid: true,
   });
-  secondWorker.emit("message", {
+  ingestWorkers.emitMessage(secondWorker, {
     committedEvents: 7,
     ingestId: 2,
     type: "complete",
@@ -1213,35 +1222,39 @@ async function checkRuntimeIgnoresStaleIngestWorkerMessages() {
   assert.deepEqual(indexReaderOpenCalls, ["indexes/second.idx"]);
   assert.equal(workerStatus.at(-1).message.ingestId, 2);
 
-  secondWorker.emit("message", {
-    committedPages: 99,
-    fileOffset: 999,
-    ingestId: 2,
-    type: "progress",
-  });
-  secondWorker.emit("message", {
-    end: 999,
-    ingestId: 2,
-    start: 900,
-    type: "covered_range",
-    valid: true,
-  });
-  assert.equal(
-    controller.status().state,
-    "complete",
+  ingestWorkers.assertWorkerIgnored(
+    secondWorker,
+    () => ({
+      coveredRangeEnd: controller.status().coveredRange.end,
+      indexReaderOpenCalls: [...indexReaderOpenCalls],
+      progressFileOffset: controller.status().progress.fileOffset,
+      state: controller.status().state,
+    }),
+    (completedWorker) => {
+      ingestWorkers.emitMessage(completedWorker, {
+        committedPages: 99,
+        fileOffset: 999,
+        ingestId: 2,
+        type: "progress",
+      });
+      ingestWorkers.emitMessage(completedWorker, {
+        end: 999,
+        ingestId: 2,
+        start: 900,
+        type: "covered_range",
+        valid: true,
+      });
+    },
     "late same-ingest messages should not revive a completed ingest",
   );
-  assert.equal(controller.status().progress.fileOffset, 64);
-  assert.equal(controller.status().coveredRange.end, 132);
-  assert.deepEqual(indexReaderOpenCalls, ["indexes/second.idx"]);
 
   assert.equal(controller.preload() instanceof Promise, true);
-  assert.equal(secondWorker.posted.at(-1).type, "preload");
-  secondWorker.emit("message", { type: "preloaded" });
+  assert.equal(ingestWorkers.latestPostedMessage(secondWorker).type, "preload");
+  ingestWorkers.emitMessage(secondWorker, { type: "preloaded" });
   assert.equal(await controller.preload(), true);
 
   const errorController = runtime.createIngestWorkerController({
-    Worker: FakeWorker,
+    Worker: ingestWorkers.Worker,
     indexReader: {
       open(indexName) {
         indexReaderOpenCalls.push(indexName);
@@ -1258,18 +1271,18 @@ async function checkRuntimeIgnoresStaleIngestWorkerMessages() {
     true,
   );
   const errorWorker = errorController.worker;
-  errorWorker.emit("message", {
+  ingestWorkers.emitMessage(errorWorker, {
     ingestId: 1,
     message: "ingest failed",
     type: "error",
   });
-  errorWorker.emit("message", {
+  ingestWorkers.emitMessage(errorWorker, {
     committedPages: 42,
     fileOffset: 4242,
     ingestId: 1,
     type: "progress",
   });
-  errorWorker.emit("message", {
+  ingestWorkers.emitMessage(errorWorker, {
     end: 4242,
     ingestId: 1,
     start: 4200,
@@ -1281,7 +1294,7 @@ async function checkRuntimeIgnoresStaleIngestWorkerMessages() {
   assert.equal(errorController.status().progress, null);
   assert.equal(errorController.status().coveredRange, null);
   assert.equal(errorController.preload() instanceof Promise, true);
-  assert.equal(errorWorker.posted.at(-1).type, "preload");
+  assert.equal(ingestWorkers.latestPostedMessage(errorWorker).type, "preload");
 }
 
 async function checkFileSelectionSetupErrorsReportStatus() {
@@ -2196,7 +2209,7 @@ async function checkWorkerStatusReportsReaderCatalogOverflow() {
     },
   };
   const controller = runtime.createIngestWorkerController({
-    Worker: FakeWorker,
+    Worker: ingestWorkers.Worker,
     indexReader,
     onWorkerStatus(status, message) {
       workerStatus.push({ message, status });
@@ -2204,10 +2217,10 @@ async function checkWorkerStatusReportsReaderCatalogOverflow() {
   });
 
   controller.start({ indexName: "indexes/trace.idx" });
-  const worker = FakeWorker.instances.at(-1);
-  const ingestId = worker.posted.at(-1).ingestId;
+  const worker = ingestWorkers.latestWorker();
+  const ingestId = ingestWorkers.latestIngestId(worker);
 
-  worker.emit("message", {
+  ingestWorkers.emitMessage(worker, {
     end: 140,
     ingestId,
     start: 100,
@@ -2225,7 +2238,7 @@ async function checkWorkerCoveredRangeOpensReaderBeforeRangeIsValid() {
   const runtime = await importRepoModule("host/runtime.mjs");
   const indexReaderOpenCalls = [];
   const controller = runtime.createIngestWorkerController({
-    Worker: FakeWorker,
+    Worker: ingestWorkers.Worker,
     indexReader: {
       open(indexName) {
         indexReaderOpenCalls.push(indexName);
@@ -2241,10 +2254,10 @@ async function checkWorkerCoveredRangeOpensReaderBeforeRangeIsValid() {
     }),
     true,
   );
-  const worker = FakeWorker.instances.at(-1);
-  const ingestId = worker.posted.at(-1).ingestId;
+  const worker = ingestWorkers.latestWorker();
+  const ingestId = ingestWorkers.latestIngestId(worker);
 
-  worker.emit("message", {
+  ingestWorkers.emitMessage(worker, {
     end: 0,
     ingestId,
     start: 0,


### PR DESCRIPTION
Extracts a test-only fake ingest worker lifecycle harness and migrates the runtime worker orchestration checks onto it. The tests keep preload, start, error, complete, covered-range, and stale-worker behavior explicit while static guardrails prevent raw worker lifecycle access from creeping back in.

Fixes #299.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Migrate worker lifecycle checks to the harness <!-- type:spec -->
- [x] Guard against raw worker lifecycle access <!-- type:spec -->
- [x] Extract ingest worker lifecycle harness <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->