### PR TITLE
LOC #4a - Shared dist server and browser discovery (closes #306)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,6 +265,7 @@ test: dist check-generated
 	node tools/interactive-ingest-check.js
 	node tools/interactive-ingest-browser-check.js
 	node tools/direct-esm-check.js
+	node tools/dist-browser-helpers-check.js
 	node tools/service-worker-check.js
 	node tools/generated-file-writer-check.js
 	node tools/dist-budget-check.js --self-test

--- a/bootstrap.mjs
+++ b/bootstrap.mjs
@@ -8,7 +8,11 @@ const coreReadyPromise = new Promise((resolve) => {
   if (performance.getEntriesByName(PERFORMANCE_MARKS.coreReady).length > 0 || typeof globalThis.addEventListener !== "function") resolve();
   else globalThis.addEventListener(PERFORMANCE_MARKS.coreReady, resolve, { once: true });
 });
-const importWasmModules = async () => { await coreReadyPromise; return import(`./host/${RUNTIME_URLS.WASM_MODULES_URL.replace(/^\.\//, "")}`); };
+const importWasmModules = async () => {
+  await coreReadyPromise;
+  const wasmModulesUrl = `./host/${RUNTIME_URLS.WASM_MODULES_URL.replace(/^\.\//, "")}`;
+  return import(wasmModulesUrl);
+};
 const shimModulePromise = import("./host/shim.mjs"), runtimeModulePromise = import("./host/runtime.mjs");
 const instantiateWasmModuleForThread = async (id, thread, imports, options = {}) => {
   if (id !== "app" || thread !== "main") {

--- a/bootstrap.mjs
+++ b/bootstrap.mjs
@@ -8,11 +8,7 @@ const coreReadyPromise = new Promise((resolve) => {
   if (performance.getEntriesByName(PERFORMANCE_MARKS.coreReady).length > 0 || typeof globalThis.addEventListener !== "function") resolve();
   else globalThis.addEventListener(PERFORMANCE_MARKS.coreReady, resolve, { once: true });
 });
-const importWasmModules = async () => {
-  await coreReadyPromise;
-  const wasmModulesUrl = `./host/${RUNTIME_URLS.WASM_MODULES_URL.replace(/^\.\//, "")}`;
-  return import(wasmModulesUrl);
-};
+const importWasmModules = async () => { await coreReadyPromise; const wasmModulesUrl = `./host/${RUNTIME_URLS.WASM_MODULES_URL.replace(/^\.\//, "")}`; return import(wasmModulesUrl); };
 const shimModulePromise = import("./host/shim.mjs"), runtimeModulePromise = import("./host/runtime.mjs");
 const instantiateWasmModuleForThread = async (id, thread, imports, options = {}) => {
   if (id !== "app" || thread !== "main") {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:production-topology-fixture": "node tools/production-topology-fixture-check.js",
     "test:interactive-ingest-browser": "node tools/interactive-ingest-browser-check.js",
     "test:direct-esm": "node tools/direct-esm-check.js",
+    "test:dist-browser-helpers": "node tools/dist-browser-helpers-check.js",
     "test:generated-file-writer": "node tools/generated-file-writer-check.js",
     "test:service-worker": "node tools/service-worker-check.js",
     "test:dist-budget": "node tools/dist-budget-check.js --self-test",

--- a/tools/app-load-bench.js
+++ b/tools/app-load-bench.js
@@ -4,11 +4,14 @@ const assert = require("node:assert/strict");
 const childProcess = require("node:child_process");
 const crypto = require("node:crypto");
 const fs = require("node:fs");
-const http = require("node:http");
 const net = require("node:net");
 const os = require("node:os");
 const path = require("node:path");
-const zlib = require("node:zlib");
+const {
+  CACHE_CONTROL,
+  browserExecutablePath,
+  createDistServer,
+} = require("./dist-browser-helpers.js");
 
 const ROOT_DIR = path.resolve(__dirname, "..");
 const DIST_DIR = path.join(ROOT_DIR, "dist");
@@ -55,24 +58,6 @@ const BUDGETS = Object.freeze(
     ]),
   ),
 );
-const MIME_TYPES = Object.freeze({
-  ".html": "text/html; charset=utf-8",
-  ".js": "text/javascript; charset=utf-8",
-  ".json": "application/json; charset=utf-8",
-  ".mjs": "text/javascript; charset=utf-8",
-  ".svg": "image/svg+xml",
-  ".wasm": "application/wasm",
-  ".webmanifest": "application/manifest+json",
-});
-const GZIP_EXTENSIONS = new Set([
-  ".html",
-  ".js",
-  ".json",
-  ".mjs",
-  ".svg",
-  ".wasm",
-  ".webmanifest",
-]);
 const REQUIRED_DIST_FILES = Object.freeze([
   "bootstrap.mjs",
   "build-info.js",
@@ -188,47 +173,10 @@ function medianMetrics(samples) {
 }
 
 function findBrowser(explicitPath) {
-  const candidates = [
+  return browserExecutablePath({
+    errorMessage: "Chrome/Chromium not found; set TRACY_APP_LOAD_BROWSER",
     explicitPath,
-    process.env.PUPPETEER_EXECUTABLE_PATH,
-    process.env.CHROME_PATH,
-    "google-chrome",
-    "google-chrome-stable",
-    "chromium",
-    "chromium-browser",
-  ].filter(Boolean);
-
-  for (const candidate of candidates) {
-    const result = childProcess.spawnSync("bash", ["-lc", `command -v ${JSON.stringify(candidate)}`], {
-      encoding: "utf8",
-    });
-
-    if (result.status === 0) {
-      return result.stdout.trim();
-    }
-    if (path.isAbsolute(candidate) && fs.existsSync(candidate)) {
-      return candidate;
-    }
-  }
-
-  throw new Error("Chrome/Chromium not found; set TRACY_APP_LOAD_BROWSER");
-}
-
-function contentType(file) {
-  return MIME_TYPES[path.extname(file)] ?? "application/octet-stream";
-}
-
-function acceptsGzip(request) {
-  return /\bgzip\b/.test(request.headers["accept-encoding"] ?? "");
-}
-
-function shouldGzip(file) {
-  return GZIP_EXTENSIONS.has(path.extname(file));
-}
-
-function sendNotFound(response) {
-  response.writeHead(404);
-  response.end("not found");
+  });
 }
 
 function assertDistReady(distDir) {
@@ -263,80 +211,11 @@ function assertDistReady(distDir) {
   }
 }
 
-function resolveDistPath(distDir, requestUrl) {
-  const url = new URL(requestUrl, "http://localhost");
-  const pathname = decodeURIComponent(url.pathname);
-  const relativePath = pathname === "/" ? "index.html" : pathname.replace(/^\//, "");
-  const file = path.resolve(distDir, relativePath);
-
-  if (!file.startsWith(`${path.resolve(distDir)}${path.sep}`) && file !== path.resolve(distDir)) {
-    return null;
-  }
-
-  return file;
-}
-
-async function listen(server) {
-  await new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  return server.address().port;
-}
-
 async function createServer(distDir) {
-  const server = http.createServer(async (request, response) => {
-    const file = resolveDistPath(distDir, request.url);
-
-    if (file === null) {
-      sendNotFound(response);
-      return;
-    }
-
-    let stat;
-    try {
-      stat = await fs.promises.stat(file);
-    } catch (error) {
-      if (error.code === "ENOENT" || error.code === "ENOTDIR") {
-        sendNotFound(response);
-        return;
-      }
-      response.destroy(error);
-      return;
-    }
-
-    if (!stat.isFile()) {
-      sendNotFound(response);
-      return;
-    }
-
-    const source = await fs.promises.readFile(file);
-    const body =
-      acceptsGzip(request) && shouldGzip(file)
-        ? zlib.gzipSync(source)
-        : source;
-    const headers = {
-      "Cache-Control": "public, max-age=31536000, immutable",
-      "Content-Length": body.byteLength,
-      "Content-Type": contentType(file),
-    };
-
-    if (body !== source) {
-      headers["Content-Encoding"] = "gzip";
-      headers.Vary = "Accept-Encoding";
-    }
-
-    response.writeHead(200, {
-      ...headers,
-    });
-    response.end(body);
+  return createDistServer(distDir, {
+    cacheControl: CACHE_CONTROL.IMMUTABLE,
+    gzip: true,
   });
-  const port = await listen(server);
-
-  return {
-    origin: `http://127.0.0.1:${port}`,
-    close: () => new Promise((resolve) => server.close(resolve)),
-  };
 }
 
 function connectWebSocket(url) {
@@ -1307,11 +1186,9 @@ function runSelfTest() {
     /protected startup boundary fetched broad modules before coreReady: host\/wasm-modules\.mjs/,
   );
   const staticServerSource = createServer.toString();
-  assert.match(staticServerSource, /fs\.promises\.stat/);
-  assert.match(staticServerSource, /fs\.promises\.readFile/);
-  assert.match(staticServerSource, /Content-Encoding"\] = "gzip"/);
-  assert.match(staticServerSource, /Content-Length": body\.byteLength/);
-  assert.doesNotMatch(staticServerSource, /fs\.(existsSync|statSync|readFileSync)/);
+  assert.match(staticServerSource, /createDistServer\(distDir/);
+  assert.match(staticServerSource, /cacheControl: CACHE_CONTROL\.IMMUTABLE/);
+  assert.match(staticServerSource, /gzip: true/);
 
   const tmpDist = fs.mkdtempSync(path.join(os.tmpdir(), "tracy-app-load-dist-"));
   try {

--- a/tools/app-load-bench.js
+++ b/tools/app-load-bench.js
@@ -1533,7 +1533,11 @@ function runSelfTest() {
   );
   assert.match(
     bootstrap,
-    /return import\(`\.\/host\/\$\{RUNTIME_URLS\.WASM_MODULES_URL\.replace/,
+    /const wasmModulesUrl = `\.\/host\/\$\{RUNTIME_URLS\.WASM_MODULES_URL\.replace/,
+  );
+  assert.match(
+    bootstrap,
+    /return import\(wasmModulesUrl\)/,
   );
   assert.match(
     bootstrap,

--- a/tools/direct-esm-check.js
+++ b/tools/direct-esm-check.js
@@ -1133,7 +1133,11 @@ function main() {
   );
   assert.match(
     bootstrapSource,
-    /return import\(`\.\/host\/\$\{RUNTIME_URLS\.WASM_MODULES_URL\.replace/,
+    /const wasmModulesUrl = `\.\/host\/\$\{RUNTIME_URLS\.WASM_MODULES_URL\.replace/,
+  );
+  assert.match(
+    bootstrapSource,
+    /return import\(wasmModulesUrl\)/,
   );
   assert.match(
     bootstrapSource,

--- a/tools/dist-browser-helpers-check.js
+++ b/tools/dist-browser-helpers-check.js
@@ -217,13 +217,14 @@ function assertBrowserDiscovery() {
     "/pw/chromium-120/chrome-linux64/chrome",
   ]);
   const existsSync = (file) => exists.has(file);
+  const isExecutableFile = existsSync;
 
   assert.equal(
     browserExecutablePath({
       commandPath: commandPathStub,
       env: { PUPPETEER_EXECUTABLE_PATH: "/env/chrome" },
-      existsSync,
       explicitPath: "/custom/chrome",
+      isExecutableFile,
     }),
     "/custom/chrome",
   );
@@ -232,7 +233,7 @@ function assertBrowserDiscovery() {
       commandPath: commandPathStub,
       env: { TRACY_INTERACTIVE_INGEST_BROWSER: "/env/chrome" },
       envNames: ["TRACY_INTERACTIVE_INGEST_BROWSER"],
-      existsSync,
+      isExecutableFile,
     }),
     "/env/chrome",
   );
@@ -240,7 +241,7 @@ function assertBrowserDiscovery() {
     browserExecutablePath({
       commandPath: commandPathStub,
       env: {},
-      existsSync,
+      isExecutableFile,
     }),
     "/usr/bin/chromium",
   );
@@ -254,7 +255,7 @@ function assertBrowserDiscovery() {
       commandNames: [],
       commandPath: commandPathStub,
       env: {},
-      existsSync,
+      isExecutableFile,
       playwrightChromes: ["/pw/chromium-120/chrome-linux64/chrome"],
     }),
     "/pw/chromium-120/chrome-linux64/chrome",
@@ -307,7 +308,6 @@ function assertBrowserDiscovery() {
           TRACY_INTERACTIVE_INGEST_BROWSER: `$(touch ${markerPath})`,
         },
         envNames: ["TRACY_INTERACTIVE_INGEST_BROWSER"],
-        existsSync: fs.existsSync,
       }),
       browserPath,
     );
@@ -348,7 +348,6 @@ function assertBrowserDiscovery() {
             pathDelimiter: ":",
           }),
         env: {},
-        existsSync: fs.existsSync,
       }),
       browserPath,
     );
@@ -361,12 +360,44 @@ function assertBrowserDiscovery() {
     });
   }
 
+  const relativeLookupRoot = fs.mkdtempSync(path.join(os.tmpdir(), "tracy-browser-relative-"));
+  try {
+    const browserPath = path.join(relativeLookupRoot, "chromium");
+    const relativeBrowserPath = path.relative(process.cwd(), browserPath);
+    fs.writeFileSync(browserPath, "#!/bin/sh\nexit 0\n");
+    fs.chmodSync(browserPath, 0o755);
+
+    assert.equal(
+      browserExecutablePath({
+        commandNames: ["chromium"],
+        env: {},
+        explicitPath: relativeBrowserPath,
+      }),
+      path.resolve(relativeBrowserPath),
+    );
+    assert.equal(
+      browserExecutablePath({
+        commandNames: ["chromium"],
+        env: { TRACY_INTERACTIVE_INGEST_BROWSER: relativeBrowserPath },
+        envNames: ["TRACY_INTERACTIVE_INGEST_BROWSER"],
+      }),
+      path.resolve(relativeBrowserPath),
+    );
+  } finally {
+    fs.rmSync(relativeLookupRoot, {
+      force: true,
+      maxRetries: 5,
+      recursive: true,
+      retryDelay: 100,
+    });
+  }
+
   assert.equal(
     browserExecutablePath({
       commandNames: ["chromium"],
       commandPath: () => "chromium",
       env: {},
-      existsSync,
+      isExecutableFile,
       playwrightChromes: ["/pw/chromium-120/chrome-linux64/chrome"],
     }),
     "/pw/chromium-120/chrome-linux64/chrome",
@@ -389,7 +420,7 @@ function assertBrowserDiscovery() {
       browserExecutablePath({
         commandNames: [],
         env: {},
-        existsSync,
+        isExecutableFile,
         playwrightChromes: [],
       }),
     /Chrome\/Chromium not found/,

--- a/tools/dist-browser-helpers-check.js
+++ b/tools/dist-browser-helpers-check.js
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const http = require("node:http");
+const os = require("node:os");
+const path = require("node:path");
+const zlib = require("node:zlib");
+const {
+  CACHE_CONTROL,
+  browserExecutablePath,
+  cachedPlaywrightChromes,
+  contentType,
+  createDistServer,
+  resolveDistPath,
+} = require("./dist-browser-helpers.js");
+
+function request(url, options = {}) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, { headers: options.headers ?? {} }, (response) => {
+      const chunks = [];
+
+      response.on("data", (chunk) => chunks.push(chunk));
+      response.on("end", () =>
+        resolve({
+          body: Buffer.concat(chunks),
+          headers: response.headers,
+          statusCode: response.statusCode,
+        }),
+      );
+    });
+
+    req.once("error", reject);
+  });
+}
+
+async function withTempDist(run) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tracy-dist-browser-"));
+  try {
+    fs.mkdirSync(path.join(dir, "host"), { recursive: true });
+    fs.writeFileSync(path.join(dir, "index.html"), "<!doctype html>\n");
+    fs.writeFileSync(path.join(dir, "host", "runtime.mjs"), "export {};\n");
+    fs.writeFileSync(path.join(dir, "trace.wasm"), Buffer.from([0, 97, 115, 109]));
+    fs.writeFileSync(path.join(dir, "plain.bin"), Buffer.from([1, 2, 3]));
+    await run(dir);
+  } finally {
+    fs.rmSync(dir, {
+      force: true,
+      maxRetries: 5,
+      recursive: true,
+      retryDelay: 100,
+    });
+  }
+}
+
+async function assertServerResponseModes() {
+  await withTempDist(async (distDir) => {
+    const cached = await createDistServer(distDir, {
+      cacheControl: CACHE_CONTROL.IMMUTABLE,
+      gzip: true,
+    });
+    try {
+      const html = await request(`${cached.origin}/`, {
+        headers: { "Accept-Encoding": "br, gzip" },
+      });
+      assert.equal(html.statusCode, 200);
+      assert.equal(html.headers["cache-control"], CACHE_CONTROL.IMMUTABLE);
+      assert.equal(html.headers["content-encoding"], "gzip");
+      assert.equal(html.headers.vary, "Accept-Encoding");
+      assert.equal(zlib.gunzipSync(html.body).toString("utf8"), "<!doctype html>\n");
+
+      const bin = await request(`${cached.origin}/plain.bin`, {
+        headers: { "Accept-Encoding": "gzip" },
+      });
+      assert.equal(bin.statusCode, 200);
+      assert.equal(bin.headers["content-encoding"], undefined);
+      assert.equal(bin.headers["content-type"], "application/octet-stream");
+
+      const traversal = await request(`${cached.origin}/../package.json`);
+      assert.equal(traversal.statusCode, 404);
+    } finally {
+      await cached.close();
+    }
+
+    const noStore = await createDistServer(distDir, {
+      cacheControl: CACHE_CONTROL.NO_STORE,
+      gzip: false,
+    });
+    try {
+      const runtime = await request(`${noStore.origin}/host/runtime.mjs`, {
+        headers: { "Accept-Encoding": "gzip" },
+      });
+      assert.equal(runtime.statusCode, 200);
+      assert.equal(runtime.headers["cache-control"], CACHE_CONTROL.NO_STORE);
+      assert.equal(runtime.headers["content-encoding"], undefined);
+      assert.equal(runtime.body.toString("utf8"), "export {};\n");
+    } finally {
+      await noStore.close();
+    }
+  });
+}
+
+function assertPathAndMimeHelpers() {
+  const distDir = path.resolve("/repo/dist");
+
+  assert.equal(resolveDistPath(distDir, "/"), path.join(distDir, "index.html"));
+  assert.equal(resolveDistPath(distDir, "/host/runtime.mjs"), path.join(distDir, "host", "runtime.mjs"));
+  assert.equal(resolveDistPath(distDir, "/%2e%2e/package.json"), null);
+  assert.equal(resolveDistPath(distDir, "/%E0%A4%A"), null);
+  assert.equal(contentType("index.html"), "text/html; charset=utf-8");
+  assert.equal(contentType("bootstrap.mjs"), "text/javascript; charset=utf-8");
+  assert.equal(contentType("trace.wasm"), "application/wasm");
+  assert.equal(contentType("manifest.webmanifest"), "application/manifest+json");
+  assert.equal(contentType("unknown.bin"), "application/octet-stream");
+}
+
+function assertBrowserDiscovery() {
+  const commands = [];
+  const commandPath = (command) => {
+    commands.push(command);
+    return command === "chromium" ? "/usr/bin/chromium" : "";
+  };
+  const exists = new Set([
+    "/custom/chrome",
+    "/env/chrome",
+    "/pw/chromium-120/chrome-linux64/chrome",
+  ]);
+  const existsSync = (file) => exists.has(file);
+
+  assert.equal(
+    browserExecutablePath({
+      commandPath,
+      env: { PUPPETEER_EXECUTABLE_PATH: "/env/chrome" },
+      existsSync,
+      explicitPath: "/custom/chrome",
+    }),
+    "/custom/chrome",
+  );
+  assert.equal(
+    browserExecutablePath({
+      commandPath,
+      env: { TRACY_INTERACTIVE_INGEST_BROWSER: "/env/chrome" },
+      envNames: ["TRACY_INTERACTIVE_INGEST_BROWSER"],
+      existsSync,
+    }),
+    "/env/chrome",
+  );
+  assert.equal(
+    browserExecutablePath({
+      commandPath,
+      env: {},
+      existsSync,
+    }),
+    "/usr/bin/chromium",
+  );
+  assert.deepEqual(commands.slice(-3), [
+    "google-chrome",
+    "google-chrome-stable",
+    "chromium",
+  ]);
+  assert.equal(
+    browserExecutablePath({
+      commandNames: [],
+      commandPath,
+      env: {},
+      existsSync,
+      playwrightChromes: ["/pw/chromium-120/chrome-linux64/chrome"],
+    }),
+    "/pw/chromium-120/chrome-linux64/chrome",
+  );
+  assert.deepEqual(
+    cachedPlaywrightChromes({
+      cacheRoot: "/pw",
+      existsSync: (file) => file === "/pw",
+      readdirSync: () => ["firefox-1", "chromium-99", "chromium-120"],
+    }),
+    [
+      "/pw/chromium-120/chrome-linux64/chrome",
+      "/pw/chromium-120/chrome-linux/chrome",
+      "/pw/chromium-99/chrome-linux64/chrome",
+      "/pw/chromium-99/chrome-linux/chrome",
+    ],
+  );
+  assert.throws(
+    () =>
+      browserExecutablePath({
+        commandNames: [],
+        env: {},
+        existsSync,
+        playwrightChromes: [],
+      }),
+    /Chrome\/Chromium not found/,
+  );
+}
+
+async function main() {
+  assertPathAndMimeHelpers();
+  assertBrowserDiscovery();
+  await assertServerResponseModes();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tools/dist-browser-helpers-check.js
+++ b/tools/dist-browser-helpers-check.js
@@ -16,6 +16,12 @@ const {
   resolveDistPath,
 } = require("./dist-browser-helpers.js");
 
+const ROOT_DIR = path.resolve(__dirname, "..");
+
+function readRepoFile(relativePath) {
+  return fs.readFileSync(path.join(ROOT_DIR, relativePath), "utf8");
+}
+
 function request(url, options = {}) {
   return new Promise((resolve, reject) => {
     const req = http.get(url, { headers: options.headers ?? {} }, (response) => {
@@ -194,9 +200,72 @@ function assertBrowserDiscovery() {
   );
 }
 
+function assertAppLoadUsesSharedHelpers() {
+  const source = readRepoFile("tools/app-load-bench.js");
+
+  assert.match(source, /require\("\.\/dist-browser-helpers\.js"\)/);
+  assert.match(source, /browserExecutablePath\(\{\s*errorMessage: "Chrome\/Chromium not found; set TRACY_APP_LOAD_BROWSER",\s*explicitPath,/);
+  assert.match(source, /createDistServer\(distDir,\s*\{\s*cacheControl: CACHE_CONTROL\.IMMUTABLE,\s*gzip: true,/);
+  assert.doesNotMatch(source, /const http = require\("node:http"\)/);
+  assert.doesNotMatch(source, /const zlib = require\("node:zlib"\)/);
+  assert.doesNotMatch(source, /\bconst MIME_TYPES\b/);
+  assert.doesNotMatch(source, /\bconst GZIP_EXTENSIONS\b/);
+  assert.doesNotMatch(source, /\bfunction acceptsGzip\b/);
+  assert.doesNotMatch(source, /\bfunction contentType\b/);
+  assert.doesNotMatch(source, /\bfunction resolveDistPath\b/);
+  assert.doesNotMatch(source, /\bfunction shouldGzip\b/);
+}
+
+function assertInteractiveCheckUsesSharedHelpers() {
+  const source = readRepoFile("tools/interactive-ingest-browser-check.js");
+  const browserEnvOffset = source.indexOf('"TRACY_INTERACTIVE_INGEST_BROWSER"');
+  const puppeteerEnvOffset = source.indexOf('"PUPPETEER_EXECUTABLE_PATH"');
+  const chromeEnvOffset = source.indexOf('"CHROME_PATH"');
+
+  assert.match(source, /require\("\.\/dist-browser-helpers\.js"\)/);
+  assert.match(source, /browserExecutablePath: findBrowserExecutablePath/);
+  assert.match(source, /cachedPlaywrightChromes/);
+  assert.match(source, /findBrowserExecutablePath\(\{\s*envNames: \[/);
+  assert.ok(browserEnvOffset >= 0, "interactive browser env override must stay configured");
+  assert.ok(puppeteerEnvOffset > browserEnvOffset, "TRACY_INTERACTIVE_INGEST_BROWSER must precede Puppeteer fallback");
+  assert.ok(chromeEnvOffset > puppeteerEnvOffset, "PUPPETEER_EXECUTABLE_PATH must precede CHROME_PATH fallback");
+  assert.match(source, /createDistServer\(DIST_DIR,\s*\{\s*cacheControl: CACHE_CONTROL\.NO_STORE,\s*gzip: false,/);
+  assert.doesNotMatch(source, /const childProcess = require\("node:child_process"\)/);
+  assert.doesNotMatch(source, /const http = require\("node:http"\)/);
+  assert.doesNotMatch(source, /\bfunction commandPath\b/);
+  assert.doesNotMatch(source, /\bfunction contentType\b/);
+  assert.doesNotMatch(source, /\bfunction resolveDistPath\b/);
+  assert.doesNotMatch(source, /\bfunction cachedPlaywrightChromes\b/);
+}
+
+function assertDelayedWasmImportBoundary() {
+  const bootstrap = readRepoFile("bootstrap.mjs");
+  const coreReadyOffset = bootstrap.indexOf("await coreReadyPromise");
+  const wasmModulesUrlOffset = bootstrap.indexOf("const wasmModulesUrl");
+  const dynamicImportOffset = bootstrap.indexOf("return import(wasmModulesUrl)");
+
+  assert.match(bootstrap, /const coreReadyPromise = new Promise/);
+  assert.ok(coreReadyOffset >= 0, "Wasm module graph import must await core readiness");
+  assert.ok(
+    wasmModulesUrlOffset > coreReadyOffset,
+    "Wasm module graph URL must be discovered after core readiness",
+  );
+  assert.ok(
+    dynamicImportOffset > wasmModulesUrlOffset,
+    "Wasm module graph import must use the post-ready URL variable",
+  );
+  assert.doesNotMatch(
+    bootstrap,
+    /import\(`\.\/host\/\$\{RUNTIME_URLS\.WASM_MODULES_URL\.replace/,
+  );
+}
+
 async function main() {
   assertPathAndMimeHelpers();
   assertBrowserDiscovery();
+  assertAppLoadUsesSharedHelpers();
+  assertInteractiveCheckUsesSharedHelpers();
+  assertDelayedWasmImportBoundary();
   await assertServerResponseModes();
 }
 

--- a/tools/dist-browser-helpers-check.js
+++ b/tools/dist-browser-helpers-check.js
@@ -261,6 +261,7 @@ function assertBrowserDiscovery() {
   );
 
   const commandLookupAttempts = [];
+  const statLookupAttempts = [];
   assert.equal(
     safeCommandPath("chromium", {
       accessSync: (file) => {
@@ -273,13 +274,20 @@ function assertBrowserDiscovery() {
       },
       env: { PATH: "/missing:/tools" },
       pathDelimiter: ":",
+      statSync: (file) => {
+        statLookupAttempts.push(file);
+        return {
+          isFile: () => file === "/tools/chromium",
+        };
+      },
     }),
     "/tools/chromium",
   );
-  assert.deepEqual(commandLookupAttempts, [
+  assert.deepEqual(statLookupAttempts, [
     "/missing/chromium",
     "/tools/chromium",
   ]);
+  assert.deepEqual(commandLookupAttempts, ["/tools/chromium"]);
 
   const safeLookupDir = fs.mkdtempSync(path.join(os.tmpdir(), "tracy-browser-path-"));
   try {
@@ -306,6 +314,46 @@ function assertBrowserDiscovery() {
     assert.equal(fs.existsSync(markerPath), false);
   } finally {
     fs.rmSync(safeLookupDir, {
+      force: true,
+      maxRetries: 5,
+      recursive: true,
+      retryDelay: 100,
+    });
+  }
+
+  const directoryLookupRoot = fs.mkdtempSync(path.join(os.tmpdir(), "tracy-browser-dir-"));
+  try {
+    const directoryEntry = path.join(directoryLookupRoot, "directory");
+    const binaryEntry = path.join(directoryLookupRoot, "binary");
+    const browserDirectory = path.join(directoryEntry, "chromium");
+    const browserPath = path.join(binaryEntry, "chromium");
+    fs.mkdirSync(browserDirectory, { recursive: true });
+    fs.mkdirSync(binaryEntry, { recursive: true });
+    fs.writeFileSync(browserPath, "#!/bin/sh\nexit 0\n");
+    fs.chmodSync(browserPath, 0o755);
+
+    assert.equal(
+      safeCommandPath("chromium", {
+        env: { PATH: `${directoryEntry}:${binaryEntry}` },
+        pathDelimiter: ":",
+      }),
+      browserPath,
+    );
+    assert.equal(
+      browserExecutablePath({
+        commandNames: ["chromium"],
+        commandPath: (command) =>
+          safeCommandPath(command, {
+            env: { PATH: `${directoryEntry}:${binaryEntry}` },
+            pathDelimiter: ":",
+          }),
+        env: {},
+        existsSync: fs.existsSync,
+      }),
+      browserPath,
+    );
+  } finally {
+    fs.rmSync(directoryLookupRoot, {
       force: true,
       maxRetries: 5,
       recursive: true,

--- a/tools/dist-browser-helpers-check.js
+++ b/tools/dist-browser-helpers-check.js
@@ -212,6 +212,7 @@ function assertBrowserDiscovery() {
   const exists = new Set([
     "/custom/chrome",
     "/env/chrome",
+    "/usr/bin/chromium",
     "/pw/chromium-120/chrome-linux64/chrome",
   ]);
   const existsSync = (file) => exists.has(file);
@@ -251,6 +252,16 @@ function assertBrowserDiscovery() {
     browserExecutablePath({
       commandNames: [],
       commandPath,
+      env: {},
+      existsSync,
+      playwrightChromes: ["/pw/chromium-120/chrome-linux64/chrome"],
+    }),
+    "/pw/chromium-120/chrome-linux64/chrome",
+  );
+  assert.equal(
+    browserExecutablePath({
+      commandNames: ["chromium"],
+      commandPath: () => "chromium",
       env: {},
       existsSync,
       playwrightChromes: ["/pw/chromium-120/chrome-linux64/chrome"],

--- a/tools/dist-browser-helpers-check.js
+++ b/tools/dist-browser-helpers-check.js
@@ -11,6 +11,7 @@ const {
   CACHE_CONTROL,
   browserExecutablePath,
   cachedPlaywrightChromes,
+  commandPath: safeCommandPath,
   contentType,
   createDistServer,
   resolveDistPath,
@@ -205,7 +206,7 @@ function assertPathAndMimeHelpers() {
 
 function assertBrowserDiscovery() {
   const commands = [];
-  const commandPath = (command) => {
+  const commandPathStub = (command) => {
     commands.push(command);
     return command === "chromium" ? "/usr/bin/chromium" : "";
   };
@@ -219,7 +220,7 @@ function assertBrowserDiscovery() {
 
   assert.equal(
     browserExecutablePath({
-      commandPath,
+      commandPath: commandPathStub,
       env: { PUPPETEER_EXECUTABLE_PATH: "/env/chrome" },
       existsSync,
       explicitPath: "/custom/chrome",
@@ -228,7 +229,7 @@ function assertBrowserDiscovery() {
   );
   assert.equal(
     browserExecutablePath({
-      commandPath,
+      commandPath: commandPathStub,
       env: { TRACY_INTERACTIVE_INGEST_BROWSER: "/env/chrome" },
       envNames: ["TRACY_INTERACTIVE_INGEST_BROWSER"],
       existsSync,
@@ -237,7 +238,7 @@ function assertBrowserDiscovery() {
   );
   assert.equal(
     browserExecutablePath({
-      commandPath,
+      commandPath: commandPathStub,
       env: {},
       existsSync,
     }),
@@ -251,13 +252,67 @@ function assertBrowserDiscovery() {
   assert.equal(
     browserExecutablePath({
       commandNames: [],
-      commandPath,
+      commandPath: commandPathStub,
       env: {},
       existsSync,
       playwrightChromes: ["/pw/chromium-120/chrome-linux64/chrome"],
     }),
     "/pw/chromium-120/chrome-linux64/chrome",
   );
+
+  const commandLookupAttempts = [];
+  assert.equal(
+    safeCommandPath("chromium", {
+      accessSync: (file) => {
+        commandLookupAttempts.push(file);
+        if (file !== "/tools/chromium") {
+          const error = new Error("missing");
+          error.code = "ENOENT";
+          throw error;
+        }
+      },
+      env: { PATH: "/missing:/tools" },
+      pathDelimiter: ":",
+    }),
+    "/tools/chromium",
+  );
+  assert.deepEqual(commandLookupAttempts, [
+    "/missing/chromium",
+    "/tools/chromium",
+  ]);
+
+  const safeLookupDir = fs.mkdtempSync(path.join(os.tmpdir(), "tracy-browser-path-"));
+  try {
+    const browserPath = path.join(safeLookupDir, "chromium");
+    const markerPath = path.join(safeLookupDir, "shell-candidate-ran");
+    fs.writeFileSync(browserPath, "#!/bin/sh\nexit 0\n");
+    fs.chmodSync(browserPath, 0o755);
+
+    assert.equal(
+      browserExecutablePath({
+        commandNames: ["chromium"],
+        commandPath: (command) =>
+          safeCommandPath(command, {
+            env: { PATH: safeLookupDir },
+          }),
+        env: {
+          TRACY_INTERACTIVE_INGEST_BROWSER: `$(touch ${markerPath})`,
+        },
+        envNames: ["TRACY_INTERACTIVE_INGEST_BROWSER"],
+        existsSync: fs.existsSync,
+      }),
+      browserPath,
+    );
+    assert.equal(fs.existsSync(markerPath), false);
+  } finally {
+    fs.rmSync(safeLookupDir, {
+      force: true,
+      maxRetries: 5,
+      recursive: true,
+      retryDelay: 100,
+    });
+  }
+
   assert.equal(
     browserExecutablePath({
       commandNames: ["chromium"],

--- a/tools/dist-browser-helpers-check.js
+++ b/tools/dist-browser-helpers-check.js
@@ -107,6 +107,88 @@ async function assertServerResponseModes() {
   });
 }
 
+async function withoutUnhandledRejection(run) {
+  let unhandled = null;
+  const onUnhandledRejection = (error) => {
+    unhandled = error;
+  };
+
+  process.on("unhandledRejection", onUnhandledRejection);
+  try {
+    await run();
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(unhandled, null);
+  } finally {
+    process.off("unhandledRejection", onUnhandledRejection);
+  }
+}
+
+async function assertServerFailureModes() {
+  await withTempDist(async (distDir) => {
+    const disappearingFile = await createDistServer(distDir, {
+      fsPromises: {
+        readFile: async () => {
+          const error = new Error("missing after stat");
+          error.code = "ENOENT";
+          throw error;
+        },
+        stat: async () => ({ isFile: () => true }),
+      },
+    });
+    try {
+      const response = await request(`${disappearingFile.origin}/index.html`);
+      assert.equal(response.statusCode, 404);
+      assert.equal(response.body.toString("utf8"), "not found");
+    } finally {
+      await disappearingFile.close();
+    }
+
+    const unreadableFile = await createDistServer(distDir, {
+      fsPromises: {
+        readFile: async () => {
+          const error = new Error("permission denied");
+          error.code = "EACCES";
+          throw error;
+        },
+        stat: async () => ({ isFile: () => true }),
+      },
+    });
+    try {
+      await withoutUnhandledRejection(async () => {
+        await assert.rejects(
+          request(`${unreadableFile.origin}/index.html`),
+          /socket hang up|aborted/,
+        );
+      });
+    } finally {
+      await unreadableFile.close();
+    }
+
+    const brokenGzip = await createDistServer(distDir, {
+      fsPromises: {
+        readFile: async () => Buffer.from("<!doctype html>\n"),
+        stat: async () => ({ isFile: () => true }),
+      },
+      gzip: true,
+      gzipSync: () => {
+        throw new Error("gzip failed");
+      },
+    });
+    try {
+      await withoutUnhandledRejection(async () => {
+        await assert.rejects(
+          request(`${brokenGzip.origin}/index.html`, {
+            headers: { "Accept-Encoding": "gzip" },
+          }),
+          /socket hang up|aborted/,
+        );
+      });
+    } finally {
+      await brokenGzip.close();
+    }
+  });
+}
+
 function assertPathAndMimeHelpers() {
   const distDir = path.resolve("/repo/dist");
 
@@ -267,6 +349,7 @@ async function main() {
   assertInteractiveCheckUsesSharedHelpers();
   assertDelayedWasmImportBoundary();
   await assertServerResponseModes();
+  await assertServerFailureModes();
 }
 
 main().catch((error) => {

--- a/tools/dist-browser-helpers.js
+++ b/tools/dist-browser-helpers.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const childProcess = require("node:child_process");
 const fs = require("node:fs");
 const fsp = require("node:fs/promises");
 const http = require("node:http");
@@ -187,14 +186,27 @@ async function createDistServer(distDir, options = {}) {
 }
 
 function commandPath(command, options = {}) {
-  const spawnSync = options.spawnSync ?? childProcess.spawnSync;
-  const result = spawnSync(
-    "bash",
-    ["-lc", `command -v ${JSON.stringify(command)}`],
-    { encoding: "utf8" },
-  );
+  if (path.isAbsolute(command) || command.includes(path.sep)) {
+    return "";
+  }
 
-  return result.status === 0 ? result.stdout.trim() : "";
+  const env = options.env ?? process.env;
+  const accessSync = options.accessSync ?? fs.accessSync;
+  const pathEnv = options.pathEnv ?? env.PATH ?? "";
+  const pathDelimiter = options.pathDelimiter ?? path.delimiter;
+
+  for (const entry of String(pathEnv).split(pathDelimiter)) {
+    const dir = entry === "" ? "." : entry;
+    const file = path.resolve(dir, command);
+    try {
+      accessSync(file, fs.constants.X_OK);
+      return file;
+    } catch {
+      // Keep searching PATH entries until an executable filesystem path exists.
+    }
+  }
+
+  return "";
 }
 
 function cachedPlaywrightChromes(options = {}) {

--- a/tools/dist-browser-helpers.js
+++ b/tools/dist-browser-helpers.js
@@ -185,28 +185,37 @@ async function createDistServer(distDir, options = {}) {
   };
 }
 
+function isExecutableFile(file, options = {}) {
+  const accessSync = options.accessSync ?? fs.accessSync;
+  const statSync = options.statSync ?? fs.statSync;
+
+  try {
+    if (!statSync(file).isFile()) {
+      return false;
+    }
+    accessSync(file, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function commandPath(command, options = {}) {
   if (path.isAbsolute(command) || command.includes(path.sep)) {
     return "";
   }
 
   const env = options.env ?? process.env;
-  const accessSync = options.accessSync ?? fs.accessSync;
-  const statSync = options.statSync ?? fs.statSync;
+  const isExecutableFileFn =
+    options.isExecutableFile ?? ((file) => isExecutableFile(file, options));
   const pathEnv = options.pathEnv ?? env.PATH ?? "";
   const pathDelimiter = options.pathDelimiter ?? path.delimiter;
 
   for (const entry of String(pathEnv).split(pathDelimiter)) {
     const dir = entry === "" ? "." : entry;
     const file = path.resolve(dir, command);
-    try {
-      if (!statSync(file).isFile()) {
-        continue;
-      }
-      accessSync(file, fs.constants.X_OK);
+    if (isExecutableFileFn(file)) {
       return file;
-    } catch {
-      // Keep searching PATH entries until an executable regular file exists.
     }
   }
 
@@ -233,8 +242,9 @@ function cachedPlaywrightChromes(options = {}) {
 
 function browserExecutablePath(options = {}) {
   const env = options.env ?? process.env;
-  const existsSync = options.existsSync ?? fs.existsSync;
   const commandPathFn = options.commandPath ?? commandPath;
+  const isExecutableFileFn =
+    options.isExecutableFile ?? ((file) => isExecutableFile(file, options));
   const candidates = [
     options.explicitPath,
     ...(options.envNames ?? SHARED_BROWSER_ENV).map((name) => env[name]),
@@ -243,12 +253,10 @@ function browserExecutablePath(options = {}) {
   ].filter(Boolean);
 
   for (const candidate of candidates) {
-    const resolved = path.isAbsolute(candidate) ? "" : commandPathFn(candidate);
-    if (path.isAbsolute(resolved) && existsSync(resolved)) {
+    const isPathCandidate = path.isAbsolute(candidate) || candidate.includes(path.sep);
+    const resolved = isPathCandidate ? path.resolve(candidate) : commandPathFn(candidate);
+    if (path.isAbsolute(resolved) && isExecutableFileFn(resolved)) {
       return resolved;
-    }
-    if (path.isAbsolute(candidate) && existsSync(candidate)) {
-      return candidate;
     }
   }
 
@@ -267,6 +275,7 @@ module.exports = {
   commandPath,
   contentType,
   createDistServer,
+  isExecutableFile,
   resolveDistPath,
   shouldGzip,
 };

--- a/tools/dist-browser-helpers.js
+++ b/tools/dist-browser-helpers.js
@@ -1,0 +1,244 @@
+"use strict";
+
+const childProcess = require("node:child_process");
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const http = require("node:http");
+const os = require("node:os");
+const path = require("node:path");
+const zlib = require("node:zlib");
+
+const CACHE_CONTROL = Object.freeze({
+  IMMUTABLE: "public, max-age=31536000, immutable",
+  NO_STORE: "no-store",
+});
+const MIME_TYPES = Object.freeze({
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".wasm": "application/wasm",
+  ".webmanifest": "application/manifest+json",
+});
+const GZIP_EXTENSIONS = new Set([
+  ".html",
+  ".js",
+  ".json",
+  ".mjs",
+  ".svg",
+  ".wasm",
+  ".webmanifest",
+]);
+const CHROME_COMMANDS = Object.freeze([
+  "google-chrome",
+  "google-chrome-stable",
+  "chromium",
+  "chromium-browser",
+]);
+const SHARED_BROWSER_ENV = Object.freeze([
+  "PUPPETEER_EXECUTABLE_PATH",
+  "CHROME_PATH",
+]);
+
+function contentType(file, mimeTypes = MIME_TYPES) {
+  return mimeTypes[path.extname(file)] ?? "application/octet-stream";
+}
+
+function acceptsGzip(request) {
+  return /\bgzip\b/.test(request.headers["accept-encoding"] ?? "");
+}
+
+function shouldGzip(file, gzipExtensions = GZIP_EXTENSIONS) {
+  return gzipExtensions.has(path.extname(file));
+}
+
+function hasUnsafeDotSegment(requestUrl) {
+  const pathname = String(requestUrl).split(/[?#]/, 1)[0];
+
+  for (const segment of pathname.split("/")) {
+    try {
+      if (decodeURIComponent(segment) === "..") {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function resolveDistPath(distDir, requestUrl) {
+  if (hasUnsafeDotSegment(requestUrl)) {
+    return null;
+  }
+
+  let url;
+  try {
+    url = new URL(requestUrl, "http://127.0.0.1");
+  } catch {
+    return null;
+  }
+
+  let relativePath;
+  try {
+    relativePath =
+      url.pathname === "/" ? "index.html" : decodeURIComponent(url.pathname.replace(/^\//, ""));
+  } catch {
+    return null;
+  }
+
+  const root = path.resolve(distDir);
+  const file = path.resolve(root, relativePath);
+
+  return file === root || file.startsWith(`${root}${path.sep}`) ? file : null;
+}
+
+function sendNotFound(response) {
+  response.writeHead(404);
+  response.end("not found");
+}
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  return server.address().port;
+}
+
+async function serveFile(request, response, file, options) {
+  let stat;
+  try {
+    stat = await options.fsPromises.stat(file);
+  } catch (error) {
+    if (error.code === "ENOENT" || error.code === "ENOTDIR") {
+      sendNotFound(response);
+      return;
+    }
+    response.destroy(error);
+    return;
+  }
+
+  if (!stat.isFile()) {
+    sendNotFound(response);
+    return;
+  }
+
+  const source = await options.fsPromises.readFile(file);
+  const body =
+    options.gzip && acceptsGzip(request) && shouldGzip(file, options.gzipExtensions)
+      ? options.gzipSync(source)
+      : source;
+  const headers = {
+    "Content-Length": body.byteLength,
+    "Content-Type": contentType(file, options.mimeTypes),
+  };
+
+  if (options.cacheControl !== null) {
+    headers["Cache-Control"] = options.cacheControl;
+  }
+  if (body !== source) {
+    headers["Content-Encoding"] = "gzip";
+    headers.Vary = "Accept-Encoding";
+  }
+
+  response.writeHead(200, headers);
+  response.end(body);
+}
+
+async function createDistServer(distDir, options = {}) {
+  const serverOptions = {
+    cacheControl: options.cacheControl ?? null,
+    fsPromises: options.fsPromises ?? fsp,
+    gzip: options.gzip === true,
+    gzipExtensions: options.gzipExtensions ?? GZIP_EXTENSIONS,
+    gzipSync: options.gzipSync ?? zlib.gzipSync,
+    mimeTypes: options.mimeTypes ?? MIME_TYPES,
+  };
+  const server = http.createServer(async (request, response) => {
+    const file = resolveDistPath(distDir, request.url);
+    if (file === null) {
+      sendNotFound(response);
+      return;
+    }
+
+    await serveFile(request, response, file, serverOptions);
+  });
+  const port = await listen(server);
+
+  return {
+    close: () => new Promise((resolve) => server.close(resolve)),
+    origin: `http://127.0.0.1:${port}`,
+  };
+}
+
+function commandPath(command, options = {}) {
+  const spawnSync = options.spawnSync ?? childProcess.spawnSync;
+  const result = spawnSync(
+    "bash",
+    ["-lc", `command -v ${JSON.stringify(command)}`],
+    { encoding: "utf8" },
+  );
+
+  return result.status === 0 ? result.stdout.trim() : "";
+}
+
+function cachedPlaywrightChromes(options = {}) {
+  const cacheRoot = options.cacheRoot ?? path.join(options.homeDir ?? os.homedir(), ".cache", "ms-playwright");
+  const existsSync = options.existsSync ?? fs.existsSync;
+  const readdirSync = options.readdirSync ?? fs.readdirSync;
+
+  if (!existsSync(cacheRoot)) {
+    return [];
+  }
+
+  return readdirSync(cacheRoot)
+    .filter((entry) => /^chromium-\d+$/.test(entry))
+    .sort((left, right) => right.localeCompare(left, undefined, { numeric: true }))
+    .flatMap((entry) => [
+      path.join(cacheRoot, entry, "chrome-linux64", "chrome"),
+      path.join(cacheRoot, entry, "chrome-linux", "chrome"),
+    ]);
+}
+
+function browserExecutablePath(options = {}) {
+  const env = options.env ?? process.env;
+  const existsSync = options.existsSync ?? fs.existsSync;
+  const commandPathFn = options.commandPath ?? commandPath;
+  const candidates = [
+    options.explicitPath,
+    ...(options.envNames ?? SHARED_BROWSER_ENV).map((name) => env[name]),
+    ...(options.commandNames ?? CHROME_COMMANDS),
+    ...(options.playwrightChromes ?? []),
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    const resolved = path.isAbsolute(candidate) ? "" : commandPathFn(candidate);
+    if (resolved) {
+      return resolved;
+    }
+    if (path.isAbsolute(candidate) && existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(options.errorMessage ?? "Chrome/Chromium not found");
+}
+
+module.exports = {
+  CACHE_CONTROL,
+  CHROME_COMMANDS,
+  GZIP_EXTENSIONS,
+  MIME_TYPES,
+  SHARED_BROWSER_ENV,
+  acceptsGzip,
+  browserExecutablePath,
+  cachedPlaywrightChromes,
+  commandPath,
+  contentType,
+  createDistServer,
+  resolveDistPath,
+  shouldGzip,
+};

--- a/tools/dist-browser-helpers.js
+++ b/tools/dist-browser-helpers.js
@@ -192,6 +192,7 @@ function commandPath(command, options = {}) {
 
   const env = options.env ?? process.env;
   const accessSync = options.accessSync ?? fs.accessSync;
+  const statSync = options.statSync ?? fs.statSync;
   const pathEnv = options.pathEnv ?? env.PATH ?? "";
   const pathDelimiter = options.pathDelimiter ?? path.delimiter;
 
@@ -199,10 +200,13 @@ function commandPath(command, options = {}) {
     const dir = entry === "" ? "." : entry;
     const file = path.resolve(dir, command);
     try {
+      if (!statSync(file).isFile()) {
+        continue;
+      }
       accessSync(file, fs.constants.X_OK);
       return file;
     } catch {
-      // Keep searching PATH entries until an executable filesystem path exists.
+      // Keep searching PATH entries until an executable regular file exists.
     }
   }
 

--- a/tools/dist-browser-helpers.js
+++ b/tools/dist-browser-helpers.js
@@ -100,6 +100,10 @@ function sendNotFound(response) {
   response.end("not found");
 }
 
+function destroyResponse(response, error) {
+  response.destroy(error);
+}
+
 async function listen(server) {
   await new Promise((resolve, reject) => {
     server.once("error", reject);
@@ -126,26 +130,34 @@ async function serveFile(request, response, file, options) {
     return;
   }
 
-  const source = await options.fsPromises.readFile(file);
-  const body =
-    options.gzip && acceptsGzip(request) && shouldGzip(file, options.gzipExtensions)
-      ? options.gzipSync(source)
-      : source;
-  const headers = {
-    "Content-Length": body.byteLength,
-    "Content-Type": contentType(file, options.mimeTypes),
-  };
+  try {
+    const source = await options.fsPromises.readFile(file);
+    const body =
+      options.gzip && acceptsGzip(request) && shouldGzip(file, options.gzipExtensions)
+        ? options.gzipSync(source)
+        : source;
+    const headers = {
+      "Content-Length": body.byteLength,
+      "Content-Type": contentType(file, options.mimeTypes),
+    };
 
-  if (options.cacheControl !== null) {
-    headers["Cache-Control"] = options.cacheControl;
-  }
-  if (body !== source) {
-    headers["Content-Encoding"] = "gzip";
-    headers.Vary = "Accept-Encoding";
-  }
+    if (options.cacheControl !== null) {
+      headers["Cache-Control"] = options.cacheControl;
+    }
+    if (body !== source) {
+      headers["Content-Encoding"] = "gzip";
+      headers.Vary = "Accept-Encoding";
+    }
 
-  response.writeHead(200, headers);
-  response.end(body);
+    response.writeHead(200, headers);
+    response.end(body);
+  } catch (error) {
+    if (error.code === "ENOENT" || error.code === "ENOTDIR") {
+      sendNotFound(response);
+      return;
+    }
+    destroyResponse(response, error);
+  }
 }
 
 async function createDistServer(distDir, options = {}) {

--- a/tools/dist-browser-helpers.js
+++ b/tools/dist-browser-helpers.js
@@ -228,7 +228,7 @@ function browserExecutablePath(options = {}) {
 
   for (const candidate of candidates) {
     const resolved = path.isAbsolute(candidate) ? "" : commandPathFn(candidate);
-    if (resolved) {
+    if (path.isAbsolute(resolved) && existsSync(resolved)) {
       return resolved;
     }
     if (path.isAbsolute(candidate) && existsSync(candidate)) {

--- a/tools/interactive-ingest-browser-check.js
+++ b/tools/interactive-ingest-browser-check.js
@@ -1,14 +1,18 @@
 #!/usr/bin/env node
 
 const assert = require("node:assert/strict");
-const childProcess = require("node:child_process");
 const fs = require("node:fs");
 const fsp = require("node:fs/promises");
-const http = require("node:http");
 const os = require("node:os");
 const path = require("node:path");
 const puppeteer = require("puppeteer-core");
 const { repoPath } = require("./acceptance-wasm-helpers.js");
+const {
+  CACHE_CONTROL,
+  browserExecutablePath: findBrowserExecutablePath,
+  cachedPlaywrightChromes,
+  createDistServer,
+} = require("./dist-browser-helpers.js");
 
 const DIST_DIR = repoPath("dist");
 const RUNTIME_SPEC = JSON.parse(
@@ -22,116 +26,23 @@ const FILE_CHOOSER_TIMEOUT = FILE_CHOOSER_TIMEOUT_MS.value;
 const FIRST_EVENTS_BUDGET_MS = 100;
 const BROWSER_TIMEOUT_MS = 15_000;
 
-function contentType(file) {
-  switch (path.extname(file)) {
-    case ".html":
-      return "text/html; charset=utf-8";
-    case ".js":
-    case ".mjs":
-      return "text/javascript; charset=utf-8";
-    case ".json":
-      return "application/json; charset=utf-8";
-    case ".wasm":
-      return "application/wasm";
-    case ".webmanifest":
-      return "application/manifest+json";
-    default:
-      return "application/octet-stream";
-  }
-}
-
-function commandPath(command) {
-  const result = childProcess.spawnSync(
-    "bash",
-    ["-lc", `command -v ${JSON.stringify(command)}`],
-    { encoding: "utf8" },
-  );
-
-  return result.status === 0 ? result.stdout.trim() : "";
-}
-
-function cachedPlaywrightChromes() {
-  const cacheRoot = path.join(os.homedir(), ".cache", "ms-playwright");
-  if (!fs.existsSync(cacheRoot)) {
-    return [];
-  }
-
-  return fs.readdirSync(cacheRoot)
-    .filter((entry) => /^chromium-\d+$/.test(entry))
-    .sort((left, right) => right.localeCompare(left, undefined, { numeric: true }))
-    .flatMap((entry) => [
-      path.join(cacheRoot, entry, "chrome-linux64", "chrome"),
-      path.join(cacheRoot, entry, "chrome-linux", "chrome"),
-    ]);
-}
-
 function browserExecutablePath() {
-  const candidates = [
-    process.env.TRACY_INTERACTIVE_INGEST_BROWSER,
-    process.env.PUPPETEER_EXECUTABLE_PATH,
-    process.env.CHROME_PATH,
-    commandPath("google-chrome"),
-    commandPath("google-chrome-stable"),
-    commandPath("chromium"),
-    commandPath("chromium-browser"),
-    ...cachedPlaywrightChromes(),
-  ].filter(Boolean);
-
-  for (const candidate of candidates) {
-    if (fs.existsSync(candidate)) {
-      return candidate;
-    }
-  }
-
-  throw new Error("Chrome/Chromium not found for interactive ingest browser check");
-}
-
-function resolveDistPath(requestUrl) {
-  const url = new URL(requestUrl, "http://127.0.0.1");
-  const relativePath =
-    url.pathname === "/" ? "index.html" : decodeURIComponent(url.pathname.replace(/^\//, ""));
-  const file = path.resolve(DIST_DIR, relativePath);
-  const root = path.resolve(DIST_DIR);
-
-  return file === root || file.startsWith(`${root}${path.sep}`) ? file : null;
+  return findBrowserExecutablePath({
+    envNames: [
+      "TRACY_INTERACTIVE_INGEST_BROWSER",
+      "PUPPETEER_EXECUTABLE_PATH",
+      "CHROME_PATH",
+    ],
+    errorMessage: "Chrome/Chromium not found for interactive ingest browser check",
+    playwrightChromes: cachedPlaywrightChromes(),
+  });
 }
 
 async function serveDist() {
-  const server = http.createServer(async (request, response) => {
-    const file = resolveDistPath(request.url);
-    if (file === null) {
-      response.writeHead(404);
-      response.end("not found");
-      return;
-    }
-
-    try {
-      const body = await fsp.readFile(file);
-      response.writeHead(200, {
-        "Cache-Control": "no-store",
-        "Content-Length": body.byteLength,
-        "Content-Type": contentType(file),
-      });
-      response.end(body);
-    } catch (error) {
-      if (error.code === "ENOENT" || error.code === "ENOTDIR") {
-        response.writeHead(404);
-        response.end("not found");
-        return;
-      }
-      response.destroy(error);
-    }
+  return createDistServer(DIST_DIR, {
+    cacheControl: CACHE_CONTROL.NO_STORE,
+    gzip: false,
   });
-
-  await new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-
-  return {
-    close: () => new Promise((resolve) => server.close(resolve)),
-    origin: `http://127.0.0.1:${server.address().port}`,
-  };
 }
 
 async function writeTraceFile(file) {


### PR DESCRIPTION
Fixes #306.

Finishes moving the browser checks onto the shared dist serving and Chrome/Chromium discovery helpers, with app-load gzip/cache behavior, interactive no-store serving, and the delayed Wasm import boundary still protected. Tightens browser discovery so command candidates are never shell-evaluated, PATH matches must be executable regular files, repo-relative browser paths still work, and false positives do not stop fallback search.

Fixes #306.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (12)</summary>

- [x] [Update shared browser command lookup so PATH matches are accepted only when they are executable regular files, skip executable/searchable directories, preserve fallback behavior, and add focused regression coverage for a browser-named directory before a later valid fallback.](https://github.com/rhencke/tracy/pull/330#discussion_r3226668106) <!-- type:thread -->
- [x] [Update shared browser discovery to accept explicit and environment-provided relative browser executable paths when they resolve to executable regular files, while preserving shell-free command lookup and fallback ordering. Add focused regression coverage for a repo-relative browser path.](https://github.com/rhencke/tracy/pull/330#discussion_r3226668111) <!-- type:thread -->
- [x] [Update shared browser discovery to accept explicit and environment-provided relative browser executable paths when they resolve to executable regular files, while preserving shell-free command lookup and fallback ordering. Add focused regression coverage for a repo-relative browser path.](https://github.com/rhencke/tracy/pull/330#discussion_r3226668096) <!-- type:thread -->
- [x] [Update shared browser command lookup so PATH matches are accepted only when they are executable regular files, skip executable/searchable directories, preserve fallback behavior, and add focused regression coverage for a browser-named directory before a later valid fallback.](https://github.com/rhencke/tracy/pull/330#discussion_r3226668088) <!-- type:thread -->
- [x] Validate resolved browser command paths before accepting them <!-- type:spec -->
- [x] [Update shared browser command lookup so browser candidate strings are never evaluated by a shell. Replace the `bash -lc` command lookup with a non-shell PATH lookup or equivalent safe implementation, preserve explicit/env/command/Playwright fallback behavior, and add focused regression coverage proving a `$()`-style candidate is not executed and does not block later valid fallbacks.](https://github.com/rhencke/tracy/pull/330#discussion_r3226410300) <!-- type:thread -->
- [x] [Update shared browser executable discovery to accept command lookup results only when they resolve to an existing executable filesystem path, skip non-path shell function/name outputs, preserve fallback ordering, and add a focused regression check for that behavior.](https://github.com/rhencke/tracy/pull/330#discussion_r3226410286) <!-- type:thread -->
- [x] [Handle read, gzip, and response write failures in the shared dist server so ENOENT/ENOTDIR after stat returns 404, other read failures destroy the response without an unhandled rejection, and add a focused regression check for that behavior.](https://github.com/rhencke/tracy/pull/330#discussion_r3226410268) <!-- type:thread -->
- [x] Use shared helpers in the interactive browser check <!-- type:spec -->
- [x] Add shared-browser invariant checks <!-- type:spec -->
- [x] Use shared helpers in the app-load benchmark <!-- type:spec -->
- [x] Add shared dist server and browser discovery helpers <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->