### PR TITLE
LOC #4c.1 - Browser file-selection instrumentation (closes #355)

### DIFF
--- a/tools/browser-file-selection-page-helper.js
+++ b/tools/browser-file-selection-page-helper.js
@@ -1,0 +1,79 @@
+"use strict";
+
+const BROWSER_INGEST_STATE_KEY = "__TRACY_BROWSER_INGEST__";
+
+function emptyFileSelectionSnapshot() {
+  return {
+    selectedAt: null,
+    selectedFile: {
+      name: null,
+      size: null,
+    },
+  };
+}
+
+function fileSelectionSnapshot(value = {}) {
+  const snapshot = value ?? {};
+  const selectedFile = snapshot.selectedFile ?? {};
+
+  return {
+    selectedAt: snapshot.selectedAt ?? null,
+    selectedFile: {
+      name: selectedFile.name ?? null,
+      size: selectedFile.size ?? null,
+    },
+  };
+}
+
+async function installBrowserFileSelectionInstrumentation(page) {
+  await page.evaluateOnNewDocument((stateKey) => {
+    const state = globalThis[stateKey] ?? {};
+    const fileSelection = {
+      selectedAt: null,
+      selectedFile: {
+        name: null,
+        size: null,
+      },
+    };
+
+    state.fileSelection = fileSelection;
+    globalThis[stateKey] = state;
+
+    const addEventListener = EventTarget.prototype.addEventListener;
+    EventTarget.prototype.addEventListener = function addInstrumentedListener(
+      type,
+      listener,
+      options,
+    ) {
+      if (
+        this instanceof HTMLInputElement &&
+        this.type === "file" &&
+        type === "change" &&
+        typeof listener === "function"
+      ) {
+        return addEventListener.call(
+          this,
+          type,
+          function instrumentedFileSelectionChange(event) {
+            fileSelection.selectedAt ??= performance.now();
+            fileSelection.selectedFile = {
+              name: this.files?.[0]?.name ?? null,
+              size: this.files?.[0]?.size ?? null,
+            };
+            return listener.call(this, event);
+          },
+          options,
+        );
+      }
+
+      return addEventListener.call(this, type, listener, options);
+    };
+  }, BROWSER_INGEST_STATE_KEY);
+}
+
+module.exports = {
+  BROWSER_INGEST_STATE_KEY,
+  emptyFileSelectionSnapshot,
+  fileSelectionSnapshot,
+  installBrowserFileSelectionInstrumentation,
+};

--- a/tools/dist-browser-helpers-check.js
+++ b/tools/dist-browser-helpers-check.js
@@ -18,9 +18,77 @@ const {
 } = require("./dist-browser-helpers.js");
 
 const ROOT_DIR = path.resolve(__dirname, "..");
