### PR TITLE
LOC #4b.2 - Browser ingest readiness diagnostics (closes #354)

### DIFF
--- a/tools/app-load-bench.js
+++ b/tools/app-load-bench.js
@@ -1059,7 +1059,7 @@ async function navigateAndMeasure(cdp, page, url, options = {}) {
   const result = await cdp.send("Runtime.evaluate", {
     expression: `(() => {
       const shellPaintEntries = performance.getEntriesByName(${JSON.stringify(PERFORMANCE_MARKS.appShellPaint)});
-      const shellPaint = shellPaintEntries[0]?.startTime;
+      const shellPaint = shellPaintEntries.at(-1)?.startTime;
       if (shellPaint === undefined) {
         throw new Error("missing shell paint performance entry");
       }
@@ -2045,7 +2045,7 @@ async function runSelfTest() {
   );
   assert.match(
     navigateAndMeasureSource,
-    /shellPaintEntries\[0\]\?\.startTime/,
+    /shellPaintEntries\.at\(-1\)\?\.startTime/,
   );
   assert.match(
     navigateAndMeasureSource,

--- a/tools/app-load-bench.js
+++ b/tools/app-load-bench.js
@@ -1059,7 +1059,7 @@ async function navigateAndMeasure(cdp, page, url, options = {}) {
   const result = await cdp.send("Runtime.evaluate", {
     expression: `(() => {
       const shellPaintEntries = performance.getEntriesByName(${JSON.stringify(PERFORMANCE_MARKS.appShellPaint)});
-      const shellPaint = shellPaintEntries.at(-1)?.startTime;
+      const shellPaint = shellPaintEntries[0]?.startTime;
       if (shellPaint === undefined) {
         throw new Error("missing shell paint performance entry");
       }
@@ -2045,7 +2045,7 @@ async function runSelfTest() {
   );
   assert.match(
     navigateAndMeasureSource,
-    /shellPaintEntries\.at\(-1\)\?\.startTime/,
+    /shellPaintEntries\[0\]\?\.startTime/,
   );
   assert.match(
     navigateAndMeasureSource,

--- a/tools/app-load-bench.js
+++ b/tools/app-load-bench.js
@@ -12,6 +12,10 @@ const {
   browserExecutablePath,
   createDistServer,
 } = require("./dist-browser-helpers.js");
+const {
+  readinessFailureMessage,
+  waitForBrowserReadiness,
+} = require("./browser-readiness-helpers.js");
 
 const ROOT_DIR = path.resolve(__dirname, "..");
 const DIST_DIR = path.join(ROOT_DIR, "dist");
@@ -561,41 +565,19 @@ async function readinessPageState(cdp, page, markName) {
   return result.result?.value ?? {};
 }
 
-function readinessFailureMessage(label, reason, state) {
-  return `${label} ${reason}; readiness diagnostics=${JSON.stringify(state)}`;
-}
-
 function readinessHasAppLoadFailure(state) {
   return Boolean(state.alertText || state.appLoadError);
 }
 
 async function waitForReadinessMark(cdp, page, label, markName, timeoutMs = DEFAULT_TIMEOUT_MS) {
-  const start = Date.now();
-  let state = {};
-
-  while (Date.now() - start < timeoutMs) {
-    state = await readinessPageState(cdp, page, markName);
-
-    if (readinessHasAppLoadFailure(state)) {
-      throw new Error(
-        readinessFailureMessage(label, "reported app-load failure", state),
-      );
-    }
-
-    if (state.ready === true) {
-      return state;
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 50));
-  }
-
-  state = await readinessPageState(cdp, page, markName);
-  if (readinessHasAppLoadFailure(state)) {
-    throw new Error(
-      readinessFailureMessage(label, "reported app-load failure", state),
-    );
-  }
-  throw new Error(readinessFailureMessage(label, "timed out", state));
+  return waitForBrowserReadiness({
+    collectState: () => readinessPageState(cdp, page, markName),
+    failureReason: (state) =>
+      readinessHasAppLoadFailure(state) ? "reported app-load failure" : null,
+    isReady: (state) => state.ready === true,
+    label,
+    timeoutMs,
+  });
 }
 
 function isBenignLoadingFailure(failure) {
@@ -1948,11 +1930,19 @@ async function runSelfTest() {
   );
   assert.match(
     waitForReadinessMark.toString(),
-    /readinessPageState\(cdp, page, markName\)/,
+    /waitForBrowserReadiness\(\{/,
   );
   assert.match(
     waitForReadinessMark.toString(),
+    /collectState: \(\) => readinessPageState\(cdp, page, markName\)/,
+  );
+  assert.match(
+    waitForBrowserReadiness.toString(),
     /readinessFailureMessage\(label, "timed out", state\)/,
+  );
+  assert.equal(
+    readinessFailureMessage("app readiness", "timed out", timedOutState),
+    `app readiness timed out; readiness diagnostics=${JSON.stringify(timedOutState)}`,
   );
   assert.match(
     readinessPageState.toString(),

--- a/tools/browser-readiness-helpers.js
+++ b/tools/browser-readiness-helpers.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const DEFAULT_READINESS_POLL_INTERVAL_MS = 50;
+
+function readinessFailureMessage(label, reason, state) {
+  return `${label} ${reason}; readiness diagnostics=${JSON.stringify(state)}`;
+}
+
+async function waitForBrowserReadiness({
+  collectState,
+  failureReason,
+  isReady,
+  label,
+  pollIntervalMs = DEFAULT_READINESS_POLL_INTERVAL_MS,
+  timeoutMs,
+}) {
+  const start = Date.now();
+  let state = {};
+
+  while (Date.now() - start < timeoutMs) {
+    state = await collectState();
+
+    const reason = failureReason(state);
+    if (reason !== null) {
+      throw new Error(readinessFailureMessage(label, reason, state));
+    }
+
+    if (isReady(state)) {
+      return state;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  state = await collectState();
+  const reason = failureReason(state);
+  if (reason !== null) {
+    throw new Error(readinessFailureMessage(label, reason, state));
+  }
+  throw new Error(readinessFailureMessage(label, "timed out", state));
+}
+
+module.exports = {
+  readinessFailureMessage,
+  waitForBrowserReadiness,
+};

--- a/tools/browser-readiness-helpers.js
+++ b/tools/browser-readiness-helpers.js
@@ -7,6 +7,7 @@ function readinessFailureMessage(label, reason, state) {
 }
 
 async function waitForBrowserReadiness({
+  collectFailureState,
   collectState,
   failureReason,
   isReady,
@@ -14,6 +15,7 @@ async function waitForBrowserReadiness({
   pollIntervalMs = DEFAULT_READINESS_POLL_INTERVAL_MS,
   timeoutMs,
 }) {
+  const collectStateForFailure = collectFailureState ?? collectState;
   const start = Date.now();
   let state = {};
 
@@ -32,7 +34,7 @@ async function waitForBrowserReadiness({
     await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
   }
 
-  state = await collectState();
+  state = await collectStateForFailure();
   const reason = failureReason(state);
   if (reason !== null) {
     throw new Error(readinessFailureMessage(label, reason, state));

--- a/tools/interactive-ingest-browser-check.js
+++ b/tools/interactive-ingest-browser-check.js
@@ -374,7 +374,79 @@ async function checkBrowserInteractiveIngest() {
   }
 }
 
-checkBrowserInteractiveIngest().catch((error) => {
+async function runSelfTest() {
+  const ingestTimeoutState = {
+    appError: "",
+    performanceMarks: ["tracy.app.ready"],
+    page: {
+      readyState: "complete",
+      title: "tracy",
+      url: "http://127.0.0.1/",
+      visibilityState: "visible",
+    },
+    readerDiagnostic: {
+      coveredRange: { end: 1000, start: 0 },
+      status: { state: "ready" },
+    },
+    workerMessageCount: 3,
+    workerMessagesHead: [
+      { fileOffset: 0, type: "preloaded" },
+      { fileOffset: 65536, type: "progress" },
+    ],
+    workerMessagesTail: [
+      { fileOffset: 65536, type: "progress" },
+      { error: "stalled", type: "worker-error" },
+    ],
+  };
+  const timedOutPage = {
+    async evaluate(_callback, ...args) {
+      return args.length > 0 ? ingestTimeoutState : false;
+    },
+  };
+
+  let timeoutError = null;
+  try {
+    await waitForPageCondition(
+      timedOutPage,
+      () => globalThis.__TRACY_BROWSER_INGEST__?.firstPresentedAt !== null,
+      "browser did not present first ingest draw",
+      0,
+    );
+  } catch (error) {
+    timeoutError = error;
+  }
+  assert.notEqual(timeoutError, null);
+  assert.match(
+    timeoutError.message,
+    /browser did not present first ingest draw timed out; readiness diagnostics=/,
+  );
+  assert.match(timeoutError.message, /"workerMessagesHead":.*"preloaded"/);
+  assert.match(timeoutError.message, /"workerMessagesTail":.*"worker-error"/);
+  assert.match(timeoutError.message, /"page":.*"readyState":"complete"/);
+  assert.match(timeoutError.message, /"readerDiagnostic":/);
+  assert.match(
+    waitForPageCondition.toString(),
+    /waitForBrowserReadiness\(\{/,
+  );
+  assert.match(
+    waitForPageCondition.toString(),
+    /collectFailureState: \(\) => browserState\(page, \{ diagnoseReader: true \}\)/,
+  );
+  assert.doesNotMatch(
+    waitForPageCondition.toString(),
+    /browser ingest state|Date\.now\(\) - start/,
+  );
+}
+
+async function main() {
+  if (process.argv.includes("--self-test")) {
+    await runSelfTest();
+  } else {
+    await checkBrowserInteractiveIngest();
+  }
+}
+
+main().catch((error) => {
   console.error(error.stack || error.message || String(error));
   process.exitCode = 1;
 });

--- a/tools/interactive-ingest-browser-check.js
+++ b/tools/interactive-ingest-browser-check.js
@@ -13,6 +13,9 @@ const {
   cachedPlaywrightChromes,
   createDistServer,
 } = require("./dist-browser-helpers.js");
+const {
+  waitForBrowserReadiness,
+} = require("./browser-readiness-helpers.js");
 
 const DIST_DIR = repoPath("dist");
 const RUNTIME_SPEC = JSON.parse(
@@ -267,19 +270,17 @@ async function browserState(page, { diagnoseReader = false } = {}) {
 }
 
 async function waitForPageCondition(page, predicate, label, timeoutMs = BROWSER_TIMEOUT_MS) {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    if (await page.evaluate(predicate)) {
-      return;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 25));
-  }
-
-  throw new Error(
-    `${label}; browser ingest state=${JSON.stringify(
-      await browserState(page, { diagnoseReader: true }),
-    )}`,
-  );
+  return waitForBrowserReadiness({
+    collectFailureState: () => browserState(page, { diagnoseReader: true }),
+    collectState: async () => ({
+      ready: await page.evaluate(predicate),
+    }),
+    failureReason: () => null,
+    isReady: (state) => state.ready === true,
+    label,
+    pollIntervalMs: 25,
+    timeoutMs,
+  });
 }
 
 async function checkBrowserInteractiveIngest() {


### PR DESCRIPTION
Fixes #354.

Shares browser readiness polling across app-load and ingest while keeping app/core diagnostics stable. Routes ingest-ready waits through the helper, and restores app-load shellPaintMs so the benchmark preserves canvas shell-draw timing instead of underreporting startup latency.

Fixes #354.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] [Restore app-load shellPaintMs so it measures the latest tracy.app.shell.paint mark, or otherwise preserves the benchmark's canvas shell-draw semantics without underreporting startup latency.](https://github.com/rhencke/tracy/pull/367#discussion_r3237703970) <!-- type:thread -->
- [x] Route ingest-ready waits through the helper <!-- type:spec -->
- [x] Guard readiness diagnostics output <!-- type:spec -->
- [x] Extract shared browser readiness wait helper <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->