### PR TITLE
LOC #4b - Shared browser readiness diagnostics (closes #307)

### DIFF
--- a/tools/app-load-bench.js
+++ b/tools/app-load-bench.js
@@ -11,6 +11,7 @@ const {
   CACHE_CONTROL,
   browserExecutablePath,
   createDistServer,
+  waitForBrowserReadiness,
 } = require("./dist-browser-helpers.js");
 
 const ROOT_DIR = path.resolve(__dirname, "..");
@@ -499,6 +500,34 @@ async function waitUntil(predicate, timeoutMs = DEFAULT_TIMEOUT_MS) {
   throw new Error("timed out waiting for page condition");
 }
 
+async function evaluateReadinessPredicate(cdp, page, predicate) {
+  const result = await cdp.send("Runtime.evaluate", {
+    awaitPromise: true,
+    expression: `(${predicate.toString()})()`,
+    returnByValue: true,
+  }, page.sessionId);
+
+  if (result.exceptionDetails !== undefined) {
+    const description =
+      result.exceptionDetails.exception?.description ??
+      result.exceptionDetails.text ??
+      "unknown Runtime.evaluate failure";
+    throw new Error(`failed to evaluate browser readiness predicate: ${description}`);
+  }
+
+  return result.result?.value;
+}
+
+function waitForCdpBrowserReadiness(cdp, page, label, predicate, timeoutMs = DEFAULT_TIMEOUT_MS) {
+  return waitForBrowserReadiness({
+    evaluate: (readinessPredicate) =>
+      evaluateReadinessPredicate(cdp, page, readinessPredicate),
+    label,
+    predicate,
+    timeoutMs,
+  });
+}
+
 function isBenignLoadingFailure(failure) {
   return BENIGN_LOADING_FAILURES.some(
     (benignFailure) =>
@@ -783,27 +812,12 @@ async function navigateAndMeasure(cdp, page, url, options = {}) {
   const loaded = waitForSessionEvent(cdp, page.sessionId, "Page.loadEventFired");
   const navigation = await cdp.send("Page.navigate", { url }, page.sessionId);
   await loaded;
-  await waitUntil(async () => {
-    const result = await cdp.send("Runtime.evaluate", {
-      expression: `(() => {
-        const error = document.querySelector('[role="alert"]')?.textContent ?? "";
-        const detail = globalThis.__TRACY_APP_LOAD_ERROR__ ?? "";
-        return {
-          coreReady: performance.getEntriesByName("tracy.core.ready").length > 0,
-          detail,
-          error,
-        };
-      })()`,
-      returnByValue: true,
-    }, page.sessionId);
-    const status = result.result?.value ?? {};
-
-    if (status.error) {
-      const detail = status.detail ? ` (${status.detail})` : "";
-      throw new Error(`page reported app-load failure: ${status.error}${detail}`);
-    }
-    return status.coreReady === true;
-  });
+  await waitForCdpBrowserReadiness(
+    cdp,
+    page,
+    "browser core did not become ready",
+    () => performance.getEntriesByName("tracy.core.ready").length > 0,
+  );
   const coreReadyWallMs = await performanceMarkWallMs(cdp, page, "tracy.core.ready");
   coreRequestIds = navigationFrameRequestIds(
     coreTransferRequestIds(
@@ -822,28 +836,12 @@ async function navigateAndMeasure(cdp, page, url, options = {}) {
     requestUrls,
     ["host/wasm-modules.mjs"],
   );
-  await waitUntil(async () => {
-    const result = await cdp.send("Runtime.evaluate", {
-      expression: `(() => {
-        const error = document.querySelector('[role="alert"]')?.textContent ?? "";
-        const detail = globalThis.__TRACY_APP_LOAD_ERROR__ ?? "";
-        return {
-          detail,
-          error,
-          fullReady: performance.getEntriesByName("tracy.app.ready").length > 0,
-        };
-      })()`,
-      returnByValue: true,
-    }, page.sessionId);
-    const status = result.result?.value ?? {};
-
-    if (status.error) {
-      const detail = status.detail ? ` (${status.detail})` : "";
-      throw new Error(`page reported app-load failure: ${status.error}${detail}`);
-    }
-
-    return status.fullReady === true;
-  });
+  await waitForCdpBrowserReadiness(
+    cdp,
+    page,
+    "browser app did not become ready",
+    () => performance.getEntriesByName("tracy.app.ready").length > 0,
+  );
   await waitUntil(() =>
     unfinishedTransferRequestIds(
       coreRequestIds,
@@ -1470,7 +1468,11 @@ function runSelfTest() {
   assert.match(bootstrap, /BOOTSTRAP_WASM_MEMORY\.BOOTSTRAP_MEMORY_INITIAL_PAGES/);
   assert.match(
     navigateAndMeasure.toString(),
-    /coreReady: performance\.getEntriesByName\("tracy\.core\.ready"\)\.length > 0/,
+    /waitForCdpBrowserReadiness\([\s\S]+performance\.getEntriesByName\("tracy\.core\.ready"\)\.length > 0/,
+  );
+  assert.match(
+    navigateAndMeasure.toString(),
+    /waitForCdpBrowserReadiness\([\s\S]+performance\.getEntriesByName\("tracy\.app\.ready"\)\.length > 0/,
   );
   assert.match(
     navigateAndMeasure.toString(),
@@ -1544,9 +1546,8 @@ function runSelfTest() {
   );
   assert.match(
     navigateAndMeasure.toString(),
-    /fullReady: performance\.getEntriesByName\("tracy\.app\.ready"\)\.length > 0/,
+    /waitForCdpBrowserReadiness\([\s\S]+"browser app did not become ready"[\s\S]+performance\.getEntriesByName\("tracy\.app\.ready"\)\.length > 0/,
   );
-  assert.match(navigateAndMeasure.toString(), /return status\.fullReady === true/);
   assert.match(
     indexHtml,
     /<link rel="modulepreload" href="bootstrap\.mjs">/,

--- a/tools/dist-browser-helpers-check.js
+++ b/tools/dist-browser-helpers-check.js
@@ -522,12 +522,13 @@ async function assertBrowserReadinessDiagnostics() {
 
   await assert.rejects(
     waitForBrowserReadiness({
+      collectState: async () => ({ custom: "state" }),
       evaluate: async (fn) => fn(),
       label: "test timeout",
       predicate: () => false,
       timeoutMs: 0,
     }),
-    /test timeout; browser readiness state=/,
+    /test timeout; browser readiness state=\{"custom":"state"\}/,
   );
 
   assert.deepEqual(
@@ -544,8 +545,13 @@ function assertAppLoadUsesSharedHelpers() {
   const source = readRepoFile("tools/app-load-bench.js");
 
   assert.match(source, /require\("\.\/dist-browser-helpers\.js"\)/);
+  assert.match(source, /waitForBrowserReadiness/);
+  assert.match(source, /function waitForCdpBrowserReadiness/);
+  assert.match(source, /"browser core did not become ready"/);
+  assert.match(source, /"browser app did not become ready"/);
   assert.match(source, /browserExecutablePath\(\{\s*errorMessage: "Chrome\/Chromium not found; set TRACY_APP_LOAD_BROWSER",\s*explicitPath,/);
   assert.match(source, /createDistServer\(distDir,\s*\{\s*cacheControl: CACHE_CONTROL\.IMMUTABLE,\s*gzip: true,/);
+  assert.doesNotMatch(source, /page reported app-load failure/);
   assert.doesNotMatch(source, /const http = require\("node:http"\)/);
   assert.doesNotMatch(source, /const zlib = require\("node:zlib"\)/);
   assert.doesNotMatch(source, /\bconst MIME_TYPES\b/);
@@ -565,11 +571,15 @@ function assertInteractiveCheckUsesSharedHelpers() {
   assert.match(source, /require\("\.\/dist-browser-helpers\.js"\)/);
   assert.match(source, /browserExecutablePath: findBrowserExecutablePath/);
   assert.match(source, /cachedPlaywrightChromes/);
+  assert.match(source, /collectBrowserReadinessState/);
+  assert.match(source, /waitForBrowserReadiness/);
   assert.match(source, /findBrowserExecutablePath\(\{\s*envNames: \[/);
   assert.ok(browserEnvOffset >= 0, "interactive browser env override must stay configured");
   assert.ok(puppeteerEnvOffset > browserEnvOffset, "TRACY_INTERACTIVE_INGEST_BROWSER must precede Puppeteer fallback");
   assert.ok(chromeEnvOffset > puppeteerEnvOffset, "PUPPETEER_EXECUTABLE_PATH must precede CHROME_PATH fallback");
   assert.match(source, /createDistServer\(DIST_DIR,\s*\{\s*cacheControl: CACHE_CONTROL\.NO_STORE,\s*gzip: false,/);
+  assert.doesNotMatch(source, /browser ingest state=/);
+  assert.doesNotMatch(source, /Date\.now\(\) - start < timeoutMs/);
   assert.doesNotMatch(source, /const childProcess = require\("node:child_process"\)/);
   assert.doesNotMatch(source, /const http = require\("node:http"\)/);
   assert.doesNotMatch(source, /\bfunction commandPath\b/);

--- a/tools/dist-browser-helpers-check.js
+++ b/tools/dist-browser-helpers-check.js
@@ -6,15 +6,20 @@ const fs = require("node:fs");
 const http = require("node:http");
 const os = require("node:os");
 const path = require("node:path");
+const vm = require("node:vm");
 const zlib = require("node:zlib");
 const {
   CACHE_CONTROL,
+  browserReadinessState,
   browserExecutablePath,
   cachedPlaywrightChromes,
+  collectBrowserReadinessState,
   commandPath: safeCommandPath,
   contentType,
   createDistServer,
+  formatBrowserReadinessTimeout,
   resolveDistPath,
+  waitForBrowserReadiness,
 } = require("./dist-browser-helpers.js");
 
 const ROOT_DIR = path.resolve(__dirname, "..");
@@ -427,6 +432,114 @@ function assertBrowserDiscovery() {
   );
 }
 
+async function assertBrowserReadinessDiagnostics() {
+  const workerMessages = Array.from({ length: 10 }, (_, index) => ({
+    index,
+    type: `message-${index}`,
+  }));
+  const state = JSON.parse(JSON.stringify(
+    vm.runInNewContext(`(${browserReadinessState.toString()})()`, {
+      __TRACY_APP_LOAD_ERROR__: "app failed during boot",
+      __TRACY_BROWSER_INGEST__: {
+        fileSelectionAt: 12,
+        firstPresentedAt: null,
+        frameDurations: [1, 2, 3],
+        selectedFileName: "trace.json",
+        workerMessages,
+      },
+      document: {
+        readyState: "interactive",
+        querySelector(selector) {
+          if (selector === '[role="alert"]') {
+            return { textContent: "alert text" };
+          }
+          if (selector === "#tracy") {
+            return {
+              height: 150,
+              width: 300,
+              clientHeight: 75,
+              clientWidth: 150,
+            };
+          }
+          return null;
+        },
+      },
+      location: {
+        href: "http://127.0.0.1:1234/",
+      },
+      performance: {
+        getEntriesByType(type) {
+          assert.equal(type, "mark");
+          return [
+            { name: "tracy.core.ready" },
+            { name: "tracy.app.ready" },
+          ];
+        },
+      },
+    }),
+  ));
+
+  assert.equal(state.appLoadError, "app failed during boot");
+  assert.equal(state.alertText, "alert text");
+  assert.equal(state.documentReadyState, "interactive");
+  assert.equal(state.locationHref, "http://127.0.0.1:1234/");
+  assert.deepEqual(state.performanceMarks, [
+    "tracy.core.ready",
+    "tracy.app.ready",
+  ]);
+  assert.deepEqual(state.frameDurationsSample, [1, 2, 3]);
+  assert.deepEqual(state.traceCanvas, {
+    height: 150,
+    width: 300,
+    clientHeight: 75,
+    clientWidth: 150,
+  });
+  assert.equal(state.workerMessageCount, 10);
+  assert.deepEqual(state.workerMessagesHead.map((message) => message.index), [
+    0, 1, 2, 3, 4, 5, 6, 7,
+  ]);
+  assert.deepEqual(state.workerMessagesTail.map((message) => message.index), [
+    2, 3, 4, 5, 6, 7, 8, 9,
+  ]);
+  assert.equal(state.workerMessages, undefined);
+  assert.equal(state.frameDurations, undefined);
+  assert.equal(state.selectedFileName, "trace.json");
+  assert.equal(state.firstPresentedAt, null);
+
+  let predicateChecks = 0;
+  const readyValue = await waitForBrowserReadiness({
+    evaluate: async (fn) => fn(),
+    label: "test readiness",
+    pollIntervalMs: 1,
+    predicate: () => {
+      predicateChecks += 1;
+      return predicateChecks === 2 ? "ready" : "";
+    },
+    timeoutMs: 50,
+  });
+  assert.equal(readyValue, "ready");
+  assert.equal(predicateChecks, 2);
+
+  await assert.rejects(
+    waitForBrowserReadiness({
+      evaluate: async (fn) => fn(),
+      label: "test timeout",
+      predicate: () => false,
+      timeoutMs: 0,
+    }),
+    /test timeout; browser readiness state=/,
+  );
+
+  assert.deepEqual(
+    await collectBrowserReadinessState(async () => ({ appLoadError: "from page" })),
+    { appLoadError: "from page" },
+  );
+  assert.equal(
+    formatBrowserReadinessTimeout("wait failed", { appLoadError: "boom" }),
+    'wait failed; browser readiness state={"appLoadError":"boom"}',
+  );
+}
+
 function assertAppLoadUsesSharedHelpers() {
   const source = readRepoFile("tools/app-load-bench.js");
 
@@ -490,6 +603,7 @@ function assertDelayedWasmImportBoundary() {
 async function main() {
   assertPathAndMimeHelpers();
   assertBrowserDiscovery();
+  await assertBrowserReadinessDiagnostics();
   assertAppLoadUsesSharedHelpers();
   assertInteractiveCheckUsesSharedHelpers();
   assertDelayedWasmImportBoundary();

--- a/tools/dist-browser-helpers.js
+++ b/tools/dist-browser-helpers.js
@@ -39,6 +39,7 @@ const SHARED_BROWSER_ENV = Object.freeze([
   "PUPPETEER_EXECUTABLE_PATH",
   "CHROME_PATH",
 ]);
+const DEFAULT_BROWSER_READINESS_POLL_INTERVAL_MS = 25;
 
 function contentType(file, mimeTypes = MIME_TYPES) {
   return mimeTypes[path.extname(file)] ?? "application/octet-stream";
@@ -263,6 +264,78 @@ function browserExecutablePath(options = {}) {
   throw new Error(options.errorMessage ?? "Chrome/Chromium not found");
 }
 
+function browserReadinessState() {
+  const frameDurationSampleCount = 16;
+  const workerMessageSampleCount = 8;
+  const ingestState = globalThis.__TRACY_BROWSER_INGEST__ ?? {};
+  const workerMessages = Array.isArray(ingestState.workerMessages)
+    ? ingestState.workerMessages
+    : [];
+  const frameDurations = Array.isArray(ingestState.frameDurations)
+    ? ingestState.frameDurations
+    : [];
+  const traceCanvas = globalThis.document?.querySelector?.("#tracy") ?? null;
+  const traceCanvasState = traceCanvas === null
+    ? null
+    : {
+        height: traceCanvas.height ?? null,
+        width: traceCanvas.width ?? null,
+        clientHeight: traceCanvas.clientHeight ?? null,
+        clientWidth: traceCanvas.clientWidth ?? null,
+      };
+
+  return {
+    appLoadError: globalThis.__TRACY_APP_LOAD_ERROR__ ?? "",
+    alertText: globalThis.document?.querySelector?.('[role="alert"]')?.textContent ?? "",
+    documentReadyState: globalThis.document?.readyState ?? null,
+    frameDurationsSample: frameDurations.slice(0, frameDurationSampleCount),
+    locationHref: globalThis.location?.href ?? "",
+    performanceMarks:
+      globalThis.performance?.getEntriesByType?.("mark")?.map((entry) => entry.name) ?? [],
+    traceCanvas: traceCanvasState,
+    workerMessageCount: workerMessages.length,
+    workerMessagesHead: workerMessages.slice(0, workerMessageSampleCount),
+    workerMessagesTail: workerMessages.slice(-workerMessageSampleCount),
+    ...Object.fromEntries(
+      Object.entries(ingestState).filter(
+        ([key]) => key !== "frameDurations" && key !== "workerMessages",
+      ),
+    ),
+  };
+}
+
+async function collectBrowserReadinessState(evaluate) {
+  return evaluate(browserReadinessState);
+}
+
+function formatBrowserReadinessTimeout(label, state) {
+  return `${label}; browser readiness state=${JSON.stringify(state)}`;
+}
+
+async function waitForBrowserReadiness(options) {
+  const evaluate = options.evaluate;
+  const predicate = options.predicate;
+  const timeoutMs = options.timeoutMs;
+  const pollIntervalMs =
+    options.pollIntervalMs ?? DEFAULT_BROWSER_READINESS_POLL_INTERVAL_MS;
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const value = await evaluate(predicate);
+    if (value) {
+      return value;
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  throw new Error(
+    formatBrowserReadinessTimeout(
+      options.label,
+      await collectBrowserReadinessState(evaluate),
+    ),
+  );
+}
+
 module.exports = {
   CACHE_CONTROL,
   CHROME_COMMANDS,
@@ -271,11 +344,15 @@ module.exports = {
   SHARED_BROWSER_ENV,
   acceptsGzip,
   browserExecutablePath,
+  browserReadinessState,
   cachedPlaywrightChromes,
+  collectBrowserReadinessState,
   commandPath,
   contentType,
   createDistServer,
+  formatBrowserReadinessTimeout,
   isExecutableFile,
   resolveDistPath,
   shouldGzip,
+  waitForBrowserReadiness,
 };

--- a/tools/dist-browser-helpers.js
+++ b/tools/dist-browser-helpers.js
@@ -331,7 +331,9 @@ async function waitForBrowserReadiness(options) {
   throw new Error(
     formatBrowserReadinessTimeout(
       options.label,
-      await collectBrowserReadinessState(evaluate),
+      options.collectState === undefined
+        ? await collectBrowserReadinessState(evaluate)
+        : await options.collectState(),
     ),
   );
 }

--- a/tools/interactive-ingest-browser-check.js
+++ b/tools/interactive-ingest-browser-check.js
@@ -11,7 +11,9 @@ const {
   CACHE_CONTROL,
   browserExecutablePath: findBrowserExecutablePath,
   cachedPlaywrightChromes,
+  collectBrowserReadinessState,
   createDistServer,
+  waitForBrowserReadiness,
 } = require("./dist-browser-helpers.js");
 
 const DIST_DIR = repoPath("dist");
@@ -214,68 +216,56 @@ async function installIngestInstrumentation(page) {
 }
 
 async function browserState(page, { diagnoseReader = false } = {}) {
-  return page.evaluate(async (shouldDiagnoseReader) => {
-    const state = globalThis.__TRACY_BROWSER_INGEST__ ?? {};
-    const workerMessages = state.workerMessages ?? [];
-    let readerDiagnostic = null;
+  const state = await collectBrowserReadinessState((readinessState) =>
+    page.evaluate(readinessState),
+  );
 
-    if (shouldDiagnoseReader) {
+  if (!diagnoseReader) {
+    return state;
+  }
+
+  return {
+    ...state,
+    readerDiagnostic: await page.evaluate(async () => {
+      const state = globalThis.__TRACY_BROWSER_INGEST__ ?? {};
+
       const startPost = state.workerPosts?.find((message) => message.indexName !== null);
-      if (startPost?.indexName !== undefined && startPost.indexName !== null) {
-        try {
-          const memory = new WebAssembly.Memory({ initial: 8272, maximum: 32768 });
-          const { makeMainThreadHost } = await import("./host/shim.mjs");
-          const { createMainThreadIndexReaderController } =
-            await import("./host/runtime.mjs");
-          const host = makeMainThreadHost(memory);
-          const reader = createMainThreadIndexReaderController(memory, host);
-
-          await reader.open(startPost.indexName);
-          readerDiagnostic = {
-            coveredRange: reader.coveredRange(),
-            queryRange: await reader.queryRange(0, 0, 1000, 12288),
-            status: reader.status(),
-            trackCount: reader.trackCount(),
-          };
-        } catch (error) {
-          readerDiagnostic = {
-            error: error instanceof Error ? error.message : String(error),
-          };
-        }
+      if (startPost?.indexName === undefined || startPost.indexName === null) {
+        return null;
       }
-    }
 
-    return {
-      appError: globalThis.__TRACY_APP_LOAD_ERROR__ ?? "",
-      frameDurationsSample: state.frameDurations?.slice(0, 16),
-      performanceMarks: performance.getEntriesByType("mark").map((entry) => entry.name),
-      workerMessageCount: workerMessages.length,
-      workerMessagesHead: workerMessages.slice(0, 8),
-      workerMessagesTail: workerMessages.slice(-8),
-      readerDiagnostic,
-      ...Object.fromEntries(
-        Object.entries(state).filter(
-          ([key]) => key !== "frameDurations" && key !== "workerMessages",
-        ),
-      ),
-    };
-  }, diagnoseReader);
+      try {
+        const memory = new WebAssembly.Memory({ initial: 8272, maximum: 32768 });
+        const { makeMainThreadHost } = await import("./host/shim.mjs");
+        const { createMainThreadIndexReaderController } =
+          await import("./host/runtime.mjs");
+        const host = makeMainThreadHost(memory);
+        const reader = createMainThreadIndexReaderController(memory, host);
+
+        await reader.open(startPost.indexName);
+        return {
+          coveredRange: reader.coveredRange(),
+          queryRange: await reader.queryRange(0, 0, 1000, 12288),
+          status: reader.status(),
+          trackCount: reader.trackCount(),
+        };
+      } catch (error) {
+        return {
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }),
+  };
 }
 
 async function waitForPageCondition(page, predicate, label, timeoutMs = BROWSER_TIMEOUT_MS) {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    if (await page.evaluate(predicate)) {
-      return;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 25));
-  }
-
-  throw new Error(
-    `${label}; browser ingest state=${JSON.stringify(
-      await browserState(page, { diagnoseReader: true }),
-    )}`,
-  );
+  return waitForBrowserReadiness({
+    collectState: () => browserState(page, { diagnoseReader: true }),
+    evaluate: (readinessPredicate) => page.evaluate(readinessPredicate),
+    label,
+    predicate,
+    timeoutMs,
+  });
 }
 
 async function checkBrowserInteractiveIngest() {
@@ -302,14 +292,12 @@ async function checkBrowserInteractiveIngest() {
     await page.goto(`${server.origin}/`, { waitUntil: "load" });
     await waitForPageCondition(
       page,
-      () =>
-        performance.getEntriesByName("tracy.app.ready").length > 0 ||
-        globalThis.__TRACY_APP_LOAD_ERROR__ !== undefined,
+      () => performance.getEntriesByName("tracy.app.ready").length > 0,
       "browser app did not become ready",
     );
 
     const readyState = await browserState(page);
-    assert.equal(readyState.appError, "");
+    assert.equal(readyState.appLoadError, "");
     assert.equal(readyState.suspendingType, "function");
     assert.equal(readyState.promisingType, "function");
 
@@ -340,15 +328,13 @@ async function checkBrowserInteractiveIngest() {
     await chooser.accept([tracePath]);
     await waitForPageCondition(
       page,
-      () =>
-        globalThis.__TRACY_APP_LOAD_ERROR__ !== undefined ||
-        globalThis.__TRACY_BROWSER_INGEST__?.firstPresentedAt !== null,
+      () => globalThis.__TRACY_BROWSER_INGEST__?.firstPresentedAt !== null,
       "browser did not present first ingest draw",
       10_000,
     );
 
     const result = await browserState(page);
-    assert.equal(result.appError, "");
+    assert.equal(result.appLoadError, "");
     assert.equal(result.selectedFileName, "throttled-100mb.json");
     assert.equal(result.selectedFileSize, TRACE_SIZE_BYTES);
     assert.notEqual(result.fileSelectionAt, null);


### PR DESCRIPTION
## Summary

- Share browser readiness polling and timeout diagnostics across app-ready, core-ready, and ingest-ready waits.
- Report app load errors, performance marks, worker message head/tail, and relevant page state from one diagnostic path.
- Preserve the existing spec-owned timeout values and keep this leaf scoped to readiness diagnostics.

## Test plan

- npm run test:dist-browser-helpers
- npm run test:app-load-bench
- npm run test:interactive-ingest-browser

Fixes #307.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Extract shared browser readiness diagnostics <!-- type:spec -->
- [x] Use shared readiness waits in browser gates <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->