+const BROWSER_FILE_SELECTION_HELPER = "tools/browser-file-selection-page-helper.js";
+const BROWSER_FILE_SELECTION_CHECK = "tools/interactive-ingest-browser-check.js";
+const PRODUCTION_APP_TEXT_FILES = Object.freeze([
+  "bootstrap.mjs",
+  "index.html",
+  "service-worker.js",
+  "worker.js",
+  "host/canvas.mjs",
+  "host/file-picker.mjs",
+  "host/index-reader-catalog.mjs",
+  "host/ingest-worker-runtime.mjs",
+  "host/memory.mjs",
+  "host/opfs-source.mjs",
+  "host/pointer.mjs",
+  "host/progressive-trace-renderer-loader.mjs",
+  "host/progressive-trace-renderer.mjs",
+  "host/runtime.mjs",
+  "host/shim.mjs",
+  "host/startup-spec.mjs",
+  "host/trace-renderer-spec.mjs",
+  "host/wasm-modules.mjs",
+]);
+const DIST_APP_TEXT_EXTENSIONS = new Set([".html", ".js", ".mjs"]);
+const FILE_SELECTION_INSTRUMENTATION_MARKERS = Object.freeze([
+  "installBrowserFileSelectionInstrumentation",
+  "browser-file-selection-page-helper",
+  "instrumentedFileSelectionChange",
+  "state.fileSelection = fileSelection",
+]);
+const LEGACY_FILE_SELECTION_SNAPSHOT_MARKERS = Object.freeze([
+  "fileSelectionAt",
+  "selectedFileName",
+  "selectedFileSize",
+]);
 
 function readRepoFile(relativePath) {
   return fs.readFileSync(path.join(ROOT_DIR, relativePath), "utf8");
+}
+
+function repoFileExists(relativePath) {
+  return fs.existsSync(path.join(ROOT_DIR, relativePath));
+}
+
+function walkFiles(dir) {
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+
+  const files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const file = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(file));
+    } else if (entry.isFile()) {
+      files.push(file);
+    }
+  }
+  return files;
+}
+
+function assertFilesDoNotContain(files, markers, label) {
+  for (const file of files) {
+    const source = fs.readFileSync(file, "utf8");
+    for (const marker of markers) {
+      assert.equal(
+        source.includes(marker),
+        false,
+        `${label} must not contain ${marker}: ${path.relative(ROOT_DIR, file)}`,
+      );
+    }
+  }
 }
 
 function request(url, options = {}) {
@@ -444,7 +512,7 @@ function assertAppLoadUsesSharedHelpers() {
 }
 
 function assertInteractiveCheckUsesSharedHelpers() {
-  const source = readRepoFile("tools/interactive-ingest-browser-check.js");
+  const source = readRepoFile(BROWSER_FILE_SELECTION_CHECK);
   const browserEnvOffset = source.indexOf('"TRACY_INTERACTIVE_INGEST_BROWSER"');
   const puppeteerEnvOffset = source.indexOf('"PUPPETEER_EXECUTABLE_PATH"');
   const chromeEnvOffset = source.indexOf('"CHROME_PATH"');
@@ -463,6 +531,39 @@ function assertInteractiveCheckUsesSharedHelpers() {
   assert.doesNotMatch(source, /\bfunction contentType\b/);
   assert.doesNotMatch(source, /\bfunction resolveDistPath\b/);
   assert.doesNotMatch(source, /\bfunction cachedPlaywrightChromes\b/);
+}
+
+function assertBrowserFileSelectionInstrumentationBoundary() {
+  const helper = readRepoFile(BROWSER_FILE_SELECTION_HELPER);
+  const check = readRepoFile(BROWSER_FILE_SELECTION_CHECK);
+
+  assert.match(check, /require\("\.\/browser-file-selection-page-helper\.js"\)/);
+  assert.match(check, /installBrowserFileSelectionInstrumentation\(page\)/);
+  assert.doesNotMatch(check, /EventTarget\.prototype\.addEventListener/);
+  assert.doesNotMatch(check, /this instanceof HTMLInputElement/);
+  assert.doesNotMatch(
+    check,
+    new RegExp(LEGACY_FILE_SELECTION_SNAPSHOT_MARKERS.join("|")),
+  );
+  assert.match(helper, /EventTarget\.prototype\.addEventListener/);
+  assert.match(helper, /this instanceof HTMLInputElement/);
+  assert.match(helper, /fileSelectionSnapshot/);
+
+  assertFilesDoNotContain(
+    PRODUCTION_APP_TEXT_FILES
+      .filter(repoFileExists)
+      .map((relativePath) => path.join(ROOT_DIR, relativePath)),
+    FILE_SELECTION_INSTRUMENTATION_MARKERS,
+    "production app source",
+  );
+
+  assertFilesDoNotContain(
+    walkFiles(path.join(ROOT_DIR, "dist")).filter((file) =>
+      DIST_APP_TEXT_EXTENSIONS.has(path.extname(file)),
+    ),
+    FILE_SELECTION_INSTRUMENTATION_MARKERS,
+    "dist app file",
+  );
 }
 
 function assertDelayedWasmImportBoundary() {
@@ -506,6 +607,7 @@ async function main() {
   assertBrowserDiscovery();
   assertAppLoadUsesSharedHelpers();
   assertInteractiveCheckUsesSharedHelpers();
+  assertBrowserFileSelectionInstrumentationBoundary();
   assertDelayedWasmImportBoundary();
   await assertServerResponseModes();
   await assertServerFailureModes();

--- a/tools/interactive-ingest-browser-check.js
+++ b/tools/interactive-ingest-browser-check.js
@@ -16,6 +16,12 @@ const {
 const {
   waitForBrowserReadiness,
 } = require("./browser-readiness-helpers.js");
+const {
+  BROWSER_INGEST_STATE_KEY,
+  emptyFileSelectionSnapshot,
+  fileSelectionSnapshot,
+  installBrowserFileSelectionInstrumentation,
+} = require("./browser-file-selection-page-helper.js");
 
 const DIST_DIR = repoPath("dist");
 const RUNTIME_SPEC = JSON.parse(
@@ -88,9 +94,11 @@ async function writeTraceFile(file) {
 }
 
 async function installIngestInstrumentation(page) {
-  await page.evaluateOnNewDocument(() => {
-    const state = {
-      fileSelectionAt: null,
+  await installBrowserFileSelectionInstrumentation(page);
+  await page.evaluateOnNewDocument((stateKey) => {
+    const state = globalThis[stateKey] ?? {};
+
+    Object.assign(state, {
       firstDrawAt: null,
       firstPresentedAt: null,
       fillRectCount: 0,
@@ -98,41 +106,14 @@ async function installIngestInstrumentation(page) {
       frameDurations: [],
       maxFrameDuration: 0,
       promisingType: typeof WebAssembly.promising,
-      selectedFileName: null,
-      selectedFileSize: null,
       suspendingType: typeof WebAssembly.Suspending,
       workerMessages: [],
       workerPosts: [],
-    };
-    globalThis.__TRACY_BROWSER_INGEST__ = state;
-
-    const addEventListener = EventTarget.prototype.addEventListener;
-    EventTarget.prototype.addEventListener = function addInstrumentedListener(
-      type,
-      listener,
-      options,
-    ) {
-      if (
-        this instanceof HTMLInputElement &&
-        this.type === "file" &&
-        type === "change" &&
-        typeof listener === "function"
-      ) {
-        return addEventListener.call(
-          this,
-          type,
-          function instrumentedChange(event) {
-            state.fileSelectionAt ??= performance.now();
-            state.selectedFileName = this.files?.[0]?.name ?? null;
-            state.selectedFileSize = this.files?.[0]?.size ?? null;
-            return listener.call(this, event);
-          },
-          options,
-        );
-      }
-
-      return addEventListener.call(this, type, listener, options);
-    };
+    });
+    globalThis[stateKey] = state;
+    const fileSelectionStarted = () =>
+      state.fileSelection?.selectedAt !== null &&
+      state.fileSelection?.selectedAt !== undefined;
 
     const requestAnimationFrame = globalThis.requestAnimationFrame.bind(globalThis);
     globalThis.requestAnimationFrame = (callback) =>
@@ -141,7 +122,7 @@ async function installIngestInstrumentation(page) {
         try {
           return callback(timestamp);
         } finally {
-          if (state.fileSelectionAt !== null) {
+          if (fileSelectionStarted()) {
             const duration = performance.now() - startedAt;
             state.frameDurations.push(duration);
             state.maxFrameDuration = Math.max(state.maxFrameDuration, duration);
@@ -157,7 +138,7 @@ async function installIngestInstrumentation(page) {
       height,
     ) {
       const result = fillRect.apply(this, arguments);
-      if (this.canvas?.id === "tracy" && state.fileSelectionAt !== null) {
+      if (this.canvas?.id === "tracy" && fileSelectionStarted()) {
         state.fillRectCount += 1;
         if (state.fillRectSamples.length < 16) {
           state.fillRectSamples.push({ height, width, x, y });
@@ -165,7 +146,7 @@ async function installIngestInstrumentation(page) {
       }
       if (
         this.canvas?.id === "tracy" &&
-        state.fileSelectionAt !== null &&
+        fileSelectionStarted() &&
         state.firstDrawAt === null &&
         y > 0 &&
         height > 0 &&
@@ -217,12 +198,12 @@ async function installIngestInstrumentation(page) {
       });
       return worker;
     };
-  });
+  }, BROWSER_INGEST_STATE_KEY);
 }
 
 async function browserState(page, { diagnoseReader = false } = {}) {
-  return page.evaluate(async (shouldDiagnoseReader) => {
-    const state = globalThis.__TRACY_BROWSER_INGEST__ ?? {};
+  const state = await page.evaluate(async (shouldDiagnoseReader, stateKey) => {
+    const state = globalThis[stateKey] ?? {};
     const workerMessages = state.workerMessages ?? [];
     let readerDiagnostic = null;
 
@@ -266,7 +247,12 @@ async function browserState(page, { diagnoseReader = false } = {}) {
         ),
       ),
     };
-  }, diagnoseReader);
+  }, diagnoseReader, BROWSER_INGEST_STATE_KEY);
+
+  return {
+    ...state,
+    fileSelection: fileSelectionSnapshot(state.fileSelection),
+  };
 }
 
 async function waitForPageCondition(page, predicate, label, timeoutMs = BROWSER_TIMEOUT_MS) {
@@ -353,15 +339,16 @@ async function checkBrowserInteractiveIngest() {
     );
 
     const result = await browserState(page);
+    const { fileSelection } = result;
     assert.equal(result.appError, "");
-    assert.equal(result.selectedFileName, "throttled-100mb.json");
-    assert.equal(result.selectedFileSize, TRACE_SIZE_BYTES);
-    assert.notEqual(result.fileSelectionAt, null);
+    assert.equal(fileSelection.selectedFile.name, "throttled-100mb.json");
+    assert.equal(fileSelection.selectedFile.size, TRACE_SIZE_BYTES);
+    assert.notEqual(fileSelection.selectedAt, null);
     assert.notEqual(result.firstDrawAt, null);
     assert.notEqual(result.firstPresentedAt, null);
     assert.ok(
-      result.firstPresentedAt - result.fileSelectionAt <= FIRST_PRESENTED_BUDGET,
-      `first presented ingest draw took ${result.firstPresentedAt - result.fileSelectionAt}ms`,
+      result.firstPresentedAt - fileSelection.selectedAt <= FIRST_PRESENTED_BUDGET,
+      `first presented ingest draw took ${result.firstPresentedAt - fileSelection.selectedAt}ms`,
     );
     assert.ok(
       result.maxFrameDuration <= FRAME_BUDGET,
@@ -375,6 +362,18 @@ async function checkBrowserInteractiveIngest() {
 }
 
 async function runSelfTest() {
+  assert.deepEqual(fileSelectionSnapshot(), emptyFileSelectionSnapshot());
+  assert.deepEqual(
+    fileSelectionSnapshot({
+      selectedAt: 12.5,
+      selectedFile: { name: "trace.json", size: TRACE_SIZE_BYTES },
+    }),
+    {
+      selectedAt: 12.5,
+      selectedFile: { name: "trace.json", size: TRACE_SIZE_BYTES },
+    },
+  );
+
   const ingestTimeoutState = {
     appError: "",
     performanceMarks: ["tracy.app.ready"],


### PR DESCRIPTION
## Summary

- Move browser file-selection monkey-patching into a single acceptance-page helper.
- Read file-selection observations through a typed snapshot field instead of loose top-level browser state.
- Keep this leaf limited to file-selection instrumentation and preserve the production/dist boundary.

## LOC ledger

- Raw net: TBD after implementation
- Handwritten production net: 0 planned
- Handwritten test/tool net: TBD after implementation
- Spec/generated net: 0 planned
- Guard-only net: TBD after implementation
- Lockfile/dependency noise: 0 planned

## Test plan

- `node tools/interactive-ingest-browser-check.js --self-test`
- `npm run test:interactive-ingest-browser`
- `npm run test:dist-browser-helpers`

Fixes #355.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Extract file-selection page instrumentation helper <!-- type:spec -->
- [x] Guard file-selection instrumentation boundaries <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->