### PR TITLE
LOC #4c.2 - Browser worker-message instrumentation (closes #356)

### DIFF
--- a/tools/browser-worker-message-page-helper.js
+++ b/tools/browser-worker-message-page-helper.js
@@ -11,7 +11,9 @@ function emptyWorkerMessageSnapshot() {
     messageCount: 0,
     messagesHead: [],
     messagesTail: [],
-    posts: [],
+    postCount: 0,
+    postsHead: [],
+    postsTail: [],
   };
 }
 
@@ -21,10 +23,14 @@ function workerMessageSnapshot(value = {}) {
   const posts = Array.isArray(snapshot.posts) ? snapshot.posts : [];
 
   return {
-    messageCount: messages.length,
-    messagesHead: messages.slice(0, WORKER_MESSAGE_DIAGNOSTIC_LIMIT),
-    messagesTail: messages.slice(-WORKER_MESSAGE_DIAGNOSTIC_LIMIT),
-    posts,
+    messageCount: snapshot.messageCount ?? messages.length,
+    messagesHead:
+      snapshot.messagesHead ?? messages.slice(0, WORKER_MESSAGE_DIAGNOSTIC_LIMIT),
+    messagesTail:
+      snapshot.messagesTail ?? messages.slice(-WORKER_MESSAGE_DIAGNOSTIC_LIMIT),
+    postCount: snapshot.postCount ?? posts.length,
+    postsHead: snapshot.postsHead ?? posts.slice(0, WORKER_MESSAGE_DIAGNOSTIC_LIMIT),
+    postsTail: snapshot.postsTail ?? posts.slice(-WORKER_MESSAGE_DIAGNOSTIC_LIMIT),
   };
 }
 
