### PR TITLE
LOC #3c - Selected-file ingest message helper (closes #304)

### DIFF
--- a/tools/production-topology-fixture-check.js
+++ b/tools/production-topology-fixture-check.js
@@ -467,12 +467,18 @@ async function checkTypedScenarioHelpers() {
   let delivered = null;
   const workerMessageIngestId = 1;
   const workerMessageType = "progress";
-  const workerMessage = { ingestId: workerMessageIngestId, type: workerMessageType };
+  const workerMessage = { type: workerMessageType };
+  const expectedWorkerMessage = {
+    ingestId: workerMessageIngestId,
+    type: workerMessageType,
+  };
   const expectedWorkerMessageDeliveryResult = true;
   const expectedWorkerMessageEmitType = WORKER_EVENT.EVENT_MESSAGE;
 
   assert.equal(
-    fixture.scenario.workerMessageDelivery({
+    fixture.scenario.selectedFileWorkerMessageDelivery({
+      file: selectedFile,
+      handle: selectedFileHandle,
       message: workerMessage,
       worker: {
         emit(type, message) {
@@ -483,7 +489,7 @@ async function checkTypedScenarioHelpers() {
     expectedWorkerMessageDeliveryResult,
   );
   assert.deepEqual(delivered, {
-    message: workerMessage,
+    message: expectedWorkerMessage,
     type: expectedWorkerMessageEmitType,
   });
 }
@@ -502,11 +508,14 @@ async function checkTypedScenarioOrderGuards() {
   const expectedWorkerWriteCount = workerWriteLength;
   const expectedFlushResult = 0;
   const mainThreadReadLengthBeforeOpen = workerWriteLength;
-  const noSelectionWorkerMessageIngestId = 1;
   const noSelectionWorkerMessageType = "progress";
   const noSelectionWorkerMessage = {
-    ingestId: noSelectionWorkerMessageIngestId,
     type: noSelectionWorkerMessageType,
+  };
+  const noSelectionFileHandle = 999;
+  const noSelectionFile = {
+    bytes: new Uint8Array([53, 54]),
+    name: "no-selection.json",
   };
   const expectedCreateBeforePublicationError = {
     message: `${OP.mainThreadIndexOpen}: worker must create OPFS index ${indexName} before publication`,
@@ -518,7 +527,7 @@ async function checkTypedScenarioOrderGuards() {
     message: `worker publication requires worker OPFS index ${indexName} to contain bytes`,
   };
   const expectedNoSelectionMessageError = {
-    message: `${OP.workerMessageDelivery} requires selected-file ingest first`,
+    message: `${OP.workerMessageDelivery} requires selected-file ingest for handle ${noSelectionFileHandle}`,
   };
 
   assert.throws(
@@ -572,7 +581,9 @@ async function checkTypedScenarioOrderGuards() {
   const noSelectionFixture = makeProductionTopologyFixture();
 
   assert.throws(
-    () => noSelectionFixture.scenario.workerMessageDelivery({
+    () => noSelectionFixture.scenario.selectedFileWorkerMessageDelivery({
+      file: noSelectionFile,
+      handle: noSelectionFileHandle,
       message: noSelectionWorkerMessage,
       worker: { emit() {} },
     }),
@@ -593,6 +604,9 @@ async function checkWorkerMessageDeliveryRequiresActiveIngest() {
   const firstSelectedFileIngestId = 1;
   const workerMessageType = "progress";
   const workerMessage = {
+    type: workerMessageType,
+  };
+  const expectedWorkerMessage = {
     ingestId: firstSelectedFileIngestId,
     type: workerMessageType,
   };
@@ -630,7 +644,9 @@ async function checkWorkerMessageDeliveryRequiresActiveIngest() {
   );
   assert.equal(callbackRan, false);
   assert.throws(
-    () => fixture.scenario.workerMessageDelivery({
+    () => fixture.scenario.selectedFileWorkerMessageDelivery({
+      file: selectedFile,
+      handle: selectedFileHandle,
       message: workerMessage,
       worker,
     }),
@@ -641,14 +657,16 @@ async function checkWorkerMessageDeliveryRequiresActiveIngest() {
   await Promise.resolve();
   assert.equal(callbackRan, true);
   assert.equal(
-    fixture.scenario.workerMessageDelivery({
+    fixture.scenario.selectedFileWorkerMessageDelivery({
+      file: selectedFile,
+      handle: selectedFileHandle,
       message: workerMessage,
       worker,
     }),
     true,
   );
   assert.deepEqual(delivered, {
-    message: workerMessage,
+    message: expectedWorkerMessage,
     type: WORKER_EVENT.EVENT_MESSAGE,
   });
 }
@@ -670,18 +688,22 @@ async function checkWorkerMessageDeliveryRejectsRetiredIngests() {
   const firstSelectedFileIngestId = 1;
   const secondSelectedFileIngestId = 2;
   const completeMessage = {
+    type: WORKER_MESSAGE.COMPLETE,
+  };
+  const expectedCompleteMessage = {
     ingestId: firstSelectedFileIngestId,
     type: WORKER_MESSAGE.COMPLETE,
   };
   const staleProgressAfterCompleteMessage = {
-    ingestId: firstSelectedFileIngestId,
     type: WORKER_MESSAGE.PROGRESS,
   };
   const staleProgressAfterNewSelectionMessage = {
-    ingestId: firstSelectedFileIngestId,
     type: WORKER_MESSAGE.PROGRESS,
   };
   const activeProgressMessage = {
+    type: WORKER_MESSAGE.PROGRESS,
+  };
+  const expectedActiveProgressMessage = {
     ingestId: secondSelectedFileIngestId,
     type: WORKER_MESSAGE.PROGRESS,
   };
@@ -729,7 +751,9 @@ async function checkWorkerMessageDeliveryRejectsRetiredIngests() {
     workerHost,
   });
   assert.equal(
-    fixture.scenario.workerMessageDelivery({
+    fixture.scenario.selectedFileWorkerMessageDelivery({
+      file: firstSelectedFile,
+      handle: firstSelectedFileHandle,
       message: completeMessage,
       worker,
     }),
@@ -737,7 +761,9 @@ async function checkWorkerMessageDeliveryRejectsRetiredIngests() {
     "terminal complete should deliver for the current active ingest",
   );
   assert.throws(
-    () => fixture.scenario.workerMessageDelivery({
+    () => fixture.scenario.selectedFileWorkerMessageDelivery({
+      file: firstSelectedFile,
+      handle: firstSelectedFileHandle,
       message: staleProgressAfterCompleteMessage,
       worker,
     }),
@@ -760,7 +786,9 @@ async function checkWorkerMessageDeliveryRejectsRetiredIngests() {
   assert.equal(await secondPicker, secondSelectedFileHandle);
   await Promise.resolve();
   assert.throws(
-    () => fixture.scenario.workerMessageDelivery({
+    () => fixture.scenario.selectedFileWorkerMessageDelivery({
+      file: firstSelectedFile,
+      handle: firstSelectedFileHandle,
       message: staleProgressAfterNewSelectionMessage,
       worker,
     }),
@@ -768,7 +796,9 @@ async function checkWorkerMessageDeliveryRejectsRetiredIngests() {
     "worker message delivery should reject messages for an ingest superseded by a newer selection",
   );
   assert.equal(
-    fixture.scenario.workerMessageDelivery({
+    fixture.scenario.selectedFileWorkerMessageDelivery({
+      file: secondSelectedFile,
+      handle: secondSelectedFileHandle,
       message: activeProgressMessage,
       worker,
     }),
@@ -777,11 +807,11 @@ async function checkWorkerMessageDeliveryRejectsRetiredIngests() {
   );
   assert.deepEqual(delivered, [
     {
-      message: completeMessage,
+      message: expectedCompleteMessage,
       type: WORKER_EVENT.EVENT_MESSAGE,
     },
     {
-      message: activeProgressMessage,
+      message: expectedActiveProgressMessage,
       type: WORKER_EVENT.EVENT_MESSAGE,
     },
   ]);
@@ -806,6 +836,9 @@ async function checkWorkerMessageDeliveryRequiresPublishedCompleteIndex() {
   const expectedFlushResult = 0;
   const firstSelectedFileIngestId = 1;
   const completeMessage = {
+    type: WORKER_MESSAGE.COMPLETE,
+  };
+  const expectedCompleteMessage = {
     ingestId: firstSelectedFileIngestId,
     type: WORKER_MESSAGE.COMPLETE,
   };
@@ -849,7 +882,9 @@ async function checkWorkerMessageDeliveryRequiresPublishedCompleteIndex() {
     workerHost,
   });
   assert.throws(
-    () => fixture.scenario.workerMessageDelivery({
+    () => fixture.scenario.selectedFileWorkerMessageDelivery({
+      file: selectedFile,
+      handle: selectedFileHandle,
       indexName: unrelatedIndexName,
       message: completeMessage,
       worker,
@@ -880,7 +915,9 @@ async function checkWorkerMessageDeliveryRequiresPublishedCompleteIndex() {
   );
   assert.equal(await workerHost[HOST.OPFS_INDEX_FLUSH](workerIndexId), expectedFlushResult);
   assert.throws(
-    () => fixture.scenario.workerMessageDelivery({
+    () => fixture.scenario.selectedFileWorkerMessageDelivery({
+      file: selectedFile,
+      handle: selectedFileHandle,
       message: completeMessage,
       worker,
     }),
@@ -894,7 +931,9 @@ async function checkWorkerMessageDeliveryRequiresPublishedCompleteIndex() {
     workerIndexId,
   );
   assert.equal(
-    fixture.scenario.workerMessageDelivery({
+    fixture.scenario.selectedFileWorkerMessageDelivery({
+      file: selectedFile,
+      handle: selectedFileHandle,
       message: completeMessage,
       worker,
     }),
@@ -902,7 +941,7 @@ async function checkWorkerMessageDeliveryRequiresPublishedCompleteIndex() {
     "complete delivery should accept the active ingest index after publication",
   );
   assert.deepEqual(delivered, {
-    message: completeMessage,
+    message: expectedCompleteMessage,
     type: WORKER_EVENT.EVENT_MESSAGE,
   });
 }
@@ -923,6 +962,11 @@ async function checkWorkerMessageDeliveryRequiresPublishedCoveredRangeIndex() {
   const expectedFlushResult = 0;
   const firstSelectedFileIngestId = 1;
   const coveredRangeMessage = {
+    end: selectedFileBytes.byteLength,
+    start: 0,
+    type: WORKER_MESSAGE.COVERED_RANGE,
+  };
+  const expectedCoveredRangeMessage = {
     end: selectedFileBytes.byteLength,
     ingestId: firstSelectedFileIngestId,
     start: 0,
@@ -964,8 +1008,9 @@ async function checkWorkerMessageDeliveryRequiresPublishedCoveredRangeIndex() {
   assert.equal(await picker, selectedFileHandle);
   await Promise.resolve();
   assert.throws(
-    () => fixture.scenario.workerMessageDelivery({
-      indexName,
+    () => fixture.scenario.selectedFileWorkerMessageDelivery({
+      file: selectedFile,
+      handle: selectedFileHandle,
       message: coveredRangeMessage,
       worker,
     }),
@@ -996,8 +1041,9 @@ async function checkWorkerMessageDeliveryRequiresPublishedCoveredRangeIndex() {
   );
   assert.equal(await workerHost[HOST.OPFS_INDEX_FLUSH](workerIndexId), expectedFlushResult);
   assert.throws(
-    () => fixture.scenario.workerMessageDelivery({
-      indexName,
+    () => fixture.scenario.selectedFileWorkerMessageDelivery({
+      file: selectedFile,
+      handle: selectedFileHandle,
       message: coveredRangeMessage,
       worker,
     }),
@@ -1007,15 +1053,16 @@ async function checkWorkerMessageDeliveryRequiresPublishedCoveredRangeIndex() {
 
   assert.equal(await fixture.scenario.workerPublication({ indexName }), workerIndexId);
   assert.equal(
-    fixture.scenario.workerMessageDelivery({
-      indexName,
+    fixture.scenario.selectedFileWorkerMessageDelivery({
+      file: selectedFile,
+      handle: selectedFileHandle,
       message: coveredRangeMessage,
       worker,
     }),
     true,
   );
   assert.deepEqual(delivered, {
-    message: coveredRangeMessage,
+    message: expectedCoveredRangeMessage,
     type: expectedWorkerMessageEmitType,
   });
 }
@@ -1035,6 +1082,11 @@ async function checkWorkerMessageDeliveryRejectsUnrelatedCoveredRangeIndex() {
   const unrelatedIndexBytes = new Uint8Array([83, 84]);
   const firstSelectedFileIngestId = 1;
   const coveredRangeMessage = {
+    end: selectedFileBytes.byteLength,
+    start: 0,
+    type: WORKER_MESSAGE.COVERED_RANGE,
+  };
+  const expectedCoveredRangeMessage = {
     end: selectedFileBytes.byteLength,
     ingestId: firstSelectedFileIngestId,
     start: 0,
@@ -1080,7 +1132,9 @@ async function checkWorkerMessageDeliveryRejectsUnrelatedCoveredRangeIndex() {
     workerHost,
   });
   assert.throws(
-    () => fixture.scenario.workerMessageDelivery({
+    () => fixture.scenario.selectedFileWorkerMessageDelivery({
+      file: selectedFile,
+      handle: selectedFileHandle,
       message: coveredRangeMessageWithUnrelatedIndex,
       worker,
     }),
@@ -1088,7 +1142,9 @@ async function checkWorkerMessageDeliveryRejectsUnrelatedCoveredRangeIndex() {
     "covered_range delivery should reject an unrelated published index from the message payload",
   );
   assert.throws(
-    () => fixture.scenario.workerMessageDelivery({
+    () => fixture.scenario.selectedFileWorkerMessageDelivery({
+      file: selectedFile,
+      handle: selectedFileHandle,
       indexName: unrelatedIndexName,
       message: coveredRangeMessage,
       worker,
@@ -1102,8 +1158,9 @@ async function checkWorkerMessageDeliveryRejectsUnrelatedCoveredRangeIndex() {
     workerHost,
   });
   assert.equal(
-    fixture.scenario.workerMessageDelivery({
-      indexName: activeIndexName,
+    fixture.scenario.selectedFileWorkerMessageDelivery({
+      file: selectedFile,
+      handle: selectedFileHandle,
       message: coveredRangeMessage,
       worker,
     }),
@@ -1111,7 +1168,7 @@ async function checkWorkerMessageDeliveryRejectsUnrelatedCoveredRangeIndex() {
     "covered_range delivery should accept the active ingest index after publication",
   );
   assert.deepEqual(delivered, {
-    message: coveredRangeMessage,
+    message: expectedCoveredRangeMessage,
     type: WORKER_EVENT.EVENT_MESSAGE,
   });
 }

--- a/tools/production-topology-fixture-check.js
+++ b/tools/production-topology-fixture-check.js
@@ -512,10 +512,12 @@ async function checkTypedScenarioOrderGuards() {
   const noSelectionWorkerMessage = {
     type: noSelectionWorkerMessageType,
   };
-  const noSelectionFileHandle = 999;
+  const missingSelectedFileIngestHandle = 999;
+  const missingSelectedFileIngestBytes = new Uint8Array([53, 54]);
+  const missingSelectedFileIngestName = "no-selection.json";
   const noSelectionFile = {
-    bytes: new Uint8Array([53, 54]),
-    name: "no-selection.json",
+    bytes: missingSelectedFileIngestBytes,
+    name: missingSelectedFileIngestName,
   };
   const expectedCreateBeforePublicationError = {
     message: `${OP.mainThreadIndexOpen}: worker must create OPFS index ${indexName} before publication`,
@@ -527,7 +529,7 @@ async function checkTypedScenarioOrderGuards() {
     message: `worker publication requires worker OPFS index ${indexName} to contain bytes`,
   };
   const expectedNoSelectionMessageError = {
-    message: `${OP.workerMessageDelivery} requires selected-file ingest for handle ${noSelectionFileHandle}`,
+    message: `${OP.workerMessageDelivery} requires selected-file ingest for handle ${missingSelectedFileIngestHandle}`,
   };
 
   assert.throws(
@@ -583,7 +585,7 @@ async function checkTypedScenarioOrderGuards() {
   assert.throws(
     () => noSelectionFixture.scenario.selectedFileWorkerMessageDelivery({
       file: noSelectionFile,
-      handle: noSelectionFileHandle,
+      handle: missingSelectedFileIngestHandle,
       message: noSelectionWorkerMessage,
       worker: { emit() {} },
     }),

--- a/tools/production-topology-fixture.js
+++ b/tools/production-topology-fixture.js
@@ -349,6 +349,21 @@ function makeProductionTopologyFixture(options = {}) {
     }
   }
 
+  function requireSelectedFileIngest({ file, handle }, operation) {
+    const ingest = selectedFileIngestsByHandle.get(handle);
+
+    assert.ok(
+      ingest !== undefined,
+      `${operation} requires selected-file ingest for handle ${handle}`,
+    );
+    assert.equal(
+      ingest.indexName,
+      defaultIndexName(file),
+      `${operation} requires selected file to match selected-file ingest index ${ingest.indexName}`,
+    );
+    return ingest;
+  }
+
   function startWorkerIndexGeneration(handoff, indexId) {
     handoff.bytesWrittenThisGeneration = 0;
     handoff.flushed = false;
@@ -1050,6 +1065,70 @@ function makeProductionTopologyFixture(options = {}) {
         return true;
       }
       throw new Error("worker message delivery requires emit or onmessage");
+    },
+    selectedFileWorkerMessageDelivery({
+      file,
+      handle,
+      indexName,
+      message = {},
+      messageType,
+      worker,
+    }) {
+      assert.equal(
+        typeof message,
+        "object",
+        `${FIXTURE_OPERATION.workerMessageDelivery} requires a worker message object`,
+      );
+      assert.notEqual(
+        message,
+        null,
+        `${FIXTURE_OPERATION.workerMessageDelivery} requires a worker message object`,
+      );
+      const ingest = requireSelectedFileIngest(
+        { file, handle },
+        FIXTURE_OPERATION.workerMessageDelivery,
+      );
+      const type = message.type ?? messageType;
+
+      if (message.type !== undefined && messageType !== undefined) {
+        assert.equal(
+          message.type,
+          messageType,
+          `${FIXTURE_OPERATION.workerMessageDelivery} requires worker message type ${message.type} to match helper message type ${messageType}`,
+        );
+      }
+      assert.equal(
+        typeof type,
+        "string",
+        `${FIXTURE_OPERATION.workerMessageDelivery} requires worker message type`,
+      );
+      if (indexName !== undefined && message.indexName !== undefined) {
+        assert.equal(
+          indexName,
+          message.indexName,
+          `${FIXTURE_OPERATION.workerMessageDelivery} requires helper index ${indexName} to match worker message index ${message.indexName}`,
+        );
+      }
+      if (message.ingestId !== undefined) {
+        assert.ok(
+          Number.isInteger(message.ingestId),
+          `${FIXTURE_OPERATION.workerMessageDelivery} requires worker message ingestId`,
+        );
+        assert.equal(
+          message.ingestId,
+          ingest.ingestId,
+          `${FIXTURE_OPERATION.workerMessageDelivery} requires worker message ingestId ${message.ingestId} to match selected-file ingest ${ingest.ingestId}`,
+        );
+      }
+      return scenario.workerMessageDelivery({
+        indexName,
+        message: {
+          ...message,
+          ingestId: ingest.ingestId,
+          type,
+        },
+        worker,
+      });
     },
   });
 


### PR DESCRIPTION
Fixes #304.

Extracts selected-file worker-message delivery into a production-topology scenario helper so tests bind message type, active ingest id, selected file, and published index identity through one path. Keeps the leaf scoped to fixture/test structure, with the remaining work limited to naming or documenting the no-selection fixture values that exercise the missing selected-file ingest guard.

Fixes #304.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] [Replace the new unexplained no-selection fixture literals with descriptive named constants or nearby comments that state the invariant they protect.](https://github.com/rhencke/tracy/pull/328#discussion_r3226003189) <!-- type:thread -->
- [x] Extract selected-file worker-message helper <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->