### PR TITLE
LOC #5a - Source contract assertion DSL (closes #310)

### DIFF
--- a/tools/direct-esm-check.js
+++ b/tools/direct-esm-check.js
@@ -109,6 +109,36 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function assertProtectedPropertyMessage(protectedProperty) {
+  assert.equal(
+    typeof protectedProperty,
+    "string",
+    "source contract assertions should name the protected property",
+  );
+  assert(
+    protectedProperty.trim().length > 0,
+    "source contract assertions should name the protected property",
+  );
+}
+
+function requirePattern(source, pattern, protectedProperty) {
+  assertProtectedPropertyMessage(protectedProperty);
+  assert.match(source, pattern, protectedProperty);
+}
+
+function forbidPattern(source, pattern, protectedProperty) {
+  assertProtectedPropertyMessage(protectedProperty);
+  assert.doesNotMatch(source, pattern, protectedProperty);
+}
+
+function requireOrderedText(source, firstText, secondText, protectedProperty) {
+  assertProtectedPropertyMessage(protectedProperty);
+  const firstIndex = source.indexOf(firstText);
+  const secondIndex = source.indexOf(secondText);
+
+  assert(firstIndex !== -1 && firstIndex < secondIndex, protectedProperty);
+}
+
 async function assertNoIsolationRequirement(relativePath) {
   const source = await readRepoFile(relativePath);
 

--- a/tools/direct-esm-check.js
+++ b/tools/direct-esm-check.js
@@ -380,7 +380,7 @@ async function assertSharedWasmBoundaryHelpersStayOnStartupPath(bootstrapSource,
 async function assertRuntimeWorkerCheckUsesGeneratedIndexFormatSpec() {
   const source = await readRepoFile("tools/runtime-worker-orchestration-check.js");
 
-  assert.match(
+  requirePattern(
     source,
     /host\/index-format-spec\.mjs/,
     "runtime worker orchestration check should import generated index format values",
@@ -392,7 +392,7 @@ async function assertRuntimeWorkerCheckUsesGeneratedIndexFormatSpec() {
     [/const\s+INDEX_PAGE_HEADER_[A-Z_]+_OFFSET\s*=/, "index page header offsets"],
     [/\b0x00010000\b/, "OPFS page size literal"],
   ]) {
-    assert.doesNotMatch(
+    forbidPattern(
       source,
       pattern,
       `runtime worker orchestration check should read ${message} from generated index format values`,
@@ -408,7 +408,7 @@ async function assertRuntimeWorkerCheckUsesGeneratedIndexFormatSpec() {
     [/INDEX_PAGE_HEADER_OFFSETS\.RECORD_COUNT/, "record count offset"],
     [/INDEX_PAGE_HEADER_OFFSETS\.DECODE_HINTS/, "decode hints offset"],
   ]) {
-    assert.match(
+    requirePattern(
       source,
       pattern,
       `runtime worker orchestration check should consume generated ${message}`,


### PR DESCRIPTION
## Summary

- Add a small named assertion DSL for static source-contract checks.
- Migrate a focused direct-ESM contract group to the helpers without weakening property-specific failures.

## Test plan

- `npm run test:direct-esm`
- `npm test`

Fixes #310.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Add source-contract assertion helpers <!-- type:spec -->
- [x] Migrate a direct ESM contract group to the DSL <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->