### PR TITLE
LOC #2c - Progressive renderer canvas harness (closes #300)

### DIFF
--- a/tools/progressive-renderer-test-harness.js
+++ b/tools/progressive-renderer-test-harness.js
@@ -1,0 +1,817 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const {
+  importRepoModule,
+  makeFakeCanvas,
+  makeFakeCanvasContext,
+} = require("./browser-harness.js");
+
+let INDEX_QUERY_RESULT_LAYOUT;
+let TRACE_RENDERER_CANVAS_OPS;
+let TRACE_RENDERER_INCOMPLETE_RANGE_LAYOUT;
+let TEST_TRACE_RENDER_COMMAND;
+let TEST_TRACE_RENDER_ROW_BYTES;
+let TEST_TRACE_RENDER_RANGE_BYTES;
+
+async function loadProgressiveRendererHarnessSpec() {
+  ({
+    INDEX_QUERY_RESULT_LAYOUT,
+    TRACE_RENDERER_CANVAS_OPS,
+    TRACE_RENDERER_INCOMPLETE_RANGE_LAYOUT,
+  } = await importRepoModule("host/trace-renderer-spec.mjs"));
+  TEST_TRACE_RENDER_COMMAND = Object.freeze({
+    BYTES: TRACE_RENDERER_CANVAS_OPS.DRAW_COMMAND_BYTES,
+    CLEAR_RECT: TRACE_RENDERER_CANVAS_OPS.DRAW_CLEAR_RECT_TAG,
+    END: TRACE_RENDERER_CANVAS_OPS.END_TAG,
+    FILL_RECT: TRACE_RENDERER_CANVAS_OPS.DRAW_FILL_RECT_TAG,
+    HATCH_RECT: TRACE_RENDERER_CANVAS_OPS.DRAW_HATCH_RECT_TAG,
+    INCOMPLETE_FILL: TRACE_RENDERER_CANVAS_OPS.DRAW_STYLE_ROLE_INCOMPLETE_FILL,
+    INCOMPLETE_QUERY_RANGE: TRACE_RENDERER_CANVAS_OPS.INCOMPLETE_QUERY_RANGE_TAG,
+    INCOMPLETE_STRIPE: TRACE_RENDERER_CANVAS_OPS.DRAW_STYLE_ROLE_INCOMPLETE_STRIPE,
+    PARTIAL_HATCH: TRACE_RENDERER_CANVAS_OPS.DRAW_STYLE_ROLE_PARTIAL_HATCH,
+    PARTIAL_SLICE: TRACE_RENDERER_CANVAS_OPS.DRAW_STYLE_ROLE_PARTIAL_SLICE,
+    QUERY_RANGE: TRACE_RENDERER_CANVAS_OPS.QUERY_RANGE_TAG,
+    RGB_STYLE: TRACE_RENDERER_CANVAS_OPS.DRAW_STYLE_RGB_KIND,
+    ROLE_BACKGROUND: TRACE_RENDERER_CANVAS_OPS.DRAW_STYLE_ROLE_BACKGROUND,
+    ROLE_DEFAULT_SLICE: TRACE_RENDERER_CANVAS_OPS.DRAW_STYLE_ROLE_DEFAULT_SLICE,
+    ROLE_STYLE: TRACE_RENDERER_CANVAS_OPS.DRAW_STYLE_ROLE_KIND,
+    UNKNOWN_FILL: TRACE_RENDERER_CANVAS_OPS.DRAW_STYLE_ROLE_UNKNOWN_FILL,
+    UNKNOWN_STRIPE: TRACE_RENDERER_CANVAS_OPS.DRAW_STYLE_ROLE_UNKNOWN_STRIPE,
+  });
+  TEST_TRACE_RENDER_ROW_BYTES = INDEX_QUERY_RESULT_LAYOUT.BYTES;
+  TEST_TRACE_RENDER_RANGE_BYTES = TRACE_RENDERER_INCOMPLETE_RANGE_LAYOUT.BYTES;
+}
+
+function requireProgressiveRendererHarnessSpec() {
+  assert.notEqual(
+    TEST_TRACE_RENDER_COMMAND,
+    undefined,
+    "progressive renderer harness spec must be loaded before use",
+  );
+}
+
+function progressiveRendererHarnessSpec() {
+  requireProgressiveRendererHarnessSpec();
+  return {
+    INDEX_QUERY_RESULT_LAYOUT,
+    TEST_TRACE_RENDER_COMMAND,
+    TEST_TRACE_RENDER_RANGE_BYTES,
+    TEST_TRACE_RENDER_ROW_BYTES,
+    TRACE_RENDERER_CANVAS_OPS,
+    TRACE_RENDERER_INCOMPLETE_RANGE_LAYOUT,
+  };
+}
+
+function writeTraceRenderRow(memory, ptr, row, index = 0) {
+  requireProgressiveRendererHarnessSpec();
+  const view = new DataView(memory.buffer);
+  const base = ptr + index * TEST_TRACE_RENDER_ROW_BYTES;
+
+  view.setUint32(base + INDEX_QUERY_RESULT_LAYOUT.START, row.start ?? 0, true);
+  view.setUint32(base + INDEX_QUERY_RESULT_LAYOUT.DUR, row.dur ?? 0, true);
+  view.setUint32(base + INDEX_QUERY_RESULT_LAYOUT.DEPTH, row.depth ?? 0, true);
+  view.setUint32(base + INDEX_QUERY_RESULT_LAYOUT.COLOR, row.color ?? 0, true);
+  view.setUint32(base + INDEX_QUERY_RESULT_LAYOUT.PARTIAL, row.partial ? 1 : 0, true);
+}
+
+function readTraceRenderRow(memory, ptr, index) {
+  requireProgressiveRendererHarnessSpec();
+  const view = new DataView(memory.buffer);
+  const base = ptr + index * TEST_TRACE_RENDER_ROW_BYTES;
+
+  return {
+    color: view.getUint32(base + INDEX_QUERY_RESULT_LAYOUT.COLOR, true),
+    depth: view.getUint32(base + INDEX_QUERY_RESULT_LAYOUT.DEPTH, true),
+    dur: view.getUint32(base + INDEX_QUERY_RESULT_LAYOUT.DUR, true),
+    partial: view.getUint32(base + INDEX_QUERY_RESULT_LAYOUT.PARTIAL, true) !== 0,
+    start: view.getUint32(base + INDEX_QUERY_RESULT_LAYOUT.START, true),
+  };
+}
+
+function operationMatches(expected) {
+  return (operation) =>
+    Object.entries(expected).every(([key, value]) => operation[key] === value);
+}
+
+function makeTraceRenderPlannerExports(observed = {}) {
+  requireProgressiveRendererHarnessSpec();
+  const state = {
+    commandOverflow: 0,
+    ops: [],
+    viewportEnd: 0,
+    viewportStart: 0,
+  };
+
+  function sliceX(sliceStart, viewportStart, viewportSpan, canvasWidth) {
+    if (viewportSpan === 0) {
+      return 0;
+    }
+
+    const x = Math.trunc(((sliceStart - viewportStart) * canvasWidth) / viewportSpan);
+
+    if (x < 0) {
+      return 0;
+    }
+    if (x > canvasWidth) {
+      return canvasWidth;
+    }
+    return x;
+  }
+
+  function rangeX(rangeStart, rangeEnd, viewportStart, viewportSpan, canvasWidth) {
+    const viewportEnd = viewportStart + viewportSpan;
+    const clippedStart = Math.min(viewportEnd, Math.max(viewportStart, rangeStart));
+
+    return sliceX(clippedStart, viewportStart, viewportSpan, canvasWidth);
+  }
+
+  function rangeWidth(rangeStart, rangeEnd, viewportStart, viewportSpan, canvasWidth) {
+    const viewportEnd = viewportStart + viewportSpan;
+    const clippedStart = Math.max(viewportStart, rangeStart);
+    const clippedEnd = Math.min(viewportEnd, rangeEnd);
+
+    if (clippedEnd <= clippedStart) {
+      return 0;
+    }
+
+    const x = sliceX(clippedStart, viewportStart, viewportSpan, canvasWidth);
+    const endX = sliceX(clippedEnd, viewportStart, viewportSpan, canvasWidth);
+    const width = endX - x;
+
+    return width <= 0 ? 1 : width;
+  }
+
+  function emitCommand(
+    view,
+    commandPtr,
+    commandCap,
+    tag,
+    styleKind,
+    styleValue,
+    x,
+    y,
+    width,
+    height,
+    x2,
+    y2,
+  ) {
+    if (state.commandCount >= commandCap) {
+      state.commandOverflow = 1;
+      return;
+    }
+
+    const base = commandPtr + state.commandCount * TEST_TRACE_RENDER_COMMAND.BYTES;
+
+    view.setUint32(base + TRACE_RENDERER_CANVAS_OPS.DRAW_COMMAND_TAG_OFFSET, tag, true);
+    view.setUint32(
+      base + TRACE_RENDERER_CANVAS_OPS.DRAW_COMMAND_STYLE_KIND_OFFSET,
+      styleKind,
+      true,
+    );
+    view.setUint32(
+      base + TRACE_RENDERER_CANVAS_OPS.DRAW_COMMAND_STYLE_VALUE_OFFSET,
+      styleValue,
+      true,
+    );
+    view.setInt32(base + TRACE_RENDERER_CANVAS_OPS.DRAW_COMMAND_X_OFFSET, x, true);
+    view.setInt32(base + TRACE_RENDERER_CANVAS_OPS.DRAW_COMMAND_Y_OFFSET, y, true);
+    view.setInt32(base + TRACE_RENDERER_CANVAS_OPS.DRAW_COMMAND_WIDTH_OFFSET, width, true);
+    view.setInt32(base + TRACE_RENDERER_CANVAS_OPS.DRAW_COMMAND_HEIGHT_OFFSET, height, true);
+    view.setInt32(base + TRACE_RENDERER_CANVAS_OPS.DRAW_COMMAND_X2_OFFSET, x2, true);
+    view.setInt32(base + TRACE_RENDERER_CANVAS_OPS.DRAW_COMMAND_Y2_OFFSET, y2, true);
+    state.commandCount += 1;
+  }
+
+  function emitFillRect(view, commandPtr, commandCap, styleKind, styleValue, x, y, width, height) {
+    if (width <= 0 || height <= 0) {
+      return;
+    }
+
+    emitCommand(
+      view,
+      commandPtr,
+      commandCap,
+      TEST_TRACE_RENDER_COMMAND.FILL_RECT,
+      styleKind,
+      styleValue,
+      x,
+      y,
+      width,
+      height,
+      0,
+      0,
+    );
+  }
+
+  function emitHatches(view, commandPtr, commandCap, x, y, width, height, spacing, styleValue) {
+    emitCommand(
+      view,
+      commandPtr,
+      commandCap,
+      TEST_TRACE_RENDER_COMMAND.HATCH_RECT,
+      TEST_TRACE_RENDER_COMMAND.ROLE_STYLE,
+      styleValue,
+      x,
+      y,
+      width,
+      height,
+      Math.max(1, spacing),
+      0,
+    );
+  }
+
+  return {
+    trace_render_append_query_rows(sourcePtr, sourceCount, destPtr, destCount, destCap) {
+      if (observed.memory === undefined) {
+        return 0;
+      }
+
+      const bytes = new Uint8Array(observed.memory.buffer);
+      let copied = 0;
+      while (copied < sourceCount && destCount + copied < destCap) {
+        const source = sourcePtr + copied * TEST_TRACE_RENDER_ROW_BYTES;
+        const dest = destPtr + (destCount + copied) * TEST_TRACE_RENDER_ROW_BYTES;
+
+        bytes.copyWithin(dest, source, source + TEST_TRACE_RENDER_ROW_BYTES);
+        copied += 1;
+      }
+      return copied;
+    },
+    trace_render_commands_begin(
+      commandPtr,
+      commandCap,
+      rowPtr,
+      rowCount,
+      incompletePtr,
+      incompleteCount,
+      viewportStart,
+      viewportEnd,
+      coveredEnd,
+      canvasWidth,
+      canvasHeight,
+      laneHeight,
+      laneGap,
+      top,
+      bandPadding,
+      ingestActive,
+      partialHatchSpacing,
+      unknownAffordanceWidth,
+      unknownStripeSpacing,
+      incompleteStripeSpacing,
+    ) {
+      observed.commandsBegin?.({
+        canvasHeight,
+        canvasWidth,
+        commandCap,
+        commandPtr,
+        coveredEnd,
+        incompleteCount,
+        incompletePtr,
+        rowCount,
+        rowPtr,
+        viewportEnd,
+        viewportStart,
+      });
+      state.commandOverflow = 0;
+      state.commandCount = 0;
+
+      if (observed.memory === undefined) {
+        return 0;
+      }
+
+      const view = new DataView(observed.memory.buffer);
+      const viewportSpan = Math.max(1, viewportEnd - viewportStart);
+      let maxDepth = 0;
+
+      for (let i = 0; i < rowCount; i += 1) {
+        maxDepth = Math.max(
+          maxDepth,
+          view.getUint32(
+            rowPtr + i * TEST_TRACE_RENDER_ROW_BYTES + INDEX_QUERY_RESULT_LAYOUT.DEPTH,
+            true,
+          ),
+        );
+      }
+
+      const bandHeight = Math.min(
+        canvasHeight,
+        top + (maxDepth + 1) * (laneHeight + laneGap) + bandPadding,
+      );
+
+      emitCommand(
+        view,
+        commandPtr,
+        commandCap,
+        TEST_TRACE_RENDER_COMMAND.CLEAR_RECT,
+        0,
+        0,
+        0,
+        0,
+        canvasWidth,
+        bandHeight,
+        0,
+        0,
+      );
+      emitFillRect(
+        view,
+        commandPtr,
+        commandCap,
+        TEST_TRACE_RENDER_COMMAND.ROLE_STYLE,
+        TEST_TRACE_RENDER_COMMAND.ROLE_BACKGROUND,
+        0,
+        0,
+        canvasWidth,
+        bandHeight,
+      );
+
+      for (let i = 0; i < rowCount; i += 1) {
+        const base = rowPtr + i * TEST_TRACE_RENDER_ROW_BYTES;
+        const rowStart = view.getUint32(base + INDEX_QUERY_RESULT_LAYOUT.START, true);
+        const rowDur = Math.max(1, view.getUint32(base + INDEX_QUERY_RESULT_LAYOUT.DUR, true));
+        const rowDepth = view.getUint32(base + INDEX_QUERY_RESULT_LAYOUT.DEPTH, true);
+        const rowColor = view.getUint32(base + INDEX_QUERY_RESULT_LAYOUT.COLOR, true);
+        const rowPartial = view.getUint32(base + INDEX_QUERY_RESULT_LAYOUT.PARTIAL, true) !== 0;
+        const sliceEnd = Math.min(viewportEnd, rowStart + rowDur);
+        const x = sliceX(rowStart, viewportStart, viewportSpan, canvasWidth);
+        const endX = sliceX(sliceEnd, viewportStart, viewportSpan, canvasWidth);
+        const width = Math.max(1, endX - x);
+        const y = top + rowDepth * (laneHeight + laneGap);
+
+        if (rowPartial && ingestActive !== 0) {
+          emitFillRect(
+            view,
+            commandPtr,
+            commandCap,
+            TEST_TRACE_RENDER_COMMAND.ROLE_STYLE,
+            TEST_TRACE_RENDER_COMMAND.PARTIAL_SLICE,
+            x,
+            y,
+            width,
+            laneHeight,
+          );
+          emitHatches(
+            view,
+            commandPtr,
+            commandCap,
+            x,
+            y,
+            width,
+            laneHeight,
+            partialHatchSpacing,
+            TEST_TRACE_RENDER_COMMAND.PARTIAL_HATCH,
+          );
+        } else if (rowColor === 0) {
+          emitFillRect(
+            view,
+            commandPtr,
+            commandCap,
+            TEST_TRACE_RENDER_COMMAND.ROLE_STYLE,
+            TEST_TRACE_RENDER_COMMAND.ROLE_DEFAULT_SLICE,
+            x,
+            y,
+            width,
+            laneHeight,
+          );
+        } else {
+          emitFillRect(
+            view,
+            commandPtr,
+            commandCap,
+            TEST_TRACE_RENDER_COMMAND.RGB_STYLE,
+            rowColor,
+            x,
+            y,
+            width,
+            laneHeight,
+          );
+        }
+      }
+
+      for (let i = 0; i < incompleteCount; i += 1) {
+        const base = incompletePtr + i * TEST_TRACE_RENDER_RANGE_BYTES;
+        const start = view.getUint32(base + TRACE_RENDERER_INCOMPLETE_RANGE_LAYOUT.START, true);
+        const end = view.getUint32(base + TRACE_RENDERER_INCOMPLETE_RANGE_LAYOUT.END, true);
+        const width = rangeWidth(start, end, viewportStart, viewportSpan, canvasWidth);
+
+        if (width <= 0) {
+          continue;
+        }
+
+        const x = rangeX(start, end, viewportStart, viewportSpan, canvasWidth);
+
+        emitFillRect(
+          view,
+          commandPtr,
+          commandCap,
+          TEST_TRACE_RENDER_COMMAND.ROLE_STYLE,
+          TEST_TRACE_RENDER_COMMAND.INCOMPLETE_FILL,
+          x,
+          0,
+          width,
+          bandHeight,
+        );
+        emitHatches(
+          view,
+          commandPtr,
+          commandCap,
+          x,
+          0,
+          width,
+          bandHeight,
+          incompleteStripeSpacing,
+          TEST_TRACE_RENDER_COMMAND.INCOMPLETE_STRIPE,
+        );
+      }
+
+      if (ingestActive !== 0 && coveredEnd <= viewportEnd) {
+        const width = Math.max(0, Math.min(canvasWidth, unknownAffordanceWidth));
+
+        if (width > 0) {
+          const x = Math.max(0, canvasWidth - width);
+
+          emitFillRect(
+            view,
+            commandPtr,
+            commandCap,
+            TEST_TRACE_RENDER_COMMAND.ROLE_STYLE,
+            TEST_TRACE_RENDER_COMMAND.UNKNOWN_FILL,
+            x,
+            0,
+            width,
+            bandHeight,
+          );
+          emitHatches(
+            view,
+            commandPtr,
+            commandCap,
+            x,
+            0,
+            width,
+            bandHeight,
+            unknownStripeSpacing,
+            TEST_TRACE_RENDER_COMMAND.UNKNOWN_STRIPE,
+          );
+        }
+      }
+
+      return state.commandCount;
+    },
+    trace_render_commands_overflow() {
+      return state.commandOverflow;
+    },
+    trace_render_plan_begin(
+      viewportStart,
+      viewportEnd,
+      trackCount,
+      queryRangeBudget,
+      queryWindow,
+    ) {
+      observed.planBegin?.({
+        queryRangeBudget,
+        queryWindow,
+        trackCount,
+        viewportEnd,
+        viewportStart,
+      });
+      state.viewportStart = viewportStart;
+      state.viewportEnd = viewportEnd;
+      const rangesPerTrack = Math.max(1, Math.floor(queryRangeBudget / trackCount));
+      const tileSpan = Math.max(
+        1,
+        queryWindow,
+        Math.ceil((viewportEnd - viewportStart) / rangesPerTrack),
+      );
+      const ops = [];
+      let queryRangeCount = 0;
+
+      queryLoop:
+      for (let trackId = 0; trackId < trackCount; trackId += 1) {
+        for (
+          let queryStart = viewportStart;
+          queryStart < viewportEnd;
+          queryStart = Math.min(viewportEnd, queryStart + tileSpan)
+        ) {
+          if (queryRangeCount >= queryRangeBudget) {
+            if (queryStart < viewportEnd) {
+              ops.push({
+                end: viewportEnd,
+                start: Math.max(viewportStart, queryStart),
+                tag: TEST_TRACE_RENDER_COMMAND.INCOMPLETE_QUERY_RANGE,
+                trackId,
+              });
+            }
+            for (
+              let skippedTrackId = trackId + 1;
+              skippedTrackId < trackCount;
+              skippedTrackId += 1
+            ) {
+              ops.push({
+                end: viewportEnd,
+                start: viewportStart,
+                tag: TEST_TRACE_RENDER_COMMAND.INCOMPLETE_QUERY_RANGE,
+                trackId: skippedTrackId,
+              });
+            }
+            break queryLoop;
+          }
+
+          ops.push({
+            end: Math.min(viewportEnd, queryStart + tileSpan),
+            start: queryStart,
+            tag: TEST_TRACE_RENDER_COMMAND.QUERY_RANGE,
+            trackId,
+          });
+          queryRangeCount += 1;
+        }
+      }
+
+      state.ops = ops;
+    },
+    trace_render_plan_next() {
+      const op = state.ops.shift();
+
+      if (op === undefined) {
+        return TEST_TRACE_RENDER_COMMAND.END;
+      }
+
+      state.currentOp = op;
+      return op.tag;
+    },
+    trace_render_plan_op_end() {
+      return state.currentOp?.end ?? state.viewportEnd;
+    },
+    trace_render_plan_op_start() {
+      return state.currentOp?.start ?? state.viewportStart;
+    },
+    trace_render_plan_op_track_id() {
+      return state.currentOp?.trackId ?? 0;
+    },
+    trace_render_query_ranges_per_track(queryRangeBudget, trackCount) {
+      observed.queryRangesPerTrack?.({ queryRangeBudget, trackCount });
+      return Math.max(1, Math.floor(queryRangeBudget / trackCount));
+    },
+    trace_render_query_tile_span(viewportSpan, queryWindow, rangesPerTrack) {
+      observed.queryTileSpan?.({ queryWindow, rangesPerTrack, viewportSpan });
+      return Math.max(1, queryWindow, Math.ceil(viewportSpan / rangesPerTrack));
+    },
+    trace_render_range_x(rangeStart, rangeEnd, viewportStart, viewportSpan, canvasWidth) {
+      observed.rangeX?.({
+        canvasWidth,
+        rangeEnd,
+        rangeStart,
+        viewportSpan,
+        viewportStart,
+      });
+      const viewportEnd = viewportStart + viewportSpan;
+      const start = Math.min(viewportEnd, Math.max(viewportStart, rangeStart));
+      return Math.max(0, ((start - viewportStart) / viewportSpan) * canvasWidth);
+    },
+    trace_render_range_width(rangeStart, rangeEnd, viewportStart, viewportSpan, canvasWidth) {
+      observed.rangeWidth?.({
+        canvasWidth,
+        rangeEnd,
+        rangeStart,
+        viewportSpan,
+        viewportStart,
+      });
+      const viewportEnd = viewportStart + viewportSpan;
+      const start = Math.max(viewportStart, rangeStart);
+      const end = Math.min(viewportEnd, rangeEnd);
+
+      if (end <= start) {
+        return 0;
+      }
+
+      const x = Math.max(0, ((start - viewportStart) / viewportSpan) * canvasWidth);
+      const endX = Math.min(canvasWidth, ((end - viewportStart) / viewportSpan) * canvasWidth);
+      return Math.max(1, endX - x);
+    },
+    trace_render_slice_end_x(sliceEnd, viewportStart, viewportSpan, canvasWidth) {
+      observed.sliceEndX?.({ canvasWidth, sliceEnd, viewportSpan, viewportStart });
+      return Math.min(
+        canvasWidth,
+        ((sliceEnd - viewportStart) / viewportSpan) * canvasWidth,
+      );
+    },
+    trace_render_slice_x(sliceStart, viewportStart, viewportSpan, canvasWidth) {
+      observed.sliceX?.({ canvasWidth, sliceStart, viewportSpan, viewportStart });
+      return Math.max(0, ((sliceStart - viewportStart) / viewportSpan) * canvasWidth);
+    },
+    trace_render_slice_y(depth, top, laneHeight, laneGap) {
+      observed.sliceY?.({ depth, laneGap, laneHeight, top });
+      return top + depth * (laneHeight + laneGap);
+    },
+    trace_render_stripe_end(x, width, height) {
+      observed.stripeEnd?.({ height, width, x });
+      return x + width + height;
+    },
+    trace_render_stripe_start(x, height) {
+      observed.stripeStart?.({ height, x });
+      return x - height;
+    },
+    trace_render_unknown_width(canvasWidth, affordanceWidth) {
+      observed.unknownWidth?.({ affordanceWidth, canvasWidth });
+      return Math.max(0, Math.min(canvasWidth, affordanceWidth));
+    },
+    trace_render_unknown_x(canvasWidth, affordanceWidth) {
+      observed.unknownX?.({ affordanceWidth, canvasWidth });
+      return canvasWidth - Math.max(0, Math.min(canvasWidth, affordanceWidth));
+    },
+  };
+}
+
+function createProgressiveRendererHarness(options = {}) {
+  requireProgressiveRendererHarnessSpec();
+  const memory = options.memory ?? new WebAssembly.Memory({ initial: 1 });
+  const listeners = new Map();
+  const operations = [];
+  const queryCalls = [];
+  let currentFrameAt = options.frameAt ?? 0;
+  let coveredRange =
+    options.coveredRange ?? { end: 200, start: 100, type: "covered_range", valid: true };
+  let workerState = options.workerState ?? "running";
+  let readerState = options.readerState ?? "ready";
+  let trackCount = options.trackCount ?? 1;
+  let sliceCoveredRange = options.sliceCoveredRange;
+  let queryRows = options.queryRows ?? [];
+  let queryResult = options.queryResult;
+  const context = makeFakeCanvasContext({
+    beginPath() {
+      operations.push({ at: currentFrameAt, op: "beginPath" });
+    },
+    clearRect(x, y, width, height) {
+      operations.push({ at: currentFrameAt, height, op: "clearRect", width, x, y });
+    },
+    clip() {
+      operations.push({ at: currentFrameAt, op: "clip" });
+    },
+    fillRect(x, y, width, height) {
+      operations.push({
+        at: currentFrameAt,
+        fillStyle: this.fillStyle ?? this.lastFillStyle,
+        height,
+        op: "fillRect",
+        width,
+        x,
+        y,
+      });
+    },
+    lineTo(x, y) {
+      operations.push({ at: currentFrameAt, op: "lineTo", x, y });
+    },
+    moveTo(x, y) {
+      operations.push({ at: currentFrameAt, op: "moveTo", x, y });
+    },
+    rect(x, y, width, height) {
+      operations.push({ at: currentFrameAt, height, op: "rect", width, x, y });
+    },
+    restore() {
+      operations.push({ at: currentFrameAt, op: "restore" });
+    },
+    save() {
+      operations.push({ at: currentFrameAt, op: "save" });
+    },
+    stroke() {
+      operations.push({
+        at: currentFrameAt,
+        op: "stroke",
+        strokeStyle: this.strokeStyle,
+      });
+    },
+  });
+  const canvas = makeFakeCanvas({
+    context,
+    height: options.height ?? 120,
+    width: options.width ?? 240,
+    elementOverrides: {
+      height: options.height ?? 120,
+      width: options.width ?? 240,
+      addEventListener(type, callback) {
+        listeners.set(type, callback);
+      },
+      getContext(type) {
+        assert.equal(type, "2d");
+        return context;
+      },
+      releasePointerCapture() {},
+      setPointerCapture() {},
+      ...options.canvasOverrides,
+    },
+  });
+  const reader = {
+    queryRange(trackId, tsMin, tsMax, outPtr, maxRows) {
+      const call = { maxRows, outPtr, trackId, tsMax, tsMin };
+
+      queryCalls.push(call);
+
+      if (typeof options.queryRange === "function") {
+        return options.queryRange({ ...call, memory, writeTraceRenderRow });
+      }
+
+      queryRows.forEach((row, index) => {
+        const resolvedRow =
+          typeof row === "function" ? row({ ...call, index, memory }) : row;
+
+        writeTraceRenderRow(memory, outPtr, resolvedRow, index);
+      });
+      if (queryResult !== undefined) {
+        return queryResult;
+      }
+      return queryRows.length;
+    },
+    status() {
+      return { state: readerState };
+    },
+    trackCount() {
+      return trackCount;
+    },
+  };
+  if (sliceCoveredRange !== undefined || options.readerCoveredRange === true) {
+    reader.coveredRange = () => sliceCoveredRange;
+  }
+  const ingestWorker = {
+    indexReader: reader,
+    status() {
+      return { coveredRange, state: workerState };
+    },
+  };
+
+  function findOperation(expected) {
+    return operations.find(operationMatches(expected));
+  }
+
+  function assertOperation(expected, message) {
+    assert.notEqual(findOperation(expected), undefined, message);
+  }
+
+  return {
+    canvas,
+    context,
+    ingestWorker,
+    listeners,
+    memory,
+    operations,
+    queryCalls,
+    reader,
+    assertOperation,
+    assertOperationsInclude(expected, message) {
+      assertOperation(expected, message);
+    },
+    assertQueryCalls(expected, message) {
+      assert.deepEqual(queryCalls, expected, message);
+    },
+    clearOperations() {
+      operations.length = 0;
+    },
+    findOperation,
+    readTraceRenderRow(ptr, index) {
+      return readTraceRenderRow(memory, ptr, index);
+    },
+    renderPlannerExports(observed = {}) {
+      return makeTraceRenderPlannerExports({ memory, ...observed });
+    },
+    setCoveredRange(nextCoveredRange) {
+      coveredRange = nextCoveredRange;
+    },
+    setFrameAt(nextFrameAt) {
+      currentFrameAt = nextFrameAt;
+    },
+    setQueryResult(nextQueryResult) {
+      queryResult = nextQueryResult;
+    },
+    setQueryRows(nextQueryRows) {
+      queryRows = nextQueryRows;
+    },
+    setReaderState(nextReaderState) {
+      readerState = nextReaderState;
+    },
+    setSliceCoveredRange(nextSliceCoveredRange) {
+      sliceCoveredRange = nextSliceCoveredRange;
+    },
+    setTrackCount(nextTrackCount) {
+      trackCount = nextTrackCount;
+    },
+    setWorkerState(nextWorkerState) {
+      workerState = nextWorkerState;
+    },
+    status() {
+      return {
+        coveredRange,
+        readerState,
+        sliceCoveredRange,
+        trackCount,
+        workerState,
+      };
+    },
+  };
+}
+
+module.exports = {
+  createProgressiveRendererHarness,
+  loadProgressiveRendererHarnessSpec,
+  makeTraceRenderPlannerExports,
+  progressiveRendererHarnessSpec,
+  readTraceRenderRow,
+  writeTraceRenderRow,
+};