@@ -81,6 +87,7 @@ async function installBrowserWorkerMessageInstrumentation(page) {
 }
 
 module.exports = {
+  WORKER_MESSAGE_DIAGNOSTIC_LIMIT,
   emptyWorkerMessageSnapshot,
   installBrowserWorkerMessageInstrumentation,
   workerMessageSnapshot,

--- a/tools/browser-worker-message-page-helper.js
+++ b/tools/browser-worker-message-page-helper.js
@@ -1,0 +1,87 @@
+"use strict";
+
+const {
+  BROWSER_INGEST_STATE_KEY,
+} = require("./browser-file-selection-page-helper.js");
+
+const WORKER_MESSAGE_DIAGNOSTIC_LIMIT = 8;
+
+function emptyWorkerMessageSnapshot() {
+  return {
+    messageCount: 0,
+    messagesHead: [],
+    messagesTail: [],
+    posts: [],
+  };
+}
+
+function workerMessageSnapshot(value = {}) {
+  const snapshot = value ?? {};
+  const messages = Array.isArray(snapshot.messages) ? snapshot.messages : [];
+  const posts = Array.isArray(snapshot.posts) ? snapshot.posts : [];
+
+  return {
+    messageCount: messages.length,
+    messagesHead: messages.slice(0, WORKER_MESSAGE_DIAGNOSTIC_LIMIT),
+    messagesTail: messages.slice(-WORKER_MESSAGE_DIAGNOSTIC_LIMIT),
+    posts,
+  };
+}
+
+async function installBrowserWorkerMessageInstrumentation(page) {
+  await page.evaluateOnNewDocument((stateKey) => {
+    const state = globalThis[stateKey] ?? {};
+    const workerMessages = {
+      messages: [],
+      posts: [],
+    };
+
+    state.workerMessages = workerMessages;
+    globalThis[stateKey] = state;
+
+    const NativeWorker = globalThis.Worker;
+    globalThis.Worker = function InstrumentedWorker(...args) {
+      const worker = new NativeWorker(...args);
+      const postMessage = worker.postMessage;
+      worker.postMessage = function instrumentedPostMessage(message, transfer) {
+        workerMessages.posts.push({
+          indexName: message?.indexName ?? null,
+          sourceFile: message?.sourceFile?.name ?? null,
+          sourceFileHandle: message?.sourceFileHandle ?? null,
+          sourceName: message?.sourceName ?? null,
+          sourceSize: message?.sourceSize ?? null,
+          type: message?.type ?? null,
+        });
+        return postMessage.call(this, message, transfer);
+      };
+      worker.addEventListener("message", (event) => {
+        workerMessages.messages.push({
+          committedEvents: event.data?.committedEvents ?? null,
+          end: event.data?.end ?? null,
+          error: event.data?.message ?? null,
+          fileOffset: event.data?.fileOffset ?? null,
+          indexedEvents: event.data?.indexedEvents ?? null,
+          parsedEvents: event.data?.parsedEvents ?? null,
+          start: event.data?.start ?? null,
+          totalBytes: event.data?.totalBytes ?? null,
+          type: event.data?.type ?? null,
+          valid: event.data?.valid ?? null,
+        });
+      });
+      worker.addEventListener("error", (event) => {
+        workerMessages.messages.push({
+          error: event.message,
+          fileOffset: null,
+          type: "worker-error",
+        });
+      });
+      return worker;
+    };
+  }, BROWSER_INGEST_STATE_KEY);
+}
+
+module.exports = {
+  emptyWorkerMessageSnapshot,
+  installBrowserWorkerMessageInstrumentation,
+  workerMessageSnapshot,
+};

--- a/tools/dist-browser-helpers-check.js
+++ b/tools/dist-browser-helpers-check.js
@@ -19,6 +19,7 @@ const {
 
 const ROOT_DIR = path.resolve(__dirname, "..");
 const BROWSER_FILE_SELECTION_HELPER = "tools/browser-file-selection-page-helper.js";
+const BROWSER_WORKER_MESSAGE_HELPER = "tools/browser-worker-message-page-helper.js";
 const BROWSER_FILE_SELECTION_CHECK = "tools/interactive-ingest-browser-check.js";
 const PRODUCTION_APP_TEXT_FILES = Object.freeze([
   "bootstrap.mjs",
@@ -51,6 +52,19 @@ const LEGACY_FILE_SELECTION_SNAPSHOT_MARKERS = Object.freeze([
   "fileSelectionAt",
   "selectedFileName",
   "selectedFileSize",
+]);
+const WORKER_MESSAGE_INSTRUMENTATION_MARKERS = Object.freeze([
+  "installBrowserWorkerMessageInstrumentation",
+  "browser-worker-message-page-helper",
+  "InstrumentedWorker",
+  "instrumentedPostMessage",
+  "state.workerMessages = workerMessages",
+]);
+const LEGACY_WORKER_MESSAGE_SNAPSHOT_MARKERS = Object.freeze([
+  "workerMessageCount",
+  "workerMessagesHead",
+  "workerMessagesTail",
+  "workerPosts",
 ]);
 
 function readRepoFile(relativePath) {
@@ -566,6 +580,42 @@ function assertBrowserFileSelectionInstrumentationBoundary() {
   );
 }
 
+function assertBrowserWorkerMessageInstrumentationBoundary() {
+  const helper = readRepoFile(BROWSER_WORKER_MESSAGE_HELPER);
+  const check = readRepoFile(BROWSER_FILE_SELECTION_CHECK);
+
+  assert.match(check, /require\("\.\/browser-worker-message-page-helper\.js"\)/);
+  assert.match(check, /installBrowserWorkerMessageInstrumentation\(page\)/);
+  assert.match(check, /workerMessageSnapshot\(state\.workerMessages\)/);
+  assert.doesNotMatch(check, /globalThis\.Worker/);
+  assert.doesNotMatch(check, /InstrumentedWorker/);
+  assert.doesNotMatch(check, /instrumentedPostMessage/);
+  assert.doesNotMatch(
+    check,
+    new RegExp(LEGACY_WORKER_MESSAGE_SNAPSHOT_MARKERS.join("|")),
+  );
+  assert.match(helper, /globalThis\.Worker/);
+  assert.match(helper, /InstrumentedWorker/);
+  assert.match(helper, /instrumentedPostMessage/);
+  assert.match(helper, /workerMessageSnapshot/);
+
+  assertFilesDoNotContain(
+    PRODUCTION_APP_TEXT_FILES
+      .filter(repoFileExists)
+      .map((relativePath) => path.join(ROOT_DIR, relativePath)),
+    WORKER_MESSAGE_INSTRUMENTATION_MARKERS,
+    "production app source",
+  );
+
+  assertFilesDoNotContain(
+    walkFiles(path.join(ROOT_DIR, "dist")).filter((file) =>
+      DIST_APP_TEXT_EXTENSIONS.has(path.extname(file)),
+    ),
+    WORKER_MESSAGE_INSTRUMENTATION_MARKERS,
+    "dist app file",
+  );
+}
+
 function assertDelayedWasmImportBoundary() {
   const bootstrap = readRepoFile("bootstrap.mjs");
   const coreReadyOffset = bootstrap.indexOf("const coreReadyPromise");
@@ -608,6 +658,7 @@ async function main() {
   assertAppLoadUsesSharedHelpers();
   assertInteractiveCheckUsesSharedHelpers();
   assertBrowserFileSelectionInstrumentationBoundary();
+  assertBrowserWorkerMessageInstrumentationBoundary();
   assertDelayedWasmImportBoundary();
   await assertServerResponseModes();
   await assertServerFailureModes();

--- a/tools/interactive-ingest-browser-check.js
+++ b/tools/interactive-ingest-browser-check.js
@@ -22,6 +22,11 @@ const {
   fileSelectionSnapshot,
   installBrowserFileSelectionInstrumentation,
 } = require("./browser-file-selection-page-helper.js");
+const {
+  emptyWorkerMessageSnapshot,
+  installBrowserWorkerMessageInstrumentation,
+  workerMessageSnapshot,
+} = require("./browser-worker-message-page-helper.js");
 
 const DIST_DIR = repoPath("dist");
 const RUNTIME_SPEC = JSON.parse(
@@ -95,6 +100,7 @@ async function writeTraceFile(file) {
 
 async function installIngestInstrumentation(page) {
   await installBrowserFileSelectionInstrumentation(page);
+  await installBrowserWorkerMessageInstrumentation(page);
   await page.evaluateOnNewDocument((stateKey) => {
     const state = globalThis[stateKey] ?? {};
 
@@ -107,8 +113,6 @@ async function installIngestInstrumentation(page) {
       maxFrameDuration: 0,
       promisingType: typeof WebAssembly.promising,
       suspendingType: typeof WebAssembly.Suspending,
-      workerMessages: [],
-      workerPosts: [],
     });
     globalThis[stateKey] = state;
     const fileSelectionStarted = () =>
@@ -160,55 +164,17 @@ async function installIngestInstrumentation(page) {
       return result;
     };
 
-    const NativeWorker = globalThis.Worker;
-    globalThis.Worker = function InstrumentedWorker(...args) {
-      const worker = new NativeWorker(...args);
-      const postMessage = worker.postMessage;
-      worker.postMessage = function instrumentedPostMessage(message, transfer) {
-        state.workerPosts.push({
-          indexName: message?.indexName ?? null,
-          sourceFile: message?.sourceFile?.name ?? null,
-          sourceFileHandle: message?.sourceFileHandle ?? null,
-          sourceName: message?.sourceName ?? null,
-          sourceSize: message?.sourceSize ?? null,
-          type: message?.type ?? null,
-        });
-        return postMessage.call(this, message, transfer);
-      };
-      worker.addEventListener("message", (event) => {
-        state.workerMessages.push({
-          committedEvents: event.data?.committedEvents ?? null,
-          end: event.data?.end ?? null,
-          error: event.data?.message ?? null,
-          fileOffset: event.data?.fileOffset ?? null,
-          indexedEvents: event.data?.indexedEvents ?? null,
-          parsedEvents: event.data?.parsedEvents ?? null,
-          start: event.data?.start ?? null,
-          totalBytes: event.data?.totalBytes ?? null,
-          type: event.data?.type ?? null,
-          valid: event.data?.valid ?? null,
-        });
-      });
-      worker.addEventListener("error", (event) => {
-        state.workerMessages.push({
-          error: event.message,
-          fileOffset: null,
-          type: "worker-error",
-        });
-      });
-      return worker;
-    };
   }, BROWSER_INGEST_STATE_KEY);
 }
 
 async function browserState(page, { diagnoseReader = false } = {}) {
   const state = await page.evaluate(async (shouldDiagnoseReader, stateKey) => {
     const state = globalThis[stateKey] ?? {};
-    const workerMessages = state.workerMessages ?? [];
+    const workerMessages = state.workerMessages ?? {};
     let readerDiagnostic = null;
 
     if (shouldDiagnoseReader) {
-      const startPost = state.workerPosts?.find((message) => message.indexName !== null);
+      const startPost = workerMessages.posts?.find((message) => message.indexName !== null);
       if (startPost?.indexName !== undefined && startPost.indexName !== null) {
         try {
           const memory = new WebAssembly.Memory({ initial: 8272, maximum: 32768 });
@@ -237,9 +203,7 @@ async function browserState(page, { diagnoseReader = false } = {}) {
       appError: globalThis.__TRACY_APP_LOAD_ERROR__ ?? "",
       frameDurationsSample: state.frameDurations?.slice(0, 16),
       performanceMarks: performance.getEntriesByType("mark").map((entry) => entry.name),
-      workerMessageCount: workerMessages.length,
-      workerMessagesHead: workerMessages.slice(0, 8),
-      workerMessagesTail: workerMessages.slice(-8),
+      workerMessages,
       readerDiagnostic,
       ...Object.fromEntries(
         Object.entries(state).filter(
@@ -252,6 +216,7 @@ async function browserState(page, { diagnoseReader = false } = {}) {
   return {
     ...state,
     fileSelection: fileSelectionSnapshot(state.fileSelection),
+    workerMessages: workerMessageSnapshot(state.workerMessages),
   };
 }
 
@@ -322,7 +287,7 @@ async function checkBrowserInteractiveIngest() {
     await waitForPageCondition(
       page,
       () =>
-        (globalThis.__TRACY_BROWSER_INGEST__?.workerMessages ?? []).some(
+        (globalThis.__TRACY_BROWSER_INGEST__?.workerMessages?.messages ?? []).some(
           (message) => message?.type === "preloaded",
         ),
       "browser did not preload worker wasm while file picker was open",
@@ -373,6 +338,35 @@ async function runSelfTest() {
       selectedFile: { name: "trace.json", size: TRACE_SIZE_BYTES },
     },
   );
+  assert.deepEqual(workerMessageSnapshot(), emptyWorkerMessageSnapshot());
+  assert.deepEqual(
+    workerMessageSnapshot({
+      messages: [
+        { fileOffset: 0, type: "preloaded" },
+        { fileOffset: 65536, type: "progress" },
+        { error: "stalled", type: "worker-error" },
+      ],
+      posts: [
+        { indexName: "tracy-index", sourceName: "trace.json", type: "start" },
+      ],
+    }),
+    {
+      messageCount: 3,
+      messagesHead: [
+        { fileOffset: 0, type: "preloaded" },
+        { fileOffset: 65536, type: "progress" },
+        { error: "stalled", type: "worker-error" },
+      ],
+      messagesTail: [
+        { fileOffset: 0, type: "preloaded" },
+        { fileOffset: 65536, type: "progress" },
+        { error: "stalled", type: "worker-error" },
+      ],
+      posts: [
+        { indexName: "tracy-index", sourceName: "trace.json", type: "start" },
+      ],
+    },
+  );
 
   const ingestTimeoutState = {
     appError: "",
@@ -387,15 +381,13 @@ async function runSelfTest() {
       coveredRange: { end: 1000, start: 0 },
       status: { state: "ready" },
     },
-    workerMessageCount: 3,
-    workerMessagesHead: [
-      { fileOffset: 0, type: "preloaded" },
-      { fileOffset: 65536, type: "progress" },
-    ],
-    workerMessagesTail: [
-      { fileOffset: 65536, type: "progress" },
-      { error: "stalled", type: "worker-error" },
-    ],
+    workerMessages: {
+      messages: [
+        { fileOffset: 0, type: "preloaded" },
+        { fileOffset: 65536, type: "progress" },
+        { error: "stalled", type: "worker-error" },
+      ],
+    },
   };
   const timedOutPage = {
     async evaluate(_callback, ...args) {
@@ -419,8 +411,8 @@ async function runSelfTest() {
     timeoutError.message,
     /browser did not present first ingest draw timed out; readiness diagnostics=/,
   );
-  assert.match(timeoutError.message, /"workerMessagesHead":.*"preloaded"/);
-  assert.match(timeoutError.message, /"workerMessagesTail":.*"worker-error"/);
+  assert.match(timeoutError.message, /"workerMessages":.*"messagesHead":.*"preloaded"/);
+  assert.match(timeoutError.message, /"workerMessages":.*"messagesTail":.*"worker-error"/);
   assert.match(timeoutError.message, /"page":.*"readyState":"complete"/);
   assert.match(timeoutError.message, /"readerDiagnostic":/);
   assert.match(

--- a/tools/interactive-ingest-browser-check.js
+++ b/tools/interactive-ingest-browser-check.js
@@ -23,6 +23,7 @@ const {
   installBrowserFileSelectionInstrumentation,
 } = require("./browser-file-selection-page-helper.js");
 const {
+  WORKER_MESSAGE_DIAGNOSTIC_LIMIT,
   emptyWorkerMessageSnapshot,
   installBrowserWorkerMessageInstrumentation,
   workerMessageSnapshot,
@@ -168,9 +169,21 @@ async function installIngestInstrumentation(page) {
 }
 
 async function browserState(page, { diagnoseReader = false } = {}) {
-  const state = await page.evaluate(async (shouldDiagnoseReader, stateKey) => {
+  const state = await page.evaluate(async (
+    shouldDiagnoseReader,
+    stateKey,
+    workerMessageDiagnosticLimit,
+  ) => {
     const state = globalThis[stateKey] ?? {};
     const workerMessages = state.workerMessages ?? {};
+    const workerMessageSnapshot = {
+      messageCount: workerMessages.messages?.length ?? 0,
+      messagesHead: workerMessages.messages?.slice(0, workerMessageDiagnosticLimit) ?? [],
+      messagesTail: workerMessages.messages?.slice(-workerMessageDiagnosticLimit) ?? [],
+      postCount: workerMessages.posts?.length ?? 0,
+      postsHead: workerMessages.posts?.slice(0, workerMessageDiagnosticLimit) ?? [],
+      postsTail: workerMessages.posts?.slice(-workerMessageDiagnosticLimit) ?? [],
+    };
     let readerDiagnostic = null;
 
     if (shouldDiagnoseReader) {
@@ -203,7 +216,7 @@ async function browserState(page, { diagnoseReader = false } = {}) {
       appError: globalThis.__TRACY_APP_LOAD_ERROR__ ?? "",
       frameDurationsSample: state.frameDurations?.slice(0, 16),
       performanceMarks: performance.getEntriesByType("mark").map((entry) => entry.name),
-      workerMessages,
+      workerMessages: workerMessageSnapshot,
       readerDiagnostic,
       ...Object.fromEntries(
         Object.entries(state).filter(
@@ -211,7 +224,7 @@ async function browserState(page, { diagnoseReader = false } = {}) {
         ),
       ),
     };
-  }, diagnoseReader, BROWSER_INGEST_STATE_KEY);
+  }, diagnoseReader, BROWSER_INGEST_STATE_KEY, WORKER_MESSAGE_DIAGNOSTIC_LIMIT);
 
   return {
     ...state,
@@ -362,11 +375,67 @@ async function runSelfTest() {
         { fileOffset: 65536, type: "progress" },
         { error: "stalled", type: "worker-error" },
       ],
-      posts: [
+      postCount: 1,
+      postsHead: [
+        { indexName: "tracy-index", sourceName: "trace.json", type: "start" },
+      ],
+      postsTail: [
         { indexName: "tracy-index", sourceName: "trace.json", type: "start" },
       ],
     },
   );
+  assert.deepEqual(
+    workerMessageSnapshot({
+      messageCount: 12,
+      messagesHead: [{ type: "preloaded" }],
+      messagesTail: [{ type: "done" }],
+      postCount: 2,
+      postsHead: [{ type: "start" }],
+      postsTail: [{ type: "cancel" }],
+    }),
+    {
+      messageCount: 12,
+      messagesHead: [{ type: "preloaded" }],
+      messagesTail: [{ type: "done" }],
+      postCount: 2,
+      postsHead: [{ type: "start" }],
+      postsTail: [{ type: "cancel" }],
+    },
+  );
+  const previousIngestState = globalThis[BROWSER_INGEST_STATE_KEY];
+  try {
+    globalThis[BROWSER_INGEST_STATE_KEY] = {
+      workerMessages: {
+        messages: Array.from({ length: 12 }, (_value, index) => ({
+          fileOffset: index,
+          type: "progress",
+        })),
+        posts: Array.from({ length: 10 }, (_value, index) => ({
+          indexName: `tracy-index-${index}`,
+          type: "start",
+        })),
+      },
+    };
+    const boundedState = await browserState({
+      async evaluate(callback, ...args) {
+        return callback(...args);
+      },
+    });
+    assert.equal(boundedState.workerMessages.messageCount, 12);
+    assert.equal(boundedState.workerMessages.messagesHead.length, 8);
+    assert.equal(boundedState.workerMessages.messagesTail.length, 8);
+    assert.equal(boundedState.workerMessages.postCount, 10);
+    assert.equal(boundedState.workerMessages.postsHead.length, 8);
+    assert.equal(boundedState.workerMessages.postsTail.length, 8);
+    assert.equal(boundedState.workerMessages.messages, undefined);
+    assert.equal(boundedState.workerMessages.posts, undefined);
+  } finally {
+    if (previousIngestState === undefined) {
+      delete globalThis[BROWSER_INGEST_STATE_KEY];
+    } else {
+      globalThis[BROWSER_INGEST_STATE_KEY] = previousIngestState;
+    }
+  }
 
   const ingestTimeoutState = {
     appError: "",


### PR DESCRIPTION
Move browser worker-message monkey-patching into a single acceptance-page helper, then read bounded worker diagnostics through typed snapshot fields. Snapshot the worker head/tail/count inside the page context before returning browser state so timeout and final-state diagnostics do not serialize unbounded worker message arrays over DevTools. Keep this leaf limited to worker-message instrumentation and preserve the production/dist boundary.

Fixes #356.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] [Snapshot worker message diagnostics inside the page.evaluate browser context before returning browser state, so full worker message/post arrays are not serialized over DevTools.](https://github.com/rhencke/tracy/pull/371#discussion_r3238275595) <!-- type:thread -->
- [x] Extract worker-message page instrumentation helper <!-- type:spec -->
- [x] Guard worker-message instrumentation boundaries <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->