--- a/tools/runtime-worker-orchestration-check.js
+++ b/tools/runtime-worker-orchestration-check.js
@@ -10,6 +10,10 @@ const {
   importRepoModule,
   installRuntimeBrowserGlobals,
 } = require("./browser-harness.js");
+const {
+  createProgressiveRendererHarness,
+  loadProgressiveRendererHarnessSpec,
+} = require("./progressive-renderer-test-harness.js");
 
 let OPFS_PAGE_SIZE;
 let INDEX_DECODE_HINT_COMPACT_SLICES;
@@ -39,6 +43,7 @@ async function loadGeneratedIndexFormatSpec() {
 }
 
 async function loadGeneratedTraceRendererSpec() {
+  await loadProgressiveRendererHarnessSpec();
   ({
     INDEX_QUERY_RESULT_LAYOUT,
     TRACE_RENDERER_CANVAS_OPS,
@@ -665,6 +670,49 @@ function makeAppExports(extra = {}) {
     tracy_tick() {},
     ...extra,
   };
+}
+
+async function checkProgressiveRendererHarnessCapturesCanvasReaderAndStatus() {
+  const rendererModule = await importRepoModule("host/progressive-trace-renderer.mjs");
+  const traceBlue = 0x2d74da;
+  const harness = createProgressiveRendererHarness({
+    coveredRange: { end: 200, start: 100, type: "covered_range", valid: true },
+    queryRows: [{ color: traceBlue, depth: 0, dur: 8, partial: false, start: 110 }],
+    trackCount: 1,
+  });
+  const renderer = rendererModule.createProgressiveTraceRenderer(
+    harness.memory,
+    harness.ingestWorker,
+    {
+      canvas: harness.canvas,
+      queryOutPtr: 2048,
+      queryWindow: 100,
+      renderPlannerExports: harness.renderPlannerExports(),
+    },
+  );
+
+  assert.equal(renderer.draw(123), 1);
+  harness.assertQueryCalls([
+    { maxRows: 1024, outPtr: 2048, trackId: 0, tsMax: 200, tsMin: 100 },
+  ]);
+  harness.assertOperation(
+    {
+      fillStyle: "#2d74da",
+      height: 10,
+      op: "fillRect",
+      width: 19,
+      x: 24,
+      y: 18,
+    },
+    "renderer harness should expose concrete draw operations",
+  );
+  assert.deepEqual(harness.status(), {
+    coveredRange: { end: 200, start: 100, type: "covered_range", valid: true },
+    readerState: "ready",
+    sliceCoveredRange: undefined,
+    trackCount: 1,
+    workerState: "running",
+  });
 }
 
 async function checkRuntimeOrchestratesWorker() {
@@ -3543,6 +3591,7 @@ async function main() {
   await checkWorkerStatusReportsReaderCatalogOverflow();
   await checkWorkerCoveredRangeOpensReaderBeforeRangeIsValid();
   checkWatWriterPropagatesCatalogOverflow();
+  await checkProgressiveRendererHarnessCapturesCanvasReaderAndStatus();
   await checkProgressiveTraceRendererDrawsCoveredPartialRows();
   await checkProgressiveTraceRendererClipsLeftEdgeSlices();
   await checkProgressiveTraceRendererClampsToSliceCatalogCoverage();

--- a/tools/runtime-worker-orchestration-check.js
+++ b/tools/runtime-worker-orchestration-check.js
@@ -2532,97 +2532,31 @@ async function checkProgressiveTraceRendererClampsToSliceCatalogCoverage() {
 
 async function checkProgressiveTraceRendererSurfacesCappedQueries() {
   const rendererModule = await importRepoModule("host/progressive-trace-renderer.mjs");
-  const memory = new WebAssembly.Memory({ initial: 1 });
-  const queryCalls = [];
-  const operations = [];
-  const canvas = {
-    height: 120,
-    width: 240,
-    getContext() {
-      return {
-        beginPath() {
-          operations.push({ op: "beginPath" });
-        },
-        clearRect(x, y, width, height) {
-          operations.push({ height, op: "clearRect", width, x, y });
-        },
-        clip() {
-          operations.push({ op: "clip" });
-        },
-        fillRect(x, y, width, height) {
-          operations.push({
-            fillStyle: this.fillStyle,
-            height,
-            op: "fillRect",
-            width,
-            x,
-            y,
-          });
-        },
-        lineTo(x, y) {
-          operations.push({ op: "lineTo", x, y });
-        },
-        moveTo(x, y) {
-          operations.push({ op: "moveTo", x, y });
-        },
-        rect(x, y, width, height) {
-          operations.push({ height, op: "rect", width, x, y });
-        },
-        restore() {
-          operations.push({ op: "restore" });
-        },
-        save() {
-          operations.push({ op: "save" });
-        },
-        stroke() {
-          operations.push({ op: "stroke", strokeStyle: this.strokeStyle });
-        },
-      };
+  const harness = createProgressiveRendererHarness({
+    coveredRange: { end: 200, start: 100, type: "covered_range", valid: true },
+    queryResult: {
+      capped: true,
+      count: 1,
+      matchedRows: 4096,
+      writtenRows: 1,
     },
-  };
-  const reader = {
-    queryRange(trackId, tsMin, tsMax, outPtr, maxRows) {
-      queryCalls.push({ maxRows, outPtr, trackId, tsMax, tsMin });
-      const view = new DataView(memory.buffer);
-
-      view.setUint32(outPtr, 110, true);
-      view.setUint32(outPtr + 4, 8, true);
-      view.setUint32(outPtr + 12, 0, true);
-      view.setUint32(outPtr + 20, 0x2d74da, true);
-      view.setUint32(outPtr + 24, 0, true);
-      return {
-        capped: true,
-        count: 1,
-        matchedRows: 4096,
-        writtenRows: 1,
-      };
-    },
-    status() {
-      return { state: "ready" };
-    },
-    trackCount() {
-      return 1;
-    },
-  };
-  const ingestWorker = {
-    indexReader: reader,
-    status() {
-      return {
-        coveredRange: { end: 200, start: 100, type: "covered_range", valid: true },
-        state: "running",
-      };
-    },
-  };
-  const renderer = rendererModule.createProgressiveTraceRenderer(memory, ingestWorker, {
-    canvas,
-    queryOutPtr: 2048,
-    queryRowCap: 1,
-    queryWindow: 100,
-    renderPlannerExports: makeTraceRenderPlannerExports({ memory }),
+    queryRows: [{ color: 0x2d74da, depth: 0, dur: 8, partial: false, start: 110 }],
+    trackCount: 1,
   });
+  const renderer = rendererModule.createProgressiveTraceRenderer(
+    harness.memory,
+    harness.ingestWorker,
+    {
+      canvas: harness.canvas,
+      queryOutPtr: 2048,
+      queryRowCap: 1,
+      queryWindow: 100,
+      renderPlannerExports: harness.renderPlannerExports(),
+    },
+  );
 
   assert.equal(renderer.draw(123), 1);
-  assert.deepEqual(queryCalls, [
+  harness.assertQueryCalls([
     { maxRows: 1, outPtr: 2048, trackId: 0, tsMax: 200, tsMin: 100 },
   ]);
   assert.deepEqual(renderer.status().cappedQueries, [
@@ -2631,88 +2565,56 @@ async function checkProgressiveTraceRendererSurfacesCappedQueries() {
   assert.deepEqual(renderer.status().incompleteQueryRanges, [
     { end: 200, start: 100, trackId: 0 },
   ]);
-  assert.equal(
-    operations.some(
-      (operation) =>
-        operation.op === "fillRect" &&
-        operation.fillStyle === "rgba(180, 83, 9, 0.16)" &&
-        operation.x === 0 &&
-        operation.width === 240,
-    ),
-    true,
+  harness.assertOperation(
+    {
+      fillStyle: "rgba(180, 83, 9, 0.16)",
+      op: "fillRect",
+      width: 240,
+      x: 0,
+    },
     "capped query ranges should be visibly marked incomplete",
   );
-  assert.equal(
-    operations.some(
-      (operation) =>
-        operation.op === "stroke" &&
-        operation.strokeStyle === "rgba(146, 64, 14, 0.42)",
-    ),
-    true,
+  harness.assertOperation(
+    { op: "stroke", strokeStyle: "rgba(146, 64, 14, 0.42)" },
     "capped query ranges should include an incomplete-range stripe overlay",
   );
 }
 
 async function checkProgressiveTraceRendererTilesFullVisibleViewport() {
   const rendererModule = await importRepoModule("host/progressive-trace-renderer.mjs");
-  const memory = new WebAssembly.Memory({ initial: 1 });
-  const queryCalls = [];
-  const canvas = {
-    height: 120,
-    width: 240,
-    getContext() {
-      return {
-        clearRect() {},
-        fillRect() {},
-        restore() {},
-        save() {},
-      };
-    },
-  };
-  const reader = {
-    queryRange(trackId, tsMin, tsMax, outPtr, maxRows) {
-      queryCalls.push({ maxRows, outPtr, trackId, tsMax, tsMin });
-      const view = new DataView(memory.buffer);
-
-      view.setUint32(outPtr, tsMin >= 2000 ? 2200 : tsMin + 10, true);
-      view.setUint32(outPtr + 4, 8, true);
-      view.setUint32(outPtr + 12, 0, true);
-      view.setUint32(outPtr + 20, 0x2d74da, true);
-      view.setUint32(outPtr + 24, 0, true);
-      return 1;
-    },
-    status() {
-      return { state: "ready" };
-    },
-    trackCount() {
-      return 1;
-    },
-  };
-  const ingestWorker = {
-    indexReader: reader,
-    status() {
-      return {
-        coveredRange: { end: 2500, start: 0, type: "covered_range", valid: true },
-        state: "running",
-      };
-    },
-  };
-  const renderer = rendererModule.createProgressiveTraceRenderer(memory, ingestWorker, {
-    canvas,
-    queryOutPtr: 2048,
-    renderRowPtr: 4096,
-    renderPlannerExports: makeTraceRenderPlannerExports({ memory }),
+  const harness = createProgressiveRendererHarness({
+    coveredRange: { end: 2500, start: 0, type: "covered_range", valid: true },
+    queryRows: [
+      ({ tsMin }) => ({
+        color: 0x2d74da,
+        depth: 0,
+        dur: 8,
+        partial: false,
+        start: tsMin >= 2000 ? 2200 : tsMin + 10,
+      }),
+    ],
+    trackCount: 1,
   });
+  const renderer = rendererModule.createProgressiveTraceRenderer(
+    harness.memory,
+    harness.ingestWorker,
+    {
+      canvas: harness.canvas,
+      queryOutPtr: 2048,
+      renderRowPtr: 4096,
+      renderPlannerExports: harness.renderPlannerExports(),
+    },
+  );
 
   assert.equal(renderer.draw(123), 3);
 
-  assert.deepEqual(queryCalls, [
+  harness.assertQueryCalls([
     { maxRows: 1024, outPtr: 2048, trackId: 0, tsMax: 1000, tsMin: 0 },
     { maxRows: 1024, outPtr: 2048, trackId: 0, tsMax: 2000, tsMin: 1000 },
     { maxRows: 1024, outPtr: 2048, trackId: 0, tsMax: 2500, tsMin: 2000 },
   ]);
   assert.deepEqual(
-    readTraceRenderRow(memory, 4096, 2),
+    harness.readTraceRenderRow(4096, 2),
     { color: 0x2d74da, depth: 0, dur: 8, partial: false, start: 2200 },
     "later visible rows should still render when the viewport exceeds the default query window",
   );
@@ -2720,66 +2622,41 @@ async function checkProgressiveTraceRendererTilesFullVisibleViewport() {
 
 async function checkProgressiveTraceRendererBoundsLargeViewportQueries() {
   const rendererModule = await importRepoModule("host/progressive-trace-renderer.mjs");
-  const memory = new WebAssembly.Memory({ initial: 1 });
-  const queryCalls = [];
-  const canvas = {
-    height: 120,
-    width: 240,
-    getContext() {
-      return {
-        clearRect() {},
-        fillRect() {},
-        restore() {},
-        save() {},
-      };
+  const harness = createProgressiveRendererHarness({
+    coveredRange: {
+      end: 10_000_000,
+      start: 0,
+      type: "covered_range",
+      valid: true,
     },
-  };
-  const reader = {
-    queryRange(trackId, tsMin, tsMax, outPtr, maxRows) {
-      queryCalls.push({ maxRows, outPtr, trackId, tsMax, tsMin });
-      const view = new DataView(memory.buffer);
-
-      view.setUint32(outPtr, Math.floor(tsMin), true);
-      view.setUint32(outPtr + 4, 8, true);
-      view.setUint32(outPtr + 12, trackId, true);
-      view.setUint32(outPtr + 20, 0x2d74da, true);
-      view.setUint32(outPtr + 24, 0, true);
-      return 1;
-    },
-    status() {
-      return { state: "ready" };
-    },
-    trackCount() {
-      return 2;
-    },
-  };
-  const ingestWorker = {
-    indexReader: reader,
-    status() {
-      return {
-        coveredRange: {
-          end: 10_000_000,
-          start: 0,
-          type: "covered_range",
-          valid: true,
-        },
-        state: "running",
-      };
-    },
-  };
-  const renderer = rendererModule.createProgressiveTraceRenderer(memory, ingestWorker, {
-    canvas,
-    queryOutPtr: 2048,
-    queryRangeBudget: 8,
-    queryWindow: 1000,
-    renderRowPtr: 4096,
-    renderPlannerExports: makeTraceRenderPlannerExports({ memory }),
+    queryRows: [
+      ({ trackId, tsMin }) => ({
+        color: 0x2d74da,
+        depth: trackId,
+        dur: 8,
+        partial: false,
+        start: Math.floor(tsMin),
+      }),
+    ],
+    trackCount: 2,
   });
+  const renderer = rendererModule.createProgressiveTraceRenderer(
+    harness.memory,
+    harness.ingestWorker,
+    {
+      canvas: harness.canvas,
+      queryOutPtr: 2048,
+      queryRangeBudget: 8,
+      queryWindow: 1000,
+      renderRowPtr: 4096,
+      renderPlannerExports: harness.renderPlannerExports(),
+    },
+  );
 
   assert.equal(renderer.draw(123), 8);
 
-  assert.equal(queryCalls.length, 8);
-  assert.deepEqual(queryCalls, [
+  assert.equal(harness.queryCalls.length, 8);
+  harness.assertQueryCalls([
     { maxRows: 1024, outPtr: 2048, trackId: 0, tsMax: 2500000, tsMin: 0 },
     { maxRows: 1024, outPtr: 2048, trackId: 0, tsMax: 5000000, tsMin: 2500000 },
     { maxRows: 1024, outPtr: 2048, trackId: 0, tsMax: 7500000, tsMin: 5000000 },
@@ -2790,7 +2667,7 @@ async function checkProgressiveTraceRendererBoundsLargeViewportQueries() {
     { maxRows: 1024, outPtr: 2048, trackId: 1, tsMax: 10000000, tsMin: 7500000 },
   ]);
   assert.deepEqual(
-    readTraceRenderRow(memory, 4096, 7),
+    harness.readTraceRenderRow(4096, 7),
     { color: 0x2d74da, depth: 1, dur: 8, partial: false, start: 7500000 },
     "large viewports should still represent later visible data within the query budget",
   );
@@ -2798,93 +2675,34 @@ async function checkProgressiveTraceRendererBoundsLargeViewportQueries() {
 
 async function checkProgressiveTraceRendererMarksSkippedTracksWhenBudgetExhausted() {
   const rendererModule = await importRepoModule("host/progressive-trace-renderer.mjs");
-  const memory = new WebAssembly.Memory({ initial: 1 });
-  const queryCalls = [];
-  const operations = [];
-  const canvas = {
-    height: 120,
-    width: 240,
-    getContext() {
-      return {
-        beginPath() {
-          operations.push({ op: "beginPath" });
-        },
-        clearRect(x, y, width, height) {
-          operations.push({ height, op: "clearRect", width, x, y });
-        },
-        clip() {
-          operations.push({ op: "clip" });
-        },
-        fillRect(x, y, width, height) {
-          operations.push({
-            fillStyle: this.fillStyle,
-            height,
-            op: "fillRect",
-            width,
-            x,
-            y,
-          });
-        },
-        lineTo(x, y) {
-          operations.push({ op: "lineTo", x, y });
-        },
-        moveTo(x, y) {
-          operations.push({ op: "moveTo", x, y });
-        },
-        rect(x, y, width, height) {
-          operations.push({ height, op: "rect", width, x, y });
-        },
-        restore() {
-          operations.push({ op: "restore" });
-        },
-        save() {
-          operations.push({ op: "save" });
-        },
-        stroke() {
-          operations.push({ op: "stroke", strokeStyle: this.strokeStyle });
-        },
-      };
-    },
-  };
-  const reader = {
-    queryRange(trackId, tsMin, tsMax, outPtr, maxRows) {
-      queryCalls.push({ maxRows, outPtr, trackId, tsMax, tsMin });
-      const view = new DataView(memory.buffer);
-
-      view.setUint32(outPtr, 10 + trackId * 10, true);
-      view.setUint32(outPtr + 4, 8, true);
-      view.setUint32(outPtr + 12, trackId, true);
-      view.setUint32(outPtr + 20, 0x2d74da, true);
-      view.setUint32(outPtr + 24, 0, true);
-      return 1;
-    },
-    status() {
-      return { state: "ready" };
-    },
-    trackCount() {
-      return 4;
-    },
-  };
-  const ingestWorker = {
-    indexReader: reader,
-    status() {
-      return {
-        coveredRange: { end: 100, start: 0, type: "covered_range", valid: true },
-        state: "running",
-      };
-    },
-  };
-  const renderer = rendererModule.createProgressiveTraceRenderer(memory, ingestWorker, {
-    canvas,
-    queryOutPtr: 2048,
-    queryRangeBudget: 2,
-    queryWindow: 100,
-    renderPlannerExports: makeTraceRenderPlannerExports({ memory }),
+  const harness = createProgressiveRendererHarness({
+    coveredRange: { end: 100, start: 0, type: "covered_range", valid: true },
+    queryRows: [
+      ({ trackId }) => ({
+        color: 0x2d74da,
+        depth: trackId,
+        dur: 8,
+        partial: false,
+        start: 10 + trackId * 10,
+      }),
+    ],
+    trackCount: 4,
   });
+  const renderer = rendererModule.createProgressiveTraceRenderer(
+    harness.memory,
+    harness.ingestWorker,
+    {
+      canvas: harness.canvas,
+      queryOutPtr: 2048,
+      queryRangeBudget: 2,
+      queryWindow: 100,
+      renderPlannerExports: harness.renderPlannerExports(),
+    },
+  );
 
   assert.equal(renderer.draw(123), 2);
 
-  assert.deepEqual(queryCalls, [
+  harness.assertQueryCalls([
     { maxRows: 1024, outPtr: 2048, trackId: 0, tsMax: 100, tsMin: 0 },
     { maxRows: 1024, outPtr: 2048, trackId: 1, tsMax: 100, tsMin: 0 },
   ]);
@@ -2892,24 +2710,17 @@ async function checkProgressiveTraceRendererMarksSkippedTracksWhenBudgetExhauste
     { end: 100, start: 0, trackId: 2 },
     { end: 100, start: 0, trackId: 3 },
   ]);
-  assert.equal(
-    operations.some(
-      (operation) =>
-        operation.op === "fillRect" &&
-        operation.fillStyle === "rgba(180, 83, 9, 0.16)" &&
-        operation.x === 0 &&
-        operation.width === 240,
-    ),
-    true,
+  harness.assertOperation(
+    {
+      fillStyle: "rgba(180, 83, 9, 0.16)",
+      op: "fillRect",
+      width: 240,
+      x: 0,
+    },
     "tracks skipped by query budget exhaustion should be visibly marked incomplete",
   );
-  assert.equal(
-    operations.some(
-      (operation) =>
-        operation.op === "stroke" &&
-        operation.strokeStyle === "rgba(146, 64, 14, 0.42)",
-    ),
-    true,
+  harness.assertOperation(
+    { op: "stroke", strokeStyle: "rgba(146, 64, 14, 0.42)" },
     "tracks skipped by query budget exhaustion should include the incomplete stripe overlay",
   );
 }

--- a/tools/runtime-worker-orchestration-check.js
+++ b/tools/runtime-worker-orchestration-check.js
@@ -2343,119 +2343,53 @@ function checkWatWriterPropagatesCatalogOverflow() {
 
 async function checkProgressiveTraceRendererDrawsCoveredPartialRows() {
   const rendererModule = await importRepoModule("host/progressive-trace-renderer.mjs");
-  const memory = new WebAssembly.Memory({ initial: 1 });
-  const operations = [];
-  const canvas = {
+  const harness = createProgressiveRendererHarness({
+    coveredRange: { end: 140, start: 100, type: "covered_range", valid: true },
     height: 160,
+    queryRows: [
+      ({ trackId }) => ({
+        color: trackId === 0 ? 0x2d74da : 0x6b7280,
+        depth: trackId,
+        dur: trackId === 0 ? 8 : 12,
+        partial: trackId === 1,
+        start: trackId === 0 ? 104 : 120,
+      }),
+    ],
+    trackCount: 2,
     width: 320,
-    getContext() {
-      return context;
-    },
-  };
-  const context = {
-    beginPath() {
-      operations.push({ op: "beginPath" });
-    },
-    clearRect(x, y, width, height) {
-      operations.push({ height, op: "clearRect", width, x, y });
-    },
-    clip() {
-      operations.push({ op: "clip" });
-    },
-    fillRect(x, y, width, height) {
-      operations.push({
-        fillStyle: this.fillStyle,
-        height,
-        op: "fillRect",
-        width,
-        x,
-        y,
-      });
-    },
-    lineTo(x, y) {
-      operations.push({ op: "lineTo", x, y });
-    },
-    moveTo(x, y) {
-      operations.push({ op: "moveTo", x, y });
-    },
-    rect(x, y, width, height) {
-      operations.push({ height, op: "rect", width, x, y });
-    },
-    restore() {
-      operations.push({ op: "restore" });
-    },
-    save() {
-      operations.push({ op: "save" });
-    },
-    stroke() {
-      operations.push({ op: "stroke", strokeStyle: this.strokeStyle });
-    },
-  };
-  let coveredRange = { end: 140, start: 100, type: "covered_range", valid: true };
-  const queryCalls = [];
-  const reader = {
-    queryRange(trackId, tsMin, tsMax, outPtr, maxRows) {
-      queryCalls.push({ maxRows, outPtr, trackId, tsMax, tsMin });
-      const view = new DataView(memory.buffer);
-      view.setUint32(outPtr, trackId === 0 ? 104 : 120, true);
-      view.setUint32(outPtr + 4, trackId === 0 ? 8 : 12, true);
-      view.setUint32(outPtr + 12, trackId, true);
-      view.setUint32(outPtr + 20, trackId === 0 ? 0x2d74da : 0x6b7280, true);
-      view.setUint32(outPtr + 24, trackId === 1 ? 1 : 0, true);
-      return 1;
-    },
-    status() {
-      return { state: "ready" };
-    },
-    trackCount() {
-      return 2;
-    },
-  };
-  let workerState = "running";
-  const ingestWorker = {
-    indexReader: reader,
-    status() {
-      return { coveredRange, state: workerState };
-    },
-  };
-  const renderer = rendererModule.createProgressiveTraceRenderer(memory, ingestWorker, {
-    canvas,
-    queryOutPtr: 2048,
-    queryWindow: 100,
-    renderPlannerExports: makeTraceRenderPlannerExports({ memory }),
   });
+  const renderer = rendererModule.createProgressiveTraceRenderer(
+    harness.memory,
+    harness.ingestWorker,
+    {
+      canvas: harness.canvas,
+      queryOutPtr: 2048,
+      queryWindow: 100,
+      renderPlannerExports: harness.renderPlannerExports(),
+    },
+  );
 
   assert.equal(renderer.draw(123), 2);
-  assert.deepEqual(
-    queryCalls,
-    [
-      { maxRows: 1024, outPtr: 2048, trackId: 0, tsMax: 140, tsMin: 100 },
-      { maxRows: 1024, outPtr: 2048, trackId: 1, tsMax: 140, tsMin: 100 },
-    ],
-  );
-  assert.equal(
-    operations.some((operation) => operation.op === "fillRect" && operation.fillStyle === "#2d74da"),
-    true,
+  harness.assertQueryCalls([
+    { maxRows: 1024, outPtr: 2048, trackId: 0, tsMax: 140, tsMin: 100 },
+    { maxRows: 1024, outPtr: 2048, trackId: 1, tsMax: 140, tsMin: 100 },
+  ]);
+  harness.assertOperation(
+    { fillStyle: "#2d74da", op: "fillRect" },
     "committed row should draw with its resolved color",
   );
-  assert.equal(
-    operations.some(
-      (operation) =>
-        operation.op === "fillRect" &&
-        operation.fillStyle === "rgba(92, 109, 130, 0.58)",
-    ),
-    true,
+  harness.assertOperation(
+    { fillStyle: "rgba(92, 109, 130, 0.58)", op: "fillRect" },
     "partial row should draw with unfinished styling",
   );
-  assert.equal(
-    operations.some((operation) => operation.op === "stroke"),
-    true,
+  harness.assertOperation(
+    { op: "stroke" },
     "partial row should get a hatch overlay",
   );
 
-  coveredRange = { end: 180, start: 100, type: "covered_range", valid: true };
+  harness.setCoveredRange({ end: 180, start: 100, type: "covered_range", valid: true });
   renderer.draw(124);
-  assert.deepEqual(queryCalls.at(-1), {
+  assert.deepEqual(harness.queryCalls.at(-1), {
     maxRows: 1024,
     outPtr: 2048,
     trackId: 1,
@@ -2472,26 +2406,24 @@ async function checkProgressiveTraceRendererDrawsCoveredPartialRows() {
     viewport: { end: 180, start: 100, valid: true },
   });
 
-  workerState = "complete";
-  operations.length = 0;
+  harness.setWorkerState("complete");
+  harness.clearOperations();
   renderer.draw(125);
   assert.equal(
-    operations.some(
-      (operation) =>
-        operation.op === "fillRect" &&
-        operation.fillStyle === "rgba(92, 109, 130, 0.58)",
-    ),
-    false,
+    harness.findOperation({
+      fillStyle: "rgba(92, 109, 130, 0.58)",
+      op: "fillRect",
+    }),
+    undefined,
     "completed ingest should stop drawing partial rows with unfinished styling",
   );
   assert.equal(
-    operations.some((operation) => operation.op === "stroke"),
-    false,
+    harness.findOperation({ op: "stroke" }),
+    undefined,
     "completed ingest should stop drawing partial hatch overlays",
   );
-  assert.equal(
-    operations.some((operation) => operation.op === "fillRect" && operation.fillStyle === "#6b7280"),
-    true,
+  harness.assertOperation(
+    { fillStyle: "#6b7280", op: "fillRect" },
     "completed ingest should draw formerly partial rows with their resolved color",
   );
   assert.deepEqual(renderer.status(), {
@@ -2507,86 +2439,36 @@ async function checkProgressiveTraceRendererDrawsCoveredPartialRows() {
 
 async function checkProgressiveTraceRendererClipsLeftEdgeSlices() {
   const rendererModule = await importRepoModule("host/progressive-trace-renderer.mjs");
-  const memory = new WebAssembly.Memory({ initial: 1 });
-  const operations = [];
-  const canvas = {
+  const harness = createProgressiveRendererHarness({
+    coveredRange: { end: 200, start: 100, type: "covered_range", valid: true },
     height: 160,
+    queryRows: [{ color: 0x2d74da, depth: 0, dur: 75, partial: false, start: 50 }],
+    trackCount: 1,
     width: 320,
-    getContext() {
-      return context;
-    },
-  };
-  const context = {
-    clearRect(x, y, width, height) {
-      operations.push({ height, op: "clearRect", width, x, y });
-    },
-    fillRect(x, y, width, height) {
-      operations.push({
-        fillStyle: this.fillStyle,
-        height,
-        op: "fillRect",
-        width,
-        x,
-        y,
-      });
-    },
-    restore() {
-      operations.push({ op: "restore" });
-    },
-    save() {
-      operations.push({ op: "save" });
-    },
-  };
-  const reader = {
-    queryRange(trackId, tsMin, tsMax, outPtr, maxRows) {
-      assert.deepEqual(
-        { maxRows, trackId, tsMax, tsMin },
-        { maxRows: 1024, trackId: 0, tsMax: 200, tsMin: 100 },
-      );
-      const view = new DataView(memory.buffer);
-      view.setUint32(outPtr, 50, true);
-      view.setUint32(outPtr + 4, 75, true);
-      view.setUint32(outPtr + 12, 0, true);
-      view.setUint32(outPtr + 20, 0x2d74da, true);
-      view.setUint32(outPtr + 24, 0, true);
-      return 1;
-    },
-    status() {
-      return { state: "ready" };
-    },
-    trackCount() {
-      return 1;
-    },
-  };
-  const ingestWorker = {
-    indexReader: reader,
-    status() {
-      return {
-        coveredRange: { end: 200, start: 100, type: "covered_range", valid: true },
-        state: "complete",
-      };
-    },
-  };
+    workerState: "complete",
+  });
   const renderPlannerExports = {
-    ...makeTraceRenderPlannerExports({ memory }),
+    ...harness.renderPlannerExports(),
     trace_render_slice_x(sliceStart, viewportStart, viewportSpan, canvasWidth) {
       return ((sliceStart - viewportStart) / viewportSpan) * canvasWidth;
     },
   };
-  const renderer = rendererModule.createProgressiveTraceRenderer(memory, ingestWorker, {
-    canvas,
-    queryOutPtr: 2048,
-    queryWindow: 100,
-    renderPlannerExports,
-  });
-
-  renderer.draw(123);
-  const sliceFill = operations.find(
-    (operation) => operation.op === "fillRect" && operation.fillStyle === "#2d74da",
+  const renderer = rendererModule.createProgressiveTraceRenderer(
+    harness.memory,
+    harness.ingestWorker,
+    {
+      canvas: harness.canvas,
+      queryOutPtr: 2048,
+      queryWindow: 100,
+      renderPlannerExports,
+    },
   );
 
-  assert.deepEqual(
-    sliceFill,
+  renderer.draw(123);
+  harness.assertQueryCalls([
+    { maxRows: 1024, outPtr: 2048, trackId: 0, tsMax: 200, tsMin: 100 },
+  ]);
+  harness.assertOperation(
     {
       fillStyle: "#2d74da",
       height: 10,
@@ -2601,61 +2483,27 @@ async function checkProgressiveTraceRendererClipsLeftEdgeSlices() {
 
 async function checkProgressiveTraceRendererClampsToSliceCatalogCoverage() {
   const rendererModule = await importRepoModule("host/progressive-trace-renderer.mjs");
-  const memory = new WebAssembly.Memory({ initial: 1 });
-  const canvas = {
-    height: 120,
-    width: 240,
-    getContext() {
-      return {
-        clearRect() {},
-        fillRect() {},
-        restore() {},
-        save() {},
-      };
-    },
-  };
-  const workerCoveredRange = {
-    end: 1000,
-    start: 0,
-    type: "covered_range",
-    valid: true,
-  };
-  let sliceCoveredRange = {
-    end: 320,
-    start: 200,
-    valid: true,
-  };
-  const queryCalls = [];
-  const reader = {
-    coveredRange() {
-      return sliceCoveredRange;
-    },
-    queryRange(trackId, tsMin, tsMax, outPtr, maxRows) {
-      queryCalls.push({ maxRows, outPtr, trackId, tsMax, tsMin });
-      return 0;
-    },
-    status() {
-      return { state: "ready" };
-    },
-    trackCount() {
-      return 1;
-    },
-  };
-  const ingestWorker = {
-    indexReader: reader,
-    status() {
-      return { coveredRange: workerCoveredRange, state: "running" };
-    },
-  };
-  const renderer = rendererModule.createProgressiveTraceRenderer(memory, ingestWorker, {
-    canvas,
-    queryOutPtr: 2048,
+  const harness = createProgressiveRendererHarness({
+    coveredRange: { end: 1000, start: 0, type: "covered_range", valid: true },
+    queryRows: [],
     queryWindow: 1000,
-    renderPlannerExports: makeTraceRenderPlannerExports({ memory }),
+    readerCoveredRange: true,
+    sliceCoveredRange: { end: 320, start: 200, valid: true },
+    trackCount: 1,
   });
+  const renderer = rendererModule.createProgressiveTraceRenderer(
+    harness.memory,
+    harness.ingestWorker,
+    {
+      canvas: harness.canvas,
+      queryOutPtr: 2048,
+      queryWindow: 1000,
+      renderPlannerExports: harness.renderPlannerExports(),
+    },
+  );
 
   renderer.draw(1);
-  assert.deepEqual(queryCalls, [
+  harness.assertQueryCalls([
     { maxRows: 1024, outPtr: 2048, trackId: 0, tsMax: 320, tsMin: 200 },
   ]);
   assert.deepEqual(renderer.status().viewport, {
@@ -2664,21 +2512,21 @@ async function checkProgressiveTraceRendererClampsToSliceCatalogCoverage() {
     valid: true,
   });
 
-  sliceCoveredRange = { end: 0, start: 0, valid: false };
-  queryCalls.length = 0;
+  harness.setSliceCoveredRange({ end: 0, start: 0, valid: false });
+  harness.queryCalls.length = 0;
   const emptyRenderer = rendererModule.createProgressiveTraceRenderer(
-    memory,
-    ingestWorker,
+    harness.memory,
+    harness.ingestWorker,
     {
-      canvas,
+      canvas: harness.canvas,
       queryOutPtr: 2048,
       queryWindow: 1000,
-      renderPlannerExports: makeTraceRenderPlannerExports({ memory }),
+      renderPlannerExports: harness.renderPlannerExports(),
     },
   );
 
   assert.equal(emptyRenderer.draw(2), 0);
-  assert.deepEqual(queryCalls, []);
+  harness.assertQueryCalls([]);
   assert.equal(emptyRenderer.status().viewport, null);
 }
 
@@ -3146,122 +2994,54 @@ async function checkProgressiveTraceRendererUsesWasmCanvasOpPlanner() {
 
 async function checkProgressiveTraceRendererClampsPanZoomAndDrawsUnknownRange() {
   const rendererModule = await importRepoModule("host/progressive-trace-renderer.mjs");
-  const memory = new WebAssembly.Memory({ initial: 1 });
-  const listeners = new Map();
-  const operations = [];
-  const canvas = {
-    height: 160,
-    width: 320,
-    addEventListener(type, callback) {
-      listeners.set(type, callback);
-    },
-    getBoundingClientRect() {
-      return { left: 0, top: 0 };
-    },
-    getContext() {
-      return context;
-    },
-    releasePointerCapture() {},
-    setPointerCapture() {},
-  };
-  const context = {
-    beginPath() {
-      operations.push({ op: "beginPath" });
-    },
-    clearRect(x, y, width, height) {
-      operations.push({ height, op: "clearRect", width, x, y });
-    },
-    clip() {
-      operations.push({ op: "clip" });
-    },
-    fillRect(x, y, width, height) {
-      operations.push({
-        fillStyle: this.fillStyle,
-        height,
-        op: "fillRect",
-        width,
-        x,
-        y,
-      });
-    },
-    lineTo(x, y) {
-      operations.push({ op: "lineTo", x, y });
-    },
-    moveTo(x, y) {
-      operations.push({ op: "moveTo", x, y });
-    },
-    rect(x, y, width, height) {
-      operations.push({ height, op: "rect", width, x, y });
-    },
-    restore() {
-      operations.push({ op: "restore" });
-    },
-    save() {
-      operations.push({ op: "save" });
-    },
-    stroke() {
-      operations.push({ op: "stroke", strokeStyle: this.strokeStyle });
-    },
-  };
   const coveredRange = { end: 200, start: 100, type: "covered_range", valid: true };
-  const queryCalls = [];
-  const reader = {
-    queryRange(trackId, tsMin, tsMax, outPtr, maxRows) {
-      queryCalls.push({ maxRows, outPtr, trackId, tsMax, tsMin });
-      const view = new DataView(memory.buffer);
-      view.setUint32(outPtr, Math.max(100, Math.floor(tsMin)), true);
-      view.setUint32(outPtr + 4, 8, true);
-      view.setUint32(outPtr + 12, 0, true);
-      view.setUint32(outPtr + 20, 0x2d74da, true);
-      view.setUint32(outPtr + 24, 0, true);
+  const harness = createProgressiveRendererHarness({
+    coveredRange,
+    height: 160,
+    queryRange({ outPtr, tsMin, writeTraceRenderRow }) {
+      writeTraceRenderRow(
+        harness.memory,
+        outPtr,
+        {
+          color: 0x2d74da,
+          depth: 0,
+          dur: 8,
+          partial: false,
+          start: Math.max(100, Math.floor(tsMin)),
+        },
+      );
       return 1;
     },
-    status() {
-      return { state: "ready" };
-    },
-    trackCount() {
-      return 1;
-    },
-  };
-  const ingestWorker = {
-    indexReader: reader,
-    status() {
-      return { coveredRange, state: "running" };
-    },
-  };
-  const renderer = rendererModule.createProgressiveTraceRenderer(memory, ingestWorker, {
-    canvas,
-    minViewportSpan: 10,
-    queryOutPtr: 2048,
-    queryWindow: 1000,
-    renderPlannerExports: makeTraceRenderPlannerExports({ memory }),
+    trackCount: 1,
+    width: 320,
   });
+  const renderer = rendererModule.createProgressiveTraceRenderer(
+    harness.memory,
+    harness.ingestWorker,
+    {
+      canvas: harness.canvas,
+      minViewportSpan: 10,
+      queryOutPtr: 2048,
+      queryWindow: 1000,
+      renderPlannerExports: harness.renderPlannerExports(),
+    },
+  );
 
   renderer.draw(1);
-  assert.equal(
-    operations.some(
-      (operation) =>
-        operation.op === "fillRect" &&
-        operation.fillStyle === "rgba(126, 134, 146, 0.18)",
-    ),
-    true,
+  harness.assertOperation(
+    { fillStyle: "rgba(126, 134, 146, 0.18)", op: "fillRect" },
     "unknown leading edge should draw as a striped affordance while ingest runs",
   );
-  assert.equal(
-    operations.some(
-      (operation) =>
-        operation.op === "stroke" &&
-        operation.strokeStyle === "rgba(76, 85, 99, 0.38)",
-    ),
-    true,
+  harness.assertOperation(
+    { op: "stroke", strokeStyle: "rgba(76, 85, 99, 0.38)" },
     "unknown leading edge should include stripes",
   );
 
-  listeners.get("wheel")({
+  harness.listeners.get("wheel")({
     clientX: 160,
     deltaY: -700,
     preventDefault() {
-      operations.push({ op: "wheelPrevented" });
+      harness.operations.push({ op: "wheelPrevented" });
     },
   });
   renderer.draw(2);
@@ -3271,36 +3051,36 @@ async function checkProgressiveTraceRendererClampsPanZoomAndDrawsUnknownRange() 
   assert.equal(zoomedViewport.end <= coveredRange.end, true);
   assert.equal(zoomedViewport.end - zoomedViewport.start < 100, true);
 
-  listeners.get("pointerdown")({
+  harness.listeners.get("pointerdown")({
     button: 0,
     clientX: 160,
     pointerId: 1,
     preventDefault() {},
   });
-  listeners.get("pointermove")({
+  harness.listeners.get("pointermove")({
     clientX: -10000,
     pointerId: 1,
     preventDefault() {},
   });
-  listeners.get("pointerup")({ pointerId: 1 });
+  harness.listeners.get("pointerup")({ pointerId: 1 });
   renderer.draw(3);
   assert.equal(renderer.status().viewport.end, coveredRange.end);
 
-  listeners.get("pointerdown")({
+  harness.listeners.get("pointerdown")({
     button: 0,
     clientX: 160,
     pointerId: 2,
     preventDefault() {},
   });
-  listeners.get("pointermove")({
+  harness.listeners.get("pointermove")({
     clientX: 10000,
     pointerId: 2,
     preventDefault() {},
   });
-  listeners.get("pointercancel")({ pointerId: 2 });
+  harness.listeners.get("pointercancel")({ pointerId: 2 });
   renderer.draw(4);
   assert.equal(renderer.status().viewport.start, coveredRange.start);
-  assert.equal(queryCalls.at(-1).tsMin, coveredRange.start);
+  assert.equal(harness.queryCalls.at(-1).tsMin, coveredRange.start);
 }
 
 async function checkRuntimePreloadsProgressiveTraceRendererImplementation() {


### PR DESCRIPTION
Extracts a reusable progressive renderer harness for canvas/context capture, reader stubs, ingest status, planner exports, and concrete domain assertions. The remaining work ports partial-row, viewport, capped-query, and query-budget checks onto that harness while preserving explicit renderer behavior assertions.

Fixes #300.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Port partial-row and viewport tests to the harness <!-- type:spec -->
- [x] Port capped-query and query-budget tests to the harness <!-- type:spec -->
- [x] Add progressive renderer test harness <